### PR TITLE
feat(rls): add is_settlement_collaborator(uuid) helper (#143)

### DIFF
--- a/__tests__/integration/rls/is-settlement-collaborator.test.ts
+++ b/__tests__/integration/rls/is-settlement-collaborator.test.ts
@@ -100,8 +100,7 @@ describe('RPC: is_settlement_collaborator', () => {
     // PostgREST surfaces PostgreSQL's 42501 either as a top-level `code` or
     // inside `message` ("permission denied for function ..."); accept either.
     expect(
-      error?.code === '42501' ||
-        /permission denied/i.test(error?.message ?? '')
+      error?.code === '42501' || /permission denied/i.test(error?.message ?? '')
     ).toBe(true)
   })
 })

--- a/__tests__/integration/rls/is-settlement-collaborator.test.ts
+++ b/__tests__/integration/rls/is-settlement-collaborator.test.ts
@@ -1,0 +1,97 @@
+import {
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { createClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RPC — `is_settlement_collaborator(uuid)`
+ *
+ * SECURITY DEFINER predicate consumed by collaborator-aware RLS policies on
+ * every `settlement_*` junction table (see Epic E1 — Phase 1).
+ *
+ * The helper returns `true` only when `auth.uid()` matches a `shared_user_id`
+ * row in `settlement_shared_user` for the given settlement. It MUST NOT
+ * report owners as collaborators, and it MUST NOT leak access to anonymous
+ * callers — the function is scoped to the `authenticated` role.
+ */
+describe('RPC: is_settlement_collaborator', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let settlementId: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+    settlementId = await seedSettlement(owner.id, 'Collaborator Helper Test')
+    await shareSettlement(settlementId, collaborator.id, owner.id)
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+  })
+
+  it('returns true for a shared collaborator', async () => {
+    const { data, error } = await collaborator.client.rpc(
+      'is_settlement_collaborator',
+      { target_settlement: settlementId }
+    )
+    expect(error).toBeNull()
+    expect(data).toBe(true)
+  })
+
+  it('returns false for the settlement owner', async () => {
+    // Owners are intentionally NOT modeled as collaborators — policies that
+    // accept either role should use the disjunction
+    // `is_settlement_owner(...) or is_settlement_collaborator(...)`.
+    const { data, error } = await owner.client.rpc(
+      'is_settlement_collaborator',
+      { target_settlement: settlementId }
+    )
+    expect(error).toBeNull()
+    expect(data).toBe(false)
+  })
+
+  it('returns false for an unrelated authenticated user', async () => {
+    const { data, error } = await stranger.client.rpc(
+      'is_settlement_collaborator',
+      { target_settlement: settlementId }
+    )
+    expect(error).toBeNull()
+    expect(data).toBe(false)
+  })
+
+  it('returns false for a settlement that does not exist', async () => {
+    const { data, error } = await collaborator.client.rpc(
+      'is_settlement_collaborator',
+      { target_settlement: '00000000-0000-0000-0000-000000000000' }
+    )
+    expect(error).toBeNull()
+    expect(data).toBe(false)
+  })
+
+  it('rejects an unauthenticated caller', async () => {
+    // EXECUTE was revoked from PUBLIC and granted only to `authenticated`,
+    // so the anon role cannot invoke the helper.
+    const anon = createClient(
+      process.env.SUPABASE_URL ?? '',
+      process.env.SUPABASE_ANON_KEY ?? '',
+      { auth: { persistSession: false, autoRefreshToken: false } }
+    )
+
+    const { data, error } = await anon.rpc('is_settlement_collaborator', {
+      target_settlement: settlementId
+    })
+
+    expect(data).toBeNull()
+    expect(error).not.toBeNull()
+  })
+})

--- a/__tests__/integration/rls/is-settlement-collaborator.test.ts
+++ b/__tests__/integration/rls/is-settlement-collaborator.test.ts
@@ -79,8 +79,10 @@ describe('RPC: is_settlement_collaborator', () => {
   })
 
   it('rejects an unauthenticated caller', async () => {
-    // EXECUTE was revoked from PUBLIC and granted only to `authenticated`,
-    // so the anon role cannot invoke the helper.
+    // EXECUTE was revoked from PUBLIC and from anon explicitly, so the
+    // anon role cannot invoke the helper. (service_role still holds EXECUTE
+    // via Supabase's default privileges — that's intentional and not what
+    // this test exercises.)
     const anon = createClient(
       process.env.SUPABASE_URL ?? '',
       process.env.SUPABASE_ANON_KEY ?? '',
@@ -93,5 +95,13 @@ describe('RPC: is_settlement_collaborator', () => {
 
     expect(data).toBeNull()
     expect(error).not.toBeNull()
+    // Pin the failure to a permission-denied signal so the test can't
+    // accidentally pass on an unrelated error (e.g. a malformed argument).
+    // PostgREST surfaces PostgreSQL's 42501 either as a top-level `code` or
+    // inside `message` ("permission denied for function ..."); accept either.
+    expect(
+      error?.code === '42501' ||
+        /permission denied/i.test(error?.message ?? '')
+    ).toBe(true)
   })
 })

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5838,6 +5838,10 @@ export type Database = {
         Returns: boolean
       }
       is_seed_pattern_owner: { Args: { record_id: string }; Returns: boolean }
+      is_settlement_collaborator: {
+        Args: { target_settlement: string }
+        Returns: boolean
+      }
       is_settlement_owner: { Args: { record_id: string }; Returns: boolean }
       is_strain_milestone_owner: {
         Args: { record_id: string }
@@ -5850,6 +5854,10 @@ export type Database = {
       is_trait_owner: { Args: { record_id: string }; Returns: boolean }
       is_wanderer_owner: { Args: { record_id: string }; Returns: boolean }
       is_weapon_type_owner: { Args: { record_id: string }; Returns: boolean }
+      provision_user_settings_for_oauth: {
+        Args: { p_user_id: string }
+        Returns: undefined
+      }
       realtime_publication_tables: {
         Args: never
         Returns: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260508000001_is_settlement_collaborator.sql
+++ b/supabase/migrations/20260508000001_is_settlement_collaborator.sql
@@ -1,0 +1,38 @@
+--------------------------------------------------------------------------------
+-- Helper: is_settlement_collaborator(uuid)
+--
+-- SECURITY DEFINER predicate that returns true when `auth.uid()` is listed as
+-- a collaborator on the given settlement via `settlement_shared_user`.
+--
+-- Required to break circular RLS evaluation in collaborator policies:
+-- a `settlement_*` junction table policy that calls
+-- `exists (select 1 from settlement_shared_user ...)` would re-enter the
+-- shared-user table's RLS, which itself references the parent table — the
+-- planner detects this as infinite recursion. By bypassing RLS via SECURITY
+-- DEFINER (and a locked-down search_path), the helper short-circuits the
+-- cycle without leaking access.
+--
+-- Mirrors the structure of `is_settlement_owner` introduced in
+-- `20260324185335_fix_shared_user_rls_recursion.sql`.
+--
+-- Reference: `local/sharing-architecture.md` §5.2 Decision 3 / §10 Phase 1.1.
+--------------------------------------------------------------------------------
+create or replace function is_settlement_collaborator(target_settlement uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select exists (
+    select 1
+    from public.settlement_shared_user
+    where settlement_id = target_settlement
+      and shared_user_id = auth.uid()
+  );
+$$;
+revoke all on function public.is_settlement_collaborator(uuid)
+from public;
+-- Supabase's `ALTER DEFAULT PRIVILEGES` on the `public` schema grants
+-- EXECUTE to `anon`, `authenticated`, and `service_role` independently of
+-- PUBLIC, so the revoke above is not sufficient to deny anonymous callers.
+-- Drop anon explicitly to enforce the "authenticated only" contract from
+-- Epic E1 — Phase 1.1.
+revoke execute on function public.is_settlement_collaborator(uuid)
+from anon;
+grant execute on function public.is_settlement_collaborator(uuid) to authenticated;


### PR DESCRIPTION
## Summary

Implements **E1.1** — adds the `is_settlement_collaborator(uuid)` `SECURITY DEFINER` predicate that the upcoming collaborator-aware RLS policies (E1.2.a–d, E1.3) will consume to grant CRUD access to settlement collaborators without re-entering circular RLS evaluation.

This is the structural twin of `is_settlement_owner`, introduced in `20260324185335_fix_shared_user_rls_recursion.sql`.

Closes #143.

## Changes

- **DB**: New migration [`20260508000001_is_settlement_collaborator.sql`](supabase/migrations/20260508000001_is_settlement_collaborator.sql) creates `public.is_settlement_collaborator(uuid)`. The function is `language sql stable security definer`, locks `search_path = ''`, and references `public.settlement_shared_user` fully-qualified. Returns `true` only when the row `(target_settlement, auth.uid())` exists.
- **Privileges**: `revoke all from public` + explicit `revoke execute from anon` + `grant execute to authenticated`. The explicit anon revoke is required because Supabase's `ALTER DEFAULT PRIVILEGES` on schema `public` grants EXECUTE to `anon`, `authenticated`, and `service_role` independently of `PUBLIC` — without it the helper would still be reachable by the anon role.
- **Types**: `lib/database.types.ts` regenerated; the new function appears in the typed RPC surface.
- **Tests**: New integration test [`__tests__/integration/rls/is-settlement-collaborator.test.ts`](__tests__/integration/rls/is-settlement-collaborator.test.ts) covers the five behaviors required by the acceptance criteria:
  - Collaborator → `true`
  - Owner → `false` (owners are not modeled as collaborators; policies should disjoin both helpers)
  - Unrelated authenticated user → `false`
  - Non-existent settlement → `false`
  - Anonymous caller → permission denied

## Versioning

`0.50.0` → `0.51.0` (`package.json` + `package-lock.json`).

## Verification

- `npm run db:reset` applied the migration cleanly.
- `npm run db:generate` regenerated types matching the new function signature.
- `npm test` → 117 files / 2087 unit tests passing.
- `npm run integration-test -- __tests__/integration/rls/is-settlement-collaborator.test.ts` → 5 / 5 passing.
- `\df+` confirms only `authenticated`, `service_role`, `postgres` hold EXECUTE — not `anon`, not `PUBLIC`.

## Acceptance Criteria

- [x] Migration applies cleanly on `supabase db reset`.
- [x] Function exists in `public` schema and is callable by `authenticated` role only.

## Out of Scope

- Policies that consume this helper — covered under #135 (E1.2.a) and the rest of E1.2.* / E1.3.

## Dependencies

- **Blocks**: #135 (E1.2.a), #138 (E1.2.b), #145 (E1.2.c), #140 (E1.2.d), #133 (E1.3).
- **Blocked by**: none.