### PR TITLE
docs(rls): annotate inverted RLS policies with CONTRADICTION comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -175,3 +175,8 @@ The body of the PR should include:
 - A special note of any changes to dependencies
 - A link to any relevant issues or discussions
 - Any additional context that may be helpful for reviewers
+
+## Database Considerations
+
+- When resetting the database, never reset without seeding data (e.g. including
+  the `--no-seed` option to `npx supabase db reset`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260220183545_wanderer.sql
+++ b/supabase/migrations/20260220183545_wanderer.sql
@@ -96,6 +96,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on wanderer for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190334_philosophy.sql
+++ b/supabase/migrations/20260220190334_philosophy.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on philosophy for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190335_neurosis.sql
+++ b/supabase/migrations/20260220190335_neurosis.sql
@@ -73,6 +73,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on neurosis for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190336_knowledge.sql
+++ b/supabase/migrations/20260220190336_knowledge.sql
@@ -73,6 +73,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on knowledge for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190337_strain_milestone.sql
+++ b/supabase/migrations/20260220190337_strain_milestone.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on strain_milestone for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190338_location.sql
+++ b/supabase/migrations/20260220190338_location.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on location for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190339_collective_cognition_reward.sql
+++ b/supabase/migrations/20260220190339_collective_cognition_reward.sql
@@ -77,6 +77,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on collective_cognition_reward for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190340_gear.sql
+++ b/supabase/migrations/20260220190340_gear.sql
@@ -73,6 +73,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on gear for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190341_pattern.sql
+++ b/supabase/migrations/20260220190341_pattern.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on pattern for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190342_innovation.sql
+++ b/supabase/migrations/20260220190342_innovation.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on innovation for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190343_seed_pattern.sql
+++ b/supabase/migrations/20260220190343_seed_pattern.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on seed_pattern for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190344_disorder.sql
+++ b/supabase/migrations/20260220190344_disorder.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on disorder for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190345_fighting_art.sql
+++ b/supabase/migrations/20260220190345_fighting_art.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on fighting_art for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190346_character.sql
+++ b/supabase/migrations/20260220190346_character.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on character for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190347_milestone.sql
+++ b/supabase/migrations/20260220190347_milestone.sql
@@ -74,6 +74,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on milestone for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190348_principle.sql
+++ b/supabase/migrations/20260220190348_principle.sql
@@ -75,6 +75,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on principle for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190349_secret_fighting_art.sql
+++ b/supabase/migrations/20260220190349_secret_fighting_art.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on secret_fighting_art for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190451_weapon_type.sql
+++ b/supabase/migrations/20260220190451_weapon_type.sql
@@ -72,6 +72,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on weapon_type for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190452_quarry.sql
+++ b/supabase/migrations/20260220190452_quarry.sql
@@ -80,6 +80,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on quarry for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190458_resource.sql
+++ b/supabase/migrations/20260220190458_resource.sql
@@ -74,6 +74,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on resource for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190500_nemesis.sql
+++ b/supabase/migrations/20260220190500_nemesis.sql
@@ -79,6 +79,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on nemesis for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260220190650_settlement.sql
+++ b/supabase/migrations/20260220190650_settlement.sql
@@ -75,6 +75,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators can currently UPDATE
+-- the settlement row even though only the owner should be able to edit
+-- settlement metadata (name, campaign_type, survivor_type, uses_scouts).
+-- Tightened to a hybrid model in Phase 1 — see [E1.3] (issue #133).
 create policy "Allow update for shared" on settlement for
 update to authenticated using (
     exists (

--- a/supabase/migrations/20260220190651_settlement_knowledge.sql
+++ b/supabase/migrations/20260220190651_settlement_knowledge.sql
@@ -28,6 +28,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_knowledge for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220190652_settlement_philosophy.sql
+++ b/supabase/migrations/20260220190652_settlement_philosophy.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_philosophy for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220190654_settlement_gear.sql
+++ b/supabase/migrations/20260220190654_settlement_gear.sql
@@ -27,6 +27,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_gear for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220190655_settlement_innovation.sql
+++ b/supabase/migrations/20260220190655_settlement_innovation.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_innovation for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220190656_settlement_pattern.sql
+++ b/supabase/migrations/20260220190656_settlement_pattern.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_pattern for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220190657_settlement_seed_pattern.sql
+++ b/supabase/migrations/20260220190657_settlement_seed_pattern.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_seed_pattern for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220191225_settlement_collective_cognition_reward.sql
+++ b/supabase/migrations/20260220191225_settlement_collective_cognition_reward.sql
@@ -28,6 +28,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_collective_cognition_reward for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220191337_settlement_location.sql
+++ b/supabase/migrations/20260220191337_settlement_location.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_location for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220191430_settlement_milestone.sql
+++ b/supabase/migrations/20260220191430_settlement_milestone.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_milestone for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220191452_settlement_principle.sql
+++ b/supabase/migrations/20260220191452_settlement_principle.sql
@@ -30,6 +30,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_principle for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220192121_settlement_timeline_year.sql
+++ b/supabase/migrations/20260220192121_settlement_timeline_year.sql
@@ -33,6 +33,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_timeline_year for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220192122_settlement_resource.sql
+++ b/supabase/migrations/20260220192122_settlement_resource.sql
@@ -27,6 +27,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_resource for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220192123_settlement_quarry.sql
+++ b/supabase/migrations/20260220192123_settlement_quarry.sql
@@ -33,6 +33,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_quarry for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220192124_settlement_nemesis.sql
+++ b/supabase/migrations/20260220192124_settlement_nemesis.sql
@@ -36,6 +36,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this junction. Collaborators on a
+-- shared settlement should be able to add and remove these resources.
+-- Loosened in Phase 1 — see [E1.2.a] (issue #135).
 create policy "Allow insert for owner" on settlement_nemesis for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220192245_survivor.sql
+++ b/supabase/migrations/20260220192245_survivor.sql
@@ -159,6 +159,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on survivor. Collaborators on the
+-- parent settlement should be able to mutate survivors.
+-- Loosened in Phase 1 — see [E1.2.c] (issue #145).
 create policy "Allow insert for owner" on survivor for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220192246_survivor_disorder.sql
+++ b/supabase/migrations/20260220192246_survivor_disorder.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this survivor-scoped junction.
+-- Collaborators on the parent settlement should be able to mutate it.
+-- Loosened in Phase 1 — see [E1.2.c] (issue #145).
 create policy "Allow insert for owner" on survivor_disorder for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220192247_survivor_fighting_art.sql
+++ b/supabase/migrations/20260220192247_survivor_fighting_art.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this survivor-scoped junction.
+-- Collaborators on the parent settlement should be able to mutate it.
+-- Loosened in Phase 1 — see [E1.2.c] (issue #145).
 create policy "Allow insert for owner" on survivor_fighting_art for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220192248_survivor_cursed_gear.sql
+++ b/supabase/migrations/20260220192248_survivor_cursed_gear.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this survivor-scoped junction.
+-- Collaborators on the parent settlement should be able to mutate it.
+-- Loosened in Phase 1 — see [E1.2.c] (issue #145).
 create policy "Allow insert for owner" on survivor_cursed_gear for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220192249_survivor_secret_fighting_art.sql
+++ b/supabase/migrations/20260220192249_survivor_secret_fighting_art.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this survivor-scoped junction.
+-- Collaborators on the parent settlement should be able to mutate it.
+-- Loosened in Phase 1 — see [E1.2.c] (issue #145).
 create policy "Allow insert for owner" on survivor_secret_fighting_art for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260220194908_settlement_phase.sql
+++ b/supabase/migrations/20260220194908_settlement_phase.sql
@@ -37,6 +37,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on settlement_phase. Collaborators
+-- should be able to advance phases on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.b] (issue #138).
 create policy "Allow insert for owner" on settlement_phase for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260223215817_hunt.sql
+++ b/supabase/migrations/20260223215817_hunt.sql
@@ -9,9 +9,15 @@ create table hunt (
   updated_at timestamptz not null default now(),
   -- Data
   monster_level int not null,
-  monster_position int not null default 12 check (monster_position >= 0 and monster_position <= 12),
+  monster_position int not null default 12 check (
+    monster_position >= 0
+    and monster_position <= 12
+  ),
   settlement_id uuid not null unique references settlement(id) on delete cascade,
-  survivor_position int not null default 0 check (survivor_position >= 0 and survivor_position <= 12)
+  survivor_position int not null default 0 check (
+    survivor_position >= 0
+    and survivor_position <= 12
+  )
 );
 --------------------------------------------------------------------------------
 -- Row Level Security Policies
@@ -28,6 +34,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this hunt-phase table. Collaborators
+-- should be able to play through the hunt phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on hunt for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260223215818_hunt_hunt_board.sql
+++ b/supabase/migrations/20260223215818_hunt_hunt_board.sql
@@ -42,6 +42,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this hunt-phase table. Collaborators
+-- should be able to play through the hunt phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on hunt_hunt_board for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260223215940_hunt_ai_deck.sql
+++ b/supabase/migrations/20260223215940_hunt_ai_deck.sql
@@ -31,6 +31,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this hunt-phase table. Collaborators
+-- should be able to play through the hunt phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on hunt_ai_deck for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260223215941_hunt_monster.sql
+++ b/supabase/migrations/20260223215941_hunt_monster.sql
@@ -49,6 +49,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this hunt-phase table. Collaborators
+-- should be able to play through the hunt phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on hunt_monster for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260223220613_hunt_survivor.sql
+++ b/supabase/migrations/20260223220613_hunt_survivor.sql
@@ -39,6 +39,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this hunt-phase table. Collaborators
+-- should be able to play through the hunt phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on hunt_survivor for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260223223418_showdown.sql
+++ b/supabase/migrations/20260223223418_showdown.sql
@@ -30,6 +30,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this showdown-phase table. Collaborators
+-- should be able to play through the showdown phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on showdown for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260223223419_showdown_ai_deck.sql
+++ b/supabase/migrations/20260223223419_showdown_ai_deck.sql
@@ -33,6 +33,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this showdown-phase table. Collaborators
+-- should be able to play through the showdown phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on showdown_ai_deck for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260223223420_showdown_monster.sql
+++ b/supabase/migrations/20260223223420_showdown_monster.sql
@@ -50,6 +50,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this showdown-phase table. Collaborators
+-- should be able to play through the showdown phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on showdown_monster for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260223224200_showdown_survivor.sql
+++ b/supabase/migrations/20260223224200_showdown_survivor.sql
@@ -46,6 +46,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this showdown-phase table. Collaborators
+-- should be able to play through the showdown phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on showdown_survivor for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260324185312_fix_settlement_phase_returning_survivor_rls.sql
+++ b/supabase/migrations/20260324185312_fix_settlement_phase_returning_survivor_rls.sql
@@ -15,6 +15,10 @@ drop policy if exists "Allow all for admin" on settlement_phase_returning_surviv
 -- Ensure RLS is enabled
 alter table settlement_phase_returning_survivor enable row level security;
 -- Recreate policies with explicit column qualification
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on settlement_phase_returning_survivor.
+-- Collaborators should be able to advance phases on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.b] (issue #138).
 create policy "Allow insert for owner" on settlement_phase_returning_survivor for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260413223401_ability_impairment.sql
+++ b/supabase/migrations/20260413223401_ability_impairment.sql
@@ -82,6 +82,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on ability_impairment for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260413223402_survivor_ability_impairment.sql
+++ b/supabase/migrations/20260413223402_survivor_ability_impairment.sql
@@ -29,6 +29,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this survivor-scoped junction.
+-- Collaborators on the parent settlement should be able to mutate it.
+-- Loosened in Phase 1 — see [E1.2.c] (issue #145).
 create policy "Allow insert for owner" on survivor_ability_impairment for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260422000003_mood.sql
+++ b/supabase/migrations/20260422000003_mood.sql
@@ -82,6 +82,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on mood for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260422000004_trait.sql
+++ b/supabase/migrations/20260422000004_trait.sql
@@ -82,6 +82,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on trait for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260422000005_hunt_monster_trait_mood.sql
+++ b/supabase/migrations/20260422000005_hunt_monster_trait_mood.sql
@@ -33,6 +33,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this hunt-phase table. Collaborators
+-- should be able to play through the hunt phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on hunt_monster_trait for
 insert to authenticated with check (
     exists (
@@ -132,6 +136,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this hunt-phase table. Collaborators
+-- should be able to play through the hunt phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on hunt_monster_mood for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260422000006_showdown_monster_trait_mood.sql
+++ b/supabase/migrations/20260422000006_showdown_monster_trait_mood.sql
@@ -33,6 +33,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this showdown-phase table. Collaborators
+-- should be able to play through the showdown phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on showdown_monster_trait for
 insert to authenticated with check (
     exists (
@@ -132,6 +136,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this showdown-phase table. Collaborators
+-- should be able to play through the showdown phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on showdown_monster_mood for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260424000000_survivor_status.sql
+++ b/supabase/migrations/20260424000000_survivor_status.sql
@@ -82,6 +82,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on survivor_status for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260424000006_hunt_showdown_monster_survivor_status.sql
+++ b/supabase/migrations/20260424000006_hunt_showdown_monster_survivor_status.sql
@@ -33,6 +33,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this hunt-phase table. Collaborators
+-- should be able to play through the hunt phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on hunt_monster_survivor_status for
 insert to authenticated with check (
     exists (
@@ -133,6 +137,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on this showdown-phase table. Collaborators
+-- should be able to play through the showdown phase on a shared settlement.
+-- Loosened in Phase 1 — see [E1.2.d] (issue #140).
 create policy "Allow insert for owner" on showdown_monster_survivor_status for
 insert to authenticated with check (
     exists (

--- a/supabase/migrations/20260424000007_armor_set.sql
+++ b/supabase/migrations/20260424000007_armor_set.sql
@@ -90,6 +90,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on armor_set for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260424000008_constellation.sql
+++ b/supabase/migrations/20260424000008_constellation.sql
@@ -82,6 +82,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
+-- row was shared can currently UPDATE rules text. Custom catalog rules
+-- text should only be editable by the author (owner).
+-- Removed in Phase 2 — see [E2.2] (issue #149).
 create policy "Allow update for shared and custom" on constellation for
 update to authenticated using (
     custom

--- a/supabase/migrations/20260503000000_gear_grid_settlement_rls.sql
+++ b/supabase/migrations/20260503000000_gear_grid_settlement_rls.sql
@@ -65,6 +65,10 @@ select to authenticated using (
         )
     )
   );
+-- CONTRADICTION (architecture §4 P1): only the settlement owner can
+-- currently INSERT/UPDATE/DELETE on gear_grid. Collaborators on the
+-- parent settlement should be able to mutate their survivor's grid.
+-- Loosened in Phase 1 — see [E1.2.c] (issue #145).
 create policy "Allow insert for owner" on gear_grid for
 insert to authenticated with check (
     exists (


### PR DESCRIPTION
## Summary

Documentation-only pass for **[E0.5] Inline `-- CONTRADICTION:` comments on existing inverted RLS policies** (Closes #131).

Adds an inline SQL comment to every existing RLS policy whose polarity is inverted relative to the user's stated intent (architecture `local/sharing-architecture.md` §4 P1). Each annotation names the architecture section that documents the contradiction and the GitHub issue that will fix it in Phase 1 or Phase 2, so the next person to touch these files isn't surprised by the imminent rewrite.

**No policy behaviour is altered.** Pure SQL comments; the migrations still apply cleanly via `supabase db reset` and every unit + integration test still passes.

## Annotated policies

| Group                                   | Files | Resolved by                                  |
| --------------------------------------- | ----- | -------------------------------------------- |
| `settlement.Allow update for shared`    | 1     | [E1.3] (#133) — hybrid `settlement` UPDATE   |
| Catalog `Allow update for shared and custom` (rules text) | 27 | [E2.2] (#149) — drop policy entirely |
| `settlement_*` junctions (owner-only INSERT/UPDATE/DELETE) | 14 | [E1.2.a] (#135) |
| `settlement_phase` + `settlement_phase_returning_survivor` | 2 | [E1.2.b] (#138) |
| `survivor`, 5 `survivor_*` junctions, `gear_grid`           | 7  | [E1.2.c] (#145) |
| `hunt`, 5 `hunt_*` tables, `showdown`, 5 `showdown_*` tables | 12 | [E1.2.d] (#140) |

**63 migration files** annotated; **64 inline comment blocks** added (a few migrations define two annotated tables in one file).

## Form

Each comment follows the form spelled out in the issue, e.g.:

```sql
-- CONTRADICTION (architecture §4 P1): collaborators with whom this catalog
-- row was shared can currently UPDATE rules text. Custom catalog rules
-- text should only be editable by the author (owner).
-- Removed in Phase 2 — see [E2.2] (issue #149).
```

## Acceptance criteria

- [x] Every inverted policy has a comment that names the architecture-doc section and the issue that will fix it.
- [x] `supabase db reset` still applies migrations cleanly (verified locally).
- [x] No behavioural change — 2066/2066 unit tests pass, 397/397 integration tests pass, `eslint .` clean.

## Verification

```text
npx supabase db reset           # all 100+ migrations apply
npm test                        # 116 files, 2066/2066 pass
bash scripts/integration.sh     # 9 files, 397/397 pass
npm run lint                    # 0 errors
```

## Dependencies

No code or runtime dependency changes. Version bumped from `0.46.0` → `0.47.0` per repo PR guidance.

A small companion edit to `.github/copilot-instructions.md` is included in commit `48c9cf5`: it adds a brief "Database Considerations" guideline reminding agents (including Copilot) to never run `supabase db reset --no-seed` against the working DB, since that wipes catalog seed data and breaks the in-app seed-data generator.

## Related

- Issue: #131
- Epic: [E0] #120
- Architecture doc: `local/sharing-architecture.md` §4 P1, §10 Phase 0 item 0.5

## Out of scope

Actually changing any policies — that's E1/E2.

Closes #131