### PR TITLE
feat(realtime): audit and extend supabase_realtime publication (#126)

### DIFF
--- a/__tests__/integration/realtime-publication.test.ts
+++ b/__tests__/integration/realtime-publication.test.ts
@@ -1,0 +1,90 @@
+import { admin } from '@/__tests__/integration/helpers/supabase'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Integration — Realtime Publication Membership
+ *
+ * Asserts that every settlement-scoped table is included in the
+ * `supabase_realtime` publication. Tables in the publication broadcast
+ * row-level changes to subscribed clients, which is what powers multiplayer
+ * sync for shared settlements.
+ *
+ * If a new settlement-scoped table is added to the schema without being
+ * added to the publication, this test fails with a list of missing tables —
+ * a much more actionable signal than discovering the gap in production when
+ * a collaborator's UI silently goes stale.
+ *
+ * Catalog tables (`survivor_status`, `armor_set`, `wanderer*`, etc.) and
+ * `settlement_shared_user` are intentionally out of scope: the former are
+ * tracked under E2.4 and rely on a different subscription model, the latter
+ * is tracked under E1.4 alongside its user-level subscription.
+ */
+describe('Realtime publication membership', () => {
+  /**
+   * Source of truth: every settlement-scoped table that must broadcast
+   * changes for the multiplayer experience to work. Keep this list in sync
+   * with the `TABLE_DOMAIN_MAP` in `hooks/use-realtime.tsx`.
+   */
+  const EXPECTED_TABLES = [
+    // Core settlement & junctions
+    'settlement',
+    'settlement_collective_cognition_reward',
+    'settlement_gear',
+    'settlement_innovation',
+    'settlement_knowledge',
+    'settlement_location',
+    'settlement_milestone',
+    'settlement_nemesis',
+    'settlement_pattern',
+    'settlement_phase',
+    'settlement_phase_returning_survivor',
+    'settlement_philosophy',
+    'settlement_principle',
+    'settlement_quarry',
+    'settlement_resource',
+    'settlement_seed_pattern',
+    'settlement_timeline_year',
+
+    // Hunt
+    'hunt',
+    'hunt_ai_deck',
+    'hunt_hunt_board',
+    'hunt_monster',
+    'hunt_monster_mood',
+    'hunt_monster_survivor_status',
+    'hunt_monster_trait',
+    'hunt_survivor',
+
+    // Showdown
+    'showdown',
+    'showdown_ai_deck',
+    'showdown_monster',
+    'showdown_monster_mood',
+    'showdown_monster_survivor_status',
+    'showdown_monster_trait',
+    'showdown_survivor',
+
+    // Survivor
+    'survivor',
+    'survivor_ability_impairment',
+    'survivor_cursed_gear',
+    'survivor_disorder',
+    'survivor_fighting_art',
+    'survivor_secret_fighting_art',
+
+    // Gear grid
+    'gear_grid'
+  ] as const
+
+  it('includes every settlement-scoped table in `supabase_realtime`', async () => {
+    const { data, error } = await admin.rpc('realtime_publication_tables')
+
+    expect(error).toBeNull()
+    expect(data).toBeTruthy()
+
+    const actual = new Set((data ?? []).map((r) => String(r.tablename)))
+    const missing = EXPECTED_TABLES.filter((t) => !actual.has(t))
+
+    expect(missing).toEqual([])
+  })
+})

--- a/__tests__/integration/realtime-publication.test.ts
+++ b/__tests__/integration/realtime-publication.test.ts
@@ -82,7 +82,9 @@ describe('Realtime publication membership', () => {
     expect(error).toBeNull()
     expect(data).toBeTruthy()
 
-    const actual = new Set((data ?? []).map((r) => String(r.tablename)))
+    const actual = new Set(
+      (data ?? []).map((r: { tablename: string }) => String(r.tablename))
+    )
     const missing = EXPECTED_TABLES.filter((t) => !actual.has(t))
 
     expect(missing).toEqual([])

--- a/__tests__/integration/realtime-publication.test.ts
+++ b/__tests__/integration/realtime-publication.test.ts
@@ -82,9 +82,8 @@ describe('Realtime publication membership', () => {
     expect(error).toBeNull()
     expect(data).toBeTruthy()
 
-    const actual = new Set(
-      (data ?? []).map((r: { tablename: string }) => String(r.tablename))
-    )
+    const rows = (data ?? []) as { tablename: string }[]
+    const actual = new Set(rows.map((r) => r.tablename))
     const missing = EXPECTED_TABLES.filter((t) => !actual.has(t))
 
     expect(missing).toEqual([])

--- a/hooks/use-realtime.tsx
+++ b/hooks/use-realtime.tsx
@@ -241,7 +241,21 @@ export function useRealtimeSubscriptions(
           () => handleChange(domain)
         )
       } else {
-        // Survivor junction tables without settlement_id — RLS handles scoping.
+        // Junction tables that don't carry `settlement_id` directly. The
+        // realtime filter syntax doesn't support joins, so we subscribe
+        // unfiltered and rely on RLS to scope events to rows the user can
+        // read. This is the "coarse subscription" pattern from the sharing
+        // architecture doc §8.2.2 (option B).
+        //
+        // Trade-off: a user with multiple accessible settlements (owned or
+        // shared) will receive events for ALL of them, not just the active
+        // one. The hook fires the domain refetch for any such event,
+        // causing one extra refetch per unrelated mutation. The 300ms
+        // per-domain debounce bounds the blast radius — bursts of
+        // unrelated events collapse into a single refetch. Refining this
+        // to be strictly per-active-settlement requires either denormalising
+        // `settlement_id` onto each junction or threading parent-id
+        // lookups into this hook, both of which are tracked separately.
         channel = channel.on(
           'postgres_changes',
           {

--- a/hooks/use-realtime.tsx
+++ b/hooks/use-realtime.tsx
@@ -255,7 +255,7 @@ export function useRealtimeSubscriptions(
         // unrelated events collapse into a single refetch. Refining this
         // to be strictly per-active-settlement requires either denormalising
         // `settlement_id` onto each junction or threading parent-id
-        // lookups into this hook, both of which are tracked separately.
+        // lookups into this hook; tracked in #189.
         channel = channel.on(
           'postgres_changes',
           {

--- a/hooks/use-realtime.tsx
+++ b/hooks/use-realtime.tsx
@@ -91,12 +91,21 @@ const TABLE_DOMAIN_MAP: Record<string, TableDomainEntry> = {
   hunt_ai_deck: { domain: 'hunt', filterColumn: 'settlement_id' },
   hunt_hunt_board: { domain: 'hunt', filterColumn: 'settlement_id' },
   hunt_monster: { domain: 'hunt', filterColumn: 'settlement_id' },
+  hunt_monster_mood: { domain: 'hunt', filterColumn: null },
+  hunt_monster_survivor_status: { domain: 'hunt', filterColumn: null },
+  hunt_monster_trait: { domain: 'hunt', filterColumn: null },
   hunt_survivor: { domain: 'hunt', filterColumn: 'settlement_id' },
 
   // Showdown domain
   showdown: { domain: 'showdown', filterColumn: 'settlement_id' },
   showdown_ai_deck: { domain: 'showdown', filterColumn: 'settlement_id' },
   showdown_monster: { domain: 'showdown', filterColumn: 'settlement_id' },
+  showdown_monster_mood: { domain: 'showdown', filterColumn: null },
+  showdown_monster_survivor_status: {
+    domain: 'showdown',
+    filterColumn: null
+  },
+  showdown_monster_trait: { domain: 'showdown', filterColumn: null },
   showdown_survivor: { domain: 'showdown', filterColumn: 'settlement_id' },
 
   // Settlement Phase domain
@@ -111,6 +120,7 @@ const TABLE_DOMAIN_MAP: Record<string, TableDomainEntry> = {
 
   // Survivor domain
   survivor: { domain: 'survivor', filterColumn: 'settlement_id' },
+  survivor_ability_impairment: { domain: 'survivor', filterColumn: null },
   survivor_cursed_gear: { domain: 'survivor', filterColumn: null },
   survivor_disorder: { domain: 'survivor', filterColumn: null },
   survivor_fighting_art: { domain: 'survivor', filterColumn: null },

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5844,6 +5844,12 @@ export type Database = {
       is_trait_owner: { Args: { record_id: string }; Returns: boolean }
       is_wanderer_owner: { Args: { record_id: string }; Returns: boolean }
       is_weapon_type_owner: { Args: { record_id: string }; Returns: boolean }
+      realtime_publication_tables: {
+        Args: never
+        Returns: {
+          tablename: unknown
+        }[]
+      }
       sanitize_username_candidate: { Args: { raw: string }; Returns: string }
       survivor_qualifies_for_armor_set: {
         Args: { p_armor_set_id: string; p_survivor_id: string }

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5847,7 +5847,7 @@ export type Database = {
       realtime_publication_tables: {
         Args: never
         Returns: {
-          tablename: unknown
+          tablename: string
         }[]
       }
       sanitize_username_candidate: { Args: { raw: string }; Returns: string }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.45.0",
+      "version": "0.46.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260506000000_audit_realtime_publication.sql
+++ b/supabase/migrations/20260506000000_audit_realtime_publication.sql
@@ -1,0 +1,108 @@
+--------------------------------------------------------------------------------
+-- Audit `supabase_realtime` Publication
+--
+-- Earlier migrations (20260413223402, 20260422000005, 20260422000006,
+-- 20260424000006) introduced settlement-scoped junction tables AFTER the
+-- bulk realtime enablement in 20260327000000_enable_realtime_gameplay_tables.
+-- Without inclusion in the `supabase_realtime` publication, collaborators
+-- subscribed to a settlement do not receive INSERT / UPDATE / DELETE events
+-- for these tables, leading to stale UI until a manual reload.
+--
+-- Tables added here are settlement-scoped (each row reaches `settlement.id`
+-- via a foreign-key chain through `hunt_monster`, `showdown_monster`, or
+-- `survivor`). Catalog tables (`survivor_status`, `armor_set`, `armor_set_*`,
+-- `wanderer_*`, etc.) are intentionally excluded — they are tracked under
+-- E2.4 and require a different subscription model (§8.2.2 of the sharing
+-- architecture document).
+--
+-- `settlement_shared_user` is also excluded — it is added under E1.4 alongside
+-- the user-level subscription that powers "shared with me" updates.
+--
+-- Each `alter publication ... add table` is wrapped in a `do $$ ... $$` block
+-- that checks `pg_publication_tables` first so the migration is idempotent;
+-- replaying it (or running it against an environment where a table was
+-- previously added piecemeal) is a no-op for the already-present tables.
+--------------------------------------------------------------------------------
+do $$ begin if not exists (
+  select 1
+  from pg_publication_tables
+  where pubname = 'supabase_realtime'
+    and tablename = 'hunt_monster_mood'
+) then alter publication supabase_realtime
+add table hunt_monster_mood;
+end if;
+end $$;
+do $$ begin if not exists (
+  select 1
+  from pg_publication_tables
+  where pubname = 'supabase_realtime'
+    and tablename = 'hunt_monster_survivor_status'
+) then alter publication supabase_realtime
+add table hunt_monster_survivor_status;
+end if;
+end $$;
+do $$ begin if not exists (
+  select 1
+  from pg_publication_tables
+  where pubname = 'supabase_realtime'
+    and tablename = 'hunt_monster_trait'
+) then alter publication supabase_realtime
+add table hunt_monster_trait;
+end if;
+end $$;
+do $$ begin if not exists (
+  select 1
+  from pg_publication_tables
+  where pubname = 'supabase_realtime'
+    and tablename = 'showdown_monster_mood'
+) then alter publication supabase_realtime
+add table showdown_monster_mood;
+end if;
+end $$;
+do $$ begin if not exists (
+  select 1
+  from pg_publication_tables
+  where pubname = 'supabase_realtime'
+    and tablename = 'showdown_monster_survivor_status'
+) then alter publication supabase_realtime
+add table showdown_monster_survivor_status;
+end if;
+end $$;
+do $$ begin if not exists (
+  select 1
+  from pg_publication_tables
+  where pubname = 'supabase_realtime'
+    and tablename = 'showdown_monster_trait'
+) then alter publication supabase_realtime
+add table showdown_monster_trait;
+end if;
+end $$;
+do $$ begin if not exists (
+  select 1
+  from pg_publication_tables
+  where pubname = 'supabase_realtime'
+    and tablename = 'survivor_ability_impairment'
+) then alter publication supabase_realtime
+add table survivor_ability_impairment;
+end if;
+end $$;
+--------------------------------------------------------------------------------
+-- Helper: realtime_publication_tables()
+--
+-- SECURITY DEFINER function returning the names of tables in the
+-- `supabase_realtime` publication. `pg_publication_tables` is in `pg_catalog`
+-- and is not exposed via PostgREST, so without this helper the integration
+-- suite (and any other tooling that wants to verify publication state) would
+-- need a direct Postgres connection. Returning only table names is safe — it
+-- exposes nothing that an authenticated client couldn't already infer by
+-- attempting a subscription.
+--------------------------------------------------------------------------------
+create or replace function realtime_publication_tables() returns table (tablename name) language sql security definer
+set search_path = public stable as $$
+select tablename
+from pg_publication_tables
+where pubname = 'supabase_realtime';
+$$;
+revoke all on function public.realtime_publication_tables()
+from public;
+grant execute on function public.realtime_publication_tables() to authenticated;

--- a/supabase/migrations/20260506000000_audit_realtime_publication.sql
+++ b/supabase/migrations/20260506000000_audit_realtime_publication.sql
@@ -96,10 +96,15 @@ end $$;
 -- need a direct Postgres connection. Returning only table names is safe — it
 -- exposes nothing that an authenticated client couldn't already infer by
 -- attempting a subscription.
+--
+-- `pg_publication_tables.tablename` is typed as `name` in `pg_catalog`, which
+-- is opaque enough that PostgREST surfaces it as `unknown` in the generated
+-- TypeScript types. Cast to `text` here so callers get a proper `string`
+-- payload without per-call casts.
 --------------------------------------------------------------------------------
-create or replace function realtime_publication_tables() returns table (tablename name) language sql security definer
+create or replace function realtime_publication_tables() returns table (tablename text) language sql security definer
 set search_path = public stable as $$
-select tablename
+select tablename::text
 from pg_publication_tables
 where pubname = 'supabase_realtime';
 $$;


### PR DESCRIPTION
## Summary

Implements **E0.4** from the multiplayer & content sharing architecture: audits the `supabase_realtime` publication and adds every settlement-scoped table that was introduced after the bulk realtime enablement migration (`20260327000000_enable_realtime_gameplay_tables.sql`).

Without these tables in the publication, collaborators on a shared settlement do not receive INSERT / UPDATE / DELETE events for them — the UI silently goes stale until a manual reload.

### What changed

- **New migration** [supabase/migrations/20260506000000_audit_realtime_publication.sql](supabase/migrations/20260506000000_audit_realtime_publication.sql) adds the seven missing settlement-scoped junction tables to `supabase_realtime`:
  - `hunt_monster_mood`, `hunt_monster_trait`, `hunt_monster_survivor_status`
  - `showdown_monster_mood`, `showdown_monster_trait`, `showdown_monster_survivor_status`
  - `survivor_ability_impairment`

  Each `alter publication ... add table` is wrapped in a `do $$ ... $$` block that consults `pg_publication_tables` first, so the migration is **idempotent** if a table was added piecemeal in another environment (e.g., the way `gear_grid` was in `20260503000001_gear_grid_realtime.sql`).

- **New helper RPC** `realtime_publication_tables()` (same migration)
  - SECURITY DEFINER, returns the list of tables in `supabase_realtime`.
  - Granted execute to `authenticated` only; revoked from `public`.
  - Exists because `pg_publication_tables` lives in `pg_catalog` and is not exposed via PostgREST. Tests and tooling can now verify publication membership without a direct Postgres connection.
  - Returns nothing an authenticated client couldn't already discover by attempting a subscription.

- **Extended** [hooks/use-realtime.tsx](hooks/use-realtime.tsx) — added the seven new tables to `TABLE_DOMAIN_MAP`, mapped to their parent domains (`hunt`, `showdown`, `survivor`).

- **Regenerated** [lib/database.types.ts](lib/database.types.ts) so the new RPC is type-safe.

- **New integration test** [\_\_tests\_\_/integration/realtime-publication.test.ts](__tests__/integration/realtime-publication.test.ts) asserts every settlement-scoped table appears in `supabase_realtime`. Failure prints the missing tables for easy diagnosis. The expected list is the source of truth — any future settlement-scoped table needs to be added there too.

- **Version bump**: `0.45.0` → `0.46.0` in [package.json](package.json) and [package-lock.json](package-lock.json) (additive feature).

### Out of scope

- **Catalog tables** (`survivor_status`, `wanderer_ability_impairment`, `armor_set*`, `constellation`, etc.) — handled in **E2.4** with a different (coarse, table-level) subscription model per `local/sharing-architecture.md` §8.2.2.
- **`settlement_shared_user`** — handled in **E1.4** alongside the user-level subscription that powers "shared with me" updates.

### Acceptance criteria — issue #126

- [x] New migration `supabase/migrations/_audit_realtime_publication.sql` that conditionally adds each table wrapped in `do $$ ... $$` blocks that check `pg_publication_tables` first to be idempotent.
- [x] Extend `hooks/use-realtime.tsx` `TABLE_DOMAIN_MAP` with new entries.
- [x] Integration test `__tests__/integration/realtime-publication.test.ts` asserting every settlement-scoped table is in `supabase_realtime`.
- [x] Query against `pg_publication_tables` returns every settlement-scoped table.
- [x] New integration test passes.

### Verification

- `npm test` → 2066/2066 passing.
- `npm run integration-test -- __tests__/integration/realtime-publication.test.ts` → 1/1 passing.
- `npm run lint` → clean.
- `npm run format:check` → clean.

### Dependencies

No dependency changes.

### Related

Closes #126
Part of Epic #120 (Phase 0: Foundation & Membership Model)
Source of truth: `local/sharing-architecture.md` §3.2 / §8.2.3 / §10 Phase 0 item 0.4 / Appendix A