### PR TITLE
Add hero layout to login page

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,19 +1,20 @@
+import { AuthLayout } from '@/components/auth/auth-layout'
 import { LoginForm } from '@/components/login-form'
 
 /**
  * Login Page
  *
  * This component renders the login page of the application. It uses the
- * `LoginForm` component to display the login form to the user.
+ * `LoginForm` component to display the login form to the user, wrapped in
+ * the shared `AuthLayout` which provides the marketing hero and thematic
+ * background.
  *
  * @returns Login Page Component
  */
 export default function Page() {
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
-      <div className="w-full max-w-sm">
-        <LoginForm />
-      </div>
-    </div>
+    <AuthLayout>
+      <LoginForm />
+    </AuthLayout>
   )
 }

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -1,18 +1,19 @@
+import { AuthLayout } from '@/components/auth/auth-layout'
 import { SignUpForm } from '@/components/sign-up-form'
 
 /**
  * Sign Up Page
  *
- * Renders the sign-up form for new users to create an account.
+ * Renders the sign-up form for new users to create an account, wrapped in
+ * the shared `AuthLayout` which provides the marketing hero and thematic
+ * background.
  *
  * @returns Sign Up Page Component
  */
 export default function Page() {
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
-      <div className="w-full max-w-sm">
-        <SignUpForm />
-      </div>
-    </div>
+    <AuthLayout>
+      <SignUpForm />
+    </AuthLayout>
   )
 }

--- a/components/auth/auth-hero.tsx
+++ b/components/auth/auth-hero.tsx
@@ -1,0 +1,81 @@
+import { Castle, Skull, Swords } from 'lucide-react'
+import { ReactElement } from 'react'
+
+/**
+ * Auth Hero
+ *
+ * Marketing/value-proposition panel shown alongside authentication forms
+ * (login, sign-up, etc.). Communicates what the application is and why a
+ * visitor should bother creating an account.
+ *
+ * Designed to live in the left column of a two-column auth layout on
+ * desktop, and stack above the form on mobile.
+ *
+ * @returns Auth Hero Component
+ */
+export function AuthHero(): ReactElement {
+  const features = [
+    {
+      icon: Castle,
+      title: 'Settlements',
+      description:
+        'Track timelines, principles, innovations, and locations across every Lantern Year.'
+    },
+    {
+      icon: Skull,
+      title: 'Survivors',
+      description:
+        'Manage attributes, gear grids, fighting arts, disorders, and the scars they carry.'
+    },
+    {
+      icon: Swords,
+      title: 'Hunts & Showdowns',
+      description:
+        'Phase-aware tools that surface only the rules and stats the moment demands.'
+    }
+  ]
+
+  return (
+    <div className="flex flex-col justify-center gap-10 max-w-xl">
+      <div className="flex flex-col gap-4">
+        <span className="text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          KD:M Archivist
+        </span>
+        <h1 className="text-4xl md:text-5xl font-bold leading-tight">
+          Carry the lantern.
+          <br />
+          <span className="text-muted-foreground">Track the struggle.</span>
+        </h1>
+        <p className="text-base md:text-lg text-muted-foreground leading-relaxed">
+          A companion for{' '}
+          <span className="text-foreground font-medium">
+            Kingdom Death: Monster
+          </span>
+          . Manage settlements, survivors, and the brutal hunts between them —
+          so the table stays clear for the story.
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-5">
+        {features.map(({ icon: Icon, title, description }) => (
+          <li key={title} className="flex gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-border/60 bg-background/40">
+              <Icon className="h-5 w-5 text-foreground/80" aria-hidden="true" />
+            </div>
+            <div className="flex flex-col gap-0.5">
+              <p className="font-medium leading-none">{title}</p>
+              <p className="text-sm text-muted-foreground leading-snug">
+                {description}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <p className="text-xs text-muted-foreground/70 leading-relaxed">
+        Free, unofficial fan project. Not affiliated with, endorsed by, or
+        sponsored by Adam Poots Games.
+      </p>
+    </div>
+  )
+}

--- a/components/auth/auth-layout.tsx
+++ b/components/auth/auth-layout.tsx
@@ -1,0 +1,49 @@
+import { AuthHero } from '@/components/auth/auth-hero'
+import { ReactElement, ReactNode } from 'react'
+
+/**
+ * Auth Layout
+ *
+ * Two-column layout used by authentication pages. On desktop, the marketing
+ * hero sits on the left and the auth form sits on the right. On mobile, the
+ * hero stacks above the form.
+ *
+ * A subtle radial "lantern glow" gradient sits behind the form to evoke the
+ * thematic light-in-the-dark of Kingdom Death.
+ *
+ * @param props Auth Layout Properties
+ * @returns Auth Layout Component
+ */
+export function AuthLayout({
+  children
+}: {
+  children: ReactNode
+}): ReactElement {
+  return (
+    <div className="relative min-h-svh w-full overflow-hidden">
+      {/* Lantern glow — anchors to the form column on desktop, recedes on mobile. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_75%_50%,rgba(251,191,36,0.08),transparent_60%)]"
+      />
+      {/* Faint vignette to deepen the edges. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_40%,rgba(0,0,0,0.4)_100%)]"
+      />
+
+      <div className="relative grid min-h-svh w-full grid-cols-1 lg:grid-cols-2">
+        <div className="hidden lg:flex items-center justify-center p-10 xl:p-16">
+          <AuthHero />
+        </div>
+
+        <div className="flex flex-col items-center justify-center gap-8 p-6 md:p-10">
+          <div className="lg:hidden w-full max-w-sm">
+            <AuthHero />
+          </div>
+          <div className="w-full max-w-sm">{children}</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
This pull request introduces a new shared authentication layout for the login and sign-up pages, providing a consistent and visually appealing two-column design. The layout features a marketing hero section that highlights the app's value proposition, and a thematic "lantern glow" background inspired by Kingdom Death. The login and sign-up pages are refactored to use this new layout, improving both code reuse and user experience.