### PR TITLE
feat(profile): add avatar_url + OAuth backfill + UserAvatar

### DIFF
--- a/__tests__/integration/rls/oauth-avatar-backfill.test.ts
+++ b/__tests__/integration/rls/oauth-avatar-backfill.test.ts
@@ -1,0 +1,161 @@
+import { admin } from '@/__tests__/integration/helpers/supabase'
+import { afterAll, describe, expect, it } from 'vitest'
+
+/**
+ * Trigger / Helper — `provision_user_settings_for_oauth` (avatar capture)
+ *
+ * Validates that the OAuth-provisioning helper called by the
+ * `handle_new_oauth_user()` trigger captures `avatar_url` from
+ * `raw_user_meta_data->>'avatar_url'` for OAuth sign-ups, leaves it null
+ * when the provider does not supply one, and treats empty strings as null.
+ *
+ * The end-to-end trigger path cannot be exercised through
+ * `admin.auth.admin.createUser` because GoTrue inserts the auth.users row
+ * with `provider = 'email'` first and only patches `raw_app_meta_data`
+ * afterwards — so the trigger always sees provider='email' and
+ * short-circuits. Instead we set the metadata via the admin API (which
+ * GoTrue persists onto `auth.users.raw_user_meta_data`) and then call
+ * the SECURITY DEFINER helper directly.
+ */
+describe('Helper: provision_user_settings_for_oauth (avatar_url)', () => {
+  const createdUserIds: string[] = []
+
+  afterAll(async () => {
+    for (const id of createdUserIds) await admin.auth.admin.deleteUser(id)
+  })
+
+  /**
+   * Create An OAuth-Style User Without A user_settings Row
+   *
+   * GoTrue's admin createUser fires the existing trigger as a no-op (it
+   * sees provider='email' on insert), so the user_settings row is not
+   * pre-created. Tests then call `provision_user_settings_for_oauth`
+   * directly to simulate the OAuth path.
+   *
+   * @param userMetadata Discord/Google-shaped user_metadata payload
+   * @returns Created Auth User ID
+   */
+  async function createPendingOauthUser(
+    userMetadata: Record<string, unknown>
+  ): Promise<string> {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const email = `oauth-${suffix}@test.local`
+
+    const { data, error } = await admin.auth.admin.createUser({
+      email,
+      email_confirm: true,
+      user_metadata: userMetadata
+    })
+    if (error || !data.user)
+      throw new Error(`createUser failed: ${error?.message}`)
+
+    createdUserIds.push(data.user.id)
+    return data.user.id
+  }
+
+  it('captures avatar_url from raw_user_meta_data on Discord-style sign-up', async () => {
+    const url = 'https://cdn.discordapp.com/avatars/123/abc.png'
+    const userId = await createPendingOauthUser({
+      user_name: `oauth_user_${Date.now().toString(36)}`,
+      avatar_url: url
+    })
+
+    const { error: rpcError } = await admin.rpc(
+      'provision_user_settings_for_oauth',
+      { p_user_id: userId }
+    )
+    expect(rpcError).toBeNull()
+
+    const { data, error } = await admin
+      .from('user_settings')
+      .select('avatar_url, username')
+      .eq('user_id', userId)
+      .maybeSingle()
+
+    expect(error).toBeNull()
+    expect(data).not.toBeNull()
+    expect(data?.avatar_url).toBe(url)
+    expect(data?.username).toBeTruthy()
+  })
+
+  it('stores null avatar_url when the provider does not supply one', async () => {
+    const userId = await createPendingOauthUser({
+      user_name: `noavatar_${Date.now().toString(36)}`
+    })
+
+    const { error: rpcError } = await admin.rpc(
+      'provision_user_settings_for_oauth',
+      { p_user_id: userId }
+    )
+    expect(rpcError).toBeNull()
+
+    const { data, error } = await admin
+      .from('user_settings')
+      .select('avatar_url')
+      .eq('user_id', userId)
+      .maybeSingle()
+
+    expect(error).toBeNull()
+    expect(data).not.toBeNull()
+    expect(data?.avatar_url).toBeNull()
+  })
+
+  it('treats an empty-string avatar_url as null', async () => {
+    const userId = await createPendingOauthUser({
+      user_name: `emptyavatar_${Date.now().toString(36)}`,
+      avatar_url: ''
+    })
+
+    const { error: rpcError } = await admin.rpc(
+      'provision_user_settings_for_oauth',
+      { p_user_id: userId }
+    )
+    expect(rpcError).toBeNull()
+
+    const { data } = await admin
+      .from('user_settings')
+      .select('avatar_url')
+      .eq('user_id', userId)
+      .maybeSingle()
+
+    expect(data).not.toBeNull()
+    expect(data?.avatar_url).toBeNull()
+  })
+
+  it('is idempotent when a user_settings row already exists', async () => {
+    const url = 'https://example.com/first.png'
+    const userId = await createPendingOauthUser({
+      user_name: `idempotent_${Date.now().toString(36)}`,
+      avatar_url: url
+    })
+
+    // First call provisions the row.
+    await admin.rpc('provision_user_settings_for_oauth', { p_user_id: userId })
+
+    const { data: first } = await admin
+      .from('user_settings')
+      .select('avatar_url, username')
+      .eq('user_id', userId)
+      .maybeSingle()
+
+    // Mutate raw_user_meta_data to a different avatar URL and re-run the
+    // helper — the existing row must be left alone, otherwise we'd race
+    // with user-driven changes.
+    await admin.auth.admin.updateUserById(userId, {
+      user_metadata: {
+        user_name: `idempotent_${Date.now().toString(36)}`,
+        avatar_url: 'https://example.com/second.png'
+      }
+    })
+    await admin.rpc('provision_user_settings_for_oauth', { p_user_id: userId })
+
+    const { data: second } = await admin
+      .from('user_settings')
+      .select('avatar_url, username')
+      .eq('user_id', userId)
+      .maybeSingle()
+
+    expect(second?.avatar_url).toBe(first?.avatar_url)
+    expect(second?.username).toBe(first?.username)
+  })
+})

--- a/__tests__/lib/avatar.test.ts
+++ b/__tests__/lib/avatar.test.ts
@@ -1,0 +1,82 @@
+import {
+  INITIALS_PALETTE,
+  getInitialsFromName,
+  pickInitialsColor
+} from '@/lib/avatar'
+import { describe, expect, it } from 'vitest'
+
+describe('getInitialsFromName', () => {
+  it('returns ? for null', () => {
+    expect(getInitialsFromName(null)).toBe('?')
+  })
+
+  it('returns ? for undefined', () => {
+    expect(getInitialsFromName(undefined)).toBe('?')
+  })
+
+  it('returns ? for empty string', () => {
+    expect(getInitialsFromName('')).toBe('?')
+  })
+
+  it('returns ? for whitespace-only string', () => {
+    expect(getInitialsFromName('   ')).toBe('?')
+  })
+
+  it('takes leading characters of the first two tokens', () => {
+    expect(getInitialsFromName('Jane Doe')).toBe('JD')
+    expect(getInitialsFromName('jane doe smith')).toBe('JD')
+  })
+
+  it('uppercases the result', () => {
+    expect(getInitialsFromName('alice bob')).toBe('AB')
+  })
+
+  it('falls back to first 2 chars for single-token names', () => {
+    expect(getInitialsFromName('ncalteen')).toBe('NC')
+    expect(getInitialsFromName('JD')).toBe('JD')
+  })
+
+  it('returns a single uppercase char for single-character names', () => {
+    expect(getInitialsFromName('x')).toBe('X')
+  })
+
+  it('handles extra interior whitespace', () => {
+    expect(getInitialsFromName('  jane    doe  ')).toBe('JD')
+  })
+})
+
+describe('pickInitialsColor', () => {
+  it('returns the first palette entry for null/undefined', () => {
+    expect(pickInitialsColor(null)).toBe(INITIALS_PALETTE[0])
+    expect(pickInitialsColor(undefined)).toBe(INITIALS_PALETTE[0])
+    expect(pickInitialsColor('')).toBe(INITIALS_PALETTE[0])
+  })
+
+  it('always returns a palette entry', () => {
+    for (const key of [
+      'a',
+      '00000000-0000-0000-0000-000000000001',
+      '11111111-1111-1111-1111-111111111111',
+      'jane',
+      'doe',
+      'survivor_42'
+    ])
+      expect(INITIALS_PALETTE).toContain(pickInitialsColor(key))
+  })
+
+  it('is deterministic for the same key', () => {
+    const key = '00000000-0000-0000-0000-000000000001'
+    expect(pickInitialsColor(key)).toBe(pickInitialsColor(key))
+    expect(pickInitialsColor('jane_doe')).toBe(pickInitialsColor('jane_doe'))
+  })
+
+  it('distributes different keys across the palette', () => {
+    // Probabilistic but deterministic: with 50 distinct keys and a 10-entry
+    // palette we expect to hit at least 4 distinct buckets.
+    const buckets = new Set<string>()
+    for (let i = 0; i < 50; i++)
+      buckets.add(pickInitialsColor(`user-${i}-test-key`))
+
+    expect(buckets.size).toBeGreaterThanOrEqual(4)
+  })
+})

--- a/__tests__/lib/dal/user.test.ts
+++ b/__tests__/lib/dal/user.test.ts
@@ -57,7 +57,7 @@ describe('getUserSettings', () => {
 
     expect(mockSupabase.from).toHaveBeenCalledWith('user_settings')
     expect(mockSelect).toHaveBeenCalledWith(
-      'id, unlocked_killenium_butcher, unlocked_screaming_nukalope, unlocked_white_gigalion, user_id, username, username_renamed_at'
+      'avatar_url, id, unlocked_killenium_butcher, unlocked_screaming_nukalope, unlocked_white_gigalion, user_id, username, username_renamed_at'
     )
     expect(mockEq).toHaveBeenCalledWith('user_id', mockUser.id)
     expect(mockMaybeSingle).toHaveBeenCalledOnce()

--- a/components/generic/user-avatar.tsx
+++ b/components/generic/user-avatar.tsx
@@ -50,7 +50,7 @@ export function UserAvatar({
   const initials = useMemo(
     () =>
       initialsOverride && initialsOverride.trim().length > 0
-        ? initialsOverride.toUpperCase().slice(0, 2)
+        ? initialsOverride.trim().toUpperCase().slice(0, 2)
         : getInitialsFromName(username),
     [initialsOverride, username]
   )

--- a/components/generic/user-avatar.tsx
+++ b/components/generic/user-avatar.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { getInitialsFromName, pickInitialsColor } from '@/lib/avatar'
+import { cn } from '@/lib/utils'
+import { ComponentProps, ReactElement, useMemo } from 'react'
+
+/**
+ * User Avatar Properties
+ */
+export interface UserAvatarProps extends Omit<
+  ComponentProps<typeof Avatar>,
+  'children'
+> {
+  /** Provider-Supplied Avatar URL (Discord, Google, ...) */
+  avatarUrl?: string | null
+  /** Username (used to derive initials and the alt attribute) */
+  username?: string | null
+  /** User ID (used to deterministically pick a fallback colour) */
+  userId?: string | null
+  /** Override Initials (e.g. for survivors using survivor_name) */
+  initialsOverride?: string
+  /** Override Fallback Colour (e.g. for survivors keyed on survivor_id) */
+  colorClassName?: string
+  /** Optional alt text override (defaults to the username) */
+  alt?: string
+}
+
+/**
+ * User Avatar
+ *
+ * Renders an OAuth-supplied avatar when one is available, otherwise falls
+ * back to colored initials derived from the username. Designed to be the
+ * single avatar primitive across presence indicators, "By @user" chips,
+ * and the notification bell so identity stays visually consistent.
+ *
+ * @param props User Avatar Properties
+ * @returns User Avatar Component
+ */
+export function UserAvatar({
+  avatarUrl,
+  username,
+  userId,
+  initialsOverride,
+  colorClassName,
+  alt,
+  className,
+  ...props
+}: UserAvatarProps): ReactElement {
+  const initials = useMemo(
+    () =>
+      initialsOverride && initialsOverride.trim().length > 0
+        ? initialsOverride.toUpperCase().slice(0, 2)
+        : getInitialsFromName(username),
+    [initialsOverride, username]
+  )
+
+  const fallbackColor = useMemo(
+    () => colorClassName ?? pickInitialsColor(userId ?? username ?? null),
+    [colorClassName, userId, username]
+  )
+
+  const altText = alt ?? username ?? 'User avatar'
+
+  return (
+    <Avatar className={cn('size-8', className)} {...props}>
+      {avatarUrl ? (
+        <AvatarImage
+          src={avatarUrl}
+          alt={altText}
+          referrerPolicy="no-referrer"
+        />
+      ) : null}
+      <AvatarFallback
+        className={cn('text-xs font-semibold text-white', fallbackColor)}>
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  )
+}

--- a/components/update-password-form.tsx
+++ b/components/update-password-form.tsx
@@ -83,6 +83,9 @@ export function UpdatePasswordForm({
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                 />
+                <p className="text-xs text-muted-foreground">
+                  A new ward against the dark.
+                </p>
               </div>
               {error && (
                 <Alert variant="destructive">

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -1,0 +1,87 @@
+/**
+ * Avatar Helpers
+ *
+ * Shared pure helpers for the `<UserAvatar>` component (see
+ * `components/generic/user-avatar.tsx`). Kept in `lib/` so they can be unit
+ * tested in the node test environment without pulling React/Radix DOM
+ * primitives.
+ */
+
+/**
+ * Initials Palette
+ *
+ * Curated set of background colours for the colored-initials fallback. Picked
+ * from Tailwind's saturated-but-readable hues so white text on the swatch
+ * stays legible. The selected entry is derived deterministically from the
+ * `user_id` so the same user always shows the same colour.
+ */
+export const INITIALS_PALETTE = [
+  'bg-amber-500',
+  'bg-orange-500',
+  'bg-rose-500',
+  'bg-fuchsia-500',
+  'bg-violet-500',
+  'bg-indigo-500',
+  'bg-sky-500',
+  'bg-teal-500',
+  'bg-emerald-500',
+  'bg-lime-500'
+] as const
+
+/**
+ * Derive Initials From Name
+ *
+ * Splits on whitespace, takes up to the first two non-empty tokens, and
+ * uppercases their leading character. Falls back to the first 2 characters
+ * of the input (or `?` for empty input) so the avatar always shows
+ * something legible.
+ *
+ * @param name Source Name
+ * @returns Up to 2 Uppercase Characters
+ */
+export function getInitialsFromName(name: string | null | undefined): string {
+  if (!name) return '?'
+
+  const trimmed = name.trim()
+  if (trimmed.length === 0) return '?'
+
+  const tokens = trimmed.split(/\s+/).filter(Boolean)
+  if (tokens.length >= 2) return (tokens[0][0] + tokens[1][0]).toUpperCase()
+
+  // Single token: use the first two characters so handles like `ncalteen`
+  // render as `NC` rather than just `N`.
+  return trimmed.slice(0, 2).toUpperCase()
+}
+
+/**
+ * Hash A String To An Unsigned 32-Bit Integer
+ *
+ * Uses the djb2 variant. We do not need cryptographic strength — just
+ * stable bucketing of arbitrary keys to palette entries.
+ *
+ * @param value Source String
+ * @returns Unsigned 32-Bit Hash
+ */
+function hashString(value: string): number {
+  let hash = 5381
+  for (let i = 0; i < value.length; i++)
+    hash = ((hash << 5) + hash + value.charCodeAt(i)) >>> 0
+
+  return hash
+}
+
+/**
+ * Pick Initials Color
+ *
+ * Deterministically maps an arbitrary key (typically a `user_id`) to one
+ * of the initials palette entries. Returns the same class for the same
+ * key on every call.
+ *
+ * @param key Hash Source
+ * @returns Tailwind Background Class
+ */
+export function pickInitialsColor(key: string | null | undefined): string {
+  if (!key) return INITIALS_PALETTE[0]
+
+  return INITIALS_PALETTE[hashString(key) % INITIALS_PALETTE.length]
+}

--- a/lib/dal/user.ts
+++ b/lib/dal/user.ts
@@ -158,7 +158,7 @@ export async function getUserSettings(): Promise<UserSettingsDetail | null> {
   const { data, error } = await supabase
     .from('user_settings')
     .select(
-      'id, unlocked_killenium_butcher, unlocked_screaming_nukalope, unlocked_white_gigalion, user_id, username, username_renamed_at'
+      'avatar_url, id, unlocked_killenium_butcher, unlocked_screaming_nukalope, unlocked_white_gigalion, user_id, username, username_renamed_at'
     )
     .eq('user_id', userId)
     .maybeSingle()
@@ -274,7 +274,7 @@ export async function addUserSettings(
     .from('user_settings')
     .insert(userSettings)
     .select(
-      'id, unlocked_killenium_butcher, unlocked_screaming_nukalope, unlocked_white_gigalion, user_id, username, username_renamed_at'
+      'avatar_url, id, unlocked_killenium_butcher, unlocked_screaming_nukalope, unlocked_white_gigalion, user_id, username, username_renamed_at'
     )
     .single()
 

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5482,6 +5482,7 @@ export type Database = {
       }
       user_settings: {
         Row: {
+          avatar_url: string | null
           created_at: string
           id: string
           unlocked_killenium_butcher: boolean
@@ -5493,6 +5494,7 @@ export type Database = {
           username_renamed_at: string | null
         }
         Insert: {
+          avatar_url?: string | null
           created_at?: string
           id?: string
           unlocked_killenium_butcher?: boolean
@@ -5504,6 +5506,7 @@ export type Database = {
           username_renamed_at?: string | null
         }
         Update: {
+          avatar_url?: string | null
           created_at?: string
           id?: string
           unlocked_killenium_butcher?: boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260508000000_user_settings_avatar_url.sql
+++ b/supabase/migrations/20260508000000_user_settings_avatar_url.sql
@@ -1,0 +1,143 @@
+--------------------------------------------------------------------------------
+-- User Avatar URL
+--
+-- Adds a nullable `avatar_url` column to `user_settings` so the app can
+-- render a provider-supplied avatar (Discord, Google, etc.) for OAuth users.
+-- Email-only sign-ups stay null and the `<UserAvatar>` component falls back
+-- to colored initials.
+--
+-- The column is nullable (no default) because there is no meaningful default:
+-- "no avatar" is a real, intended state.
+--
+-- See plan decision D5 (avatars from OAuth provider metadata + initials
+-- fallback; no upload UI).
+--------------------------------------------------------------------------------
+alter table user_settings
+add column if not exists avatar_url text;
+--------------------------------------------------------------------------------
+-- Provisioning helper used by both the trigger and integration tests.
+--
+-- Extracted from `handle_new_oauth_user()` so the avatar-capture path is
+-- reachable without going through GoTrue's admin createUser flow. GoTrue's
+-- admin endpoint inserts the auth.users row with `provider = 'email'`
+-- first and only updates `raw_app_meta_data` afterwards, which means the
+-- trigger always sees provider='email' and short-circuits — making
+-- end-to-end testing of provider metadata otherwise impossible.
+--
+-- The function is idempotent: it inserts a user_settings row if one is
+-- missing, otherwise leaves it alone (avoids racing with the email-flow
+-- `initialize_user_settings` RPC).
+--------------------------------------------------------------------------------
+create or replace function provision_user_settings_for_oauth(p_user_id uuid) returns void language plpgsql security definer
+set search_path = public as $$
+declare meta jsonb;
+user_email text;
+provider_avatar_url text;
+base_candidate varchar;
+candidate varchar;
+suffix text;
+attempt int := 0;
+max_attempts constant int := 25;
+begin if exists (
+  select 1
+  from user_settings
+  where user_id = p_user_id
+) then return;
+end if;
+select coalesce(au.raw_user_meta_data, '{}'::jsonb),
+  au.email into meta,
+  user_email
+from auth.users au
+where au.id = p_user_id;
+if meta is null then return;
+end if;
+provider_avatar_url := nullif(meta->>'avatar_url', '');
+base_candidate := coalesce(
+  sanitize_username_candidate(meta->>'user_name'),
+  sanitize_username_candidate(meta->>'preferred_username'),
+  sanitize_username_candidate(meta->>'username'),
+  sanitize_username_candidate(meta->>'global_name'),
+  sanitize_username_candidate(meta->>'name'),
+  sanitize_username_candidate(meta->>'full_name'),
+  sanitize_username_candidate(split_part(coalesce(user_email, ''), '@', 1)),
+  sanitize_username_candidate(
+    'survivor_' || substring(
+      p_user_id::text
+      from 1 for 8
+    )
+  )
+);
+if base_candidate is null then base_candidate := substring(
+  ('u_' || replace(p_user_id::text, '-', ''))
+  from 1 for 20
+)::varchar;
+end if;
+candidate := base_candidate;
+loop begin
+insert into user_settings (user_id, username, avatar_url)
+values (p_user_id, candidate, provider_avatar_url);
+return;
+exception
+when unique_violation then attempt := attempt + 1;
+exit
+when attempt > max_attempts;
+suffix := lpad((floor(random() * 10000))::int::text, 4, '0');
+candidate := (
+  substring(
+    base_candidate
+    from 1 for greatest(1, 20 - char_length(suffix) - 1)
+  ) || '_' || suffix
+)::varchar;
+end;
+end loop;
+candidate := substring(
+  ('u_' || replace(p_user_id::text, '-', ''))
+  from 1 for 20
+)::varchar;
+insert into user_settings (user_id, username, avatar_url)
+values (p_user_id, candidate, provider_avatar_url) on conflict (user_id) do nothing;
+end;
+$$;
+revoke all on function provision_user_settings_for_oauth(uuid)
+from public;
+grant execute on function provision_user_settings_for_oauth(uuid) to service_role;
+--------------------------------------------------------------------------------
+-- Replace `handle_new_oauth_user` to delegate to the helper.
+--
+-- Functional behaviour is preserved (still skips email sign-ups, still
+-- fires AFTER INSERT). The trigger is now a thin wrapper around the
+-- shared helper, so the avatar-capture path can be exercised end-to-end
+-- by integration tests without forging auth.users rows.
+--------------------------------------------------------------------------------
+create or replace function handle_new_oauth_user() returns trigger language plpgsql security definer
+set search_path = public as $$
+declare provider text;
+begin provider := coalesce(new.raw_app_meta_data->>'provider', '');
+-- Email sign-ups handle their own user_settings row via the
+-- initialize_user_settings RPC, using the username the user typed in.
+-- Auto-provisioning here would race with that RPC.
+if provider = ''
+or provider = 'email' then return new;
+end if;
+perform provision_user_settings_for_oauth(new.id);
+return new;
+end;
+$$;
+--------------------------------------------------------------------------------
+-- Backfill existing OAuth users.
+--
+-- Captures `avatar_url` for users who already signed in via a provider
+-- before this migration ran. Email-only users are skipped (they have no
+-- provider metadata). Existing non-null `avatar_url` values are preserved
+-- so a future user-supplied override would not be clobbered.
+--------------------------------------------------------------------------------
+update user_settings
+set avatar_url = coalesce(
+    user_settings.avatar_url,
+    nullif(au.raw_user_meta_data->>'avatar_url', '')
+  )
+from auth.users au
+where user_settings.user_id = au.id
+  and coalesce(au.raw_app_meta_data->>'provider', '') not in ('', 'email')
+  and user_settings.avatar_url is null
+  and nullif(au.raw_user_meta_data->>'avatar_url', '') is not null;


### PR DESCRIPTION
## Summary

Implements **E0.7** (issue #128): adds a nullable `user_settings.avatar_url`
column populated from OAuth provider metadata (Discord, Google) and a shared
`<UserAvatar>` primitive that falls back to deterministically-coloured initials
when no provider avatar is available.

This unblocks **D5** ("avatars from OAuth provider metadata + initials
fallback; no upload UI") and Phase 4 item 4.1 in
[`local/sharing-architecture.md`](local/sharing-architecture.md).

## Changes

### Database
- New migration `20260508000000_user_settings_avatar_url.sql`:
  - Adds `avatar_url text` (nullable) to `user_settings`.
  - Extracts the OAuth-provisioning logic into a SECURITY DEFINER helper
    `provision_user_settings_for_oauth(uuid)`. The trigger
    `handle_new_oauth_user()` now delegates to the helper. The helper is
    idempotent — it short-circuits when a `user_settings` row already
    exists, so it cannot race with the email-flow `initialize_user_settings`
    RPC.
  - Backfills `avatar_url` for existing OAuth users from
    `auth.users.raw_user_meta_data->>'avatar_url'`. Email-only users are
    skipped. Empty strings are coerced to `NULL`.

### Avatar primitives
- `lib/avatar.ts`: pure helpers `getInitialsFromName()` and
  `pickInitialsColor()` (djb2 hash → 10-entry Tailwind palette). Kept
  in `lib/` so they're testable in the node test environment.
- `components/generic/user-avatar.tsx`: `<UserAvatar>` wrapper around
  the Radix `Avatar`/`AvatarImage`/`AvatarFallback` primitives.
  Supports optional `initialsOverride` and `colorClassName` for
  non-user contexts (e.g. survivors keyed on `survivor_id`).

### DAL
- `getUserSettings()` / `addUserSettings()` SELECTs now include
  `avatar_url`. `UserSettingsDetail` automatically picks up the new
  column from the regenerated `lib/database.types.ts`.

### Settings UI alignment
- Adds a thematic hint line beneath the password input
  ("A new ward against the dark.") so the username and password cards
  have matching vertical structure (label + input + hint + button).
  Closes the visual mis-alignment between the two cards in the
  Settings tab.

## Tests

- 13 new unit tests in `__tests__/lib/avatar.test.ts` covering
  `getInitialsFromName` (null/empty/whitespace/two-token/single-token
  inputs) and `pickInitialsColor` (palette membership, determinism,
  distribution).
- 4 new integration tests in
  `__tests__/integration/rls/oauth-avatar-backfill.test.ts` that
  exercise `provision_user_settings_for_oauth` directly, since
  GoTrue's admin `createUser` API inserts the auth.users row with
  `provider='email'` first and only patches `raw_app_meta_data`
  afterwards — so the trigger always sees `provider='email'` and
  short-circuits. The helper extraction makes this path testable.
- One existing assertion in `__tests__/lib/dal/user.test.ts` updated
  to include the new `avatar_url` column in the asserted SELECT
  string.

### Verification
- `npm run lint`: clean.
- `npm test`: 2087 / 2087 passed.
- `bash scripts/integration.sh`: 409 / 409 passed.

## Dependency changes

None.

## Versioning

Bumps `package.json` / `package-lock.json` to **0.49.0**.

## Closes

Closes #128.