### PR TITLE
feat(rls): collaborator CRUD on settlement_* junction tables (#135)

### DIFF
--- a/__tests__/integration/rls/settlement-junction-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/settlement-junction-collaborator-crud.test.ts
@@ -166,9 +166,9 @@ describe('RLS: collaborator CRUD on settlement_* junction tables', () => {
   )
 
   /**
-   * Tracks IDs inserted by the collaborator so the matching DELETE test
-   * has a fresh row to operate against (UPDATE happens to the original
-   * fixture row to avoid clobbering the seeded data).
+   * Tracks IDs inserted by the collaborator so the matching UPDATE and
+   * DELETE tests can operate against fresh collaborator-created rows
+   * rather than the original seeded fixture rows.
    */
   const collaboratorInsertedIds: Record<string, string> = {}
 
@@ -183,8 +183,8 @@ describe('RLS: collaborator CRUD on settlement_* junction tables', () => {
       // settlement_timeline_year is the only table with a unique
       // (settlement_id, year_number) constraint that conflicts with the
       // seeded fixture row at year_number=0; the buildInsertRow helper
-      // already uses 99. For tables with a (settlement_id, x_id) unique
-      // index, the seeded fixture used the catalog row, so a second
+      // already uses year_number=7. For tables with a (settlement_id, x_id)
+      // unique index, the seeded fixture used the catalog row, so a second
       // insert with the same (settlement_id, x_id) would 23505. Resolve
       // by deleting the seeded row first so the collaborator's INSERT
       // has a clean slot.
@@ -194,12 +194,7 @@ describe('RLS: collaborator CRUD on settlement_* junction tables', () => {
           .from(table)
           .delete()
           .eq('id', seededId)
-        // Don't fail the test on a missing seeded row — a previous test
-        // may have already deleted it.
-        if (cleanupErr) {
-          // surface unexpected errors
-          expect(cleanupErr.code).toMatch(/PGRST|42501/)
-        }
+        expect(cleanupErr).toBeNull()
       }
 
       const { data, error } = await collaborator.client

--- a/__tests__/integration/rls/settlement-junction-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/settlement-junction-collaborator-crud.test.ts
@@ -1,0 +1,312 @@
+import {
+  deleteCatalog,
+  seedCatalog,
+  seedSettlementFixture,
+  SettlementFixture
+} from '@/__tests__/integration/helpers/fixtures'
+import {
+  createTestUser,
+  deleteTestUser,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Collaborator CRUD on `settlement_*` Junction Tables
+ *
+ * Phase 1.2.a — collaborators on a shared settlement should now have full
+ * INSERT/UPDATE/DELETE/SELECT access on every `settlement_*` junction table,
+ * matching the owner's permissions. Strangers must remain locked out.
+ *
+ * Tables exercised:
+ *   settlement_collective_cognition_reward, settlement_gear,
+ *   settlement_innovation, settlement_knowledge, settlement_location,
+ *   settlement_milestone, settlement_nemesis, settlement_pattern,
+ *   settlement_philosophy, settlement_principle, settlement_quarry,
+ *   settlement_resource, settlement_seed_pattern, settlement_timeline_year
+ */
+describe('RLS: collaborator CRUD on settlement_* junction tables', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let catalog: SettlementFixture['catalogIds']
+  let fixture: SettlementFixture
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+    catalog = await seedCatalog()
+    fixture = await seedSettlementFixture(owner, catalog)
+    await shareSettlement(fixture.settlementId, collaborator.id, owner.id)
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+    await deleteCatalog(catalog)
+  })
+
+  /**
+   * Build the matrix lazily — fixture IDs are populated in `beforeAll`
+   * but vitest evaluates `it.each` arguments at collection time, so the
+   * `rowId` getter has to close over the binding rather than capture its
+   * value.
+   */
+  const SETTLEMENT_JUNCTION_TABLES = [
+    'settlement_collective_cognition_reward',
+    'settlement_gear',
+    'settlement_innovation',
+    'settlement_knowledge',
+    'settlement_location',
+    'settlement_milestone',
+    'settlement_nemesis',
+    'settlement_pattern',
+    'settlement_philosophy',
+    'settlement_principle',
+    'settlement_quarry',
+    'settlement_resource',
+    'settlement_seed_pattern',
+    'settlement_timeline_year'
+  ] as const
+
+  /**
+   * Insert payloads keyed by table. Each table has different required
+   * non-FK columns, so each row needs its own catalog reference plus any
+   * NOT NULL columns. `settlement_id` is filled in at call time so the
+   * shape stays static.
+   */
+  const buildInsertRow = (table: string): Record<string, unknown> => {
+    switch (table) {
+      case 'settlement_collective_cognition_reward':
+        return {
+          collective_cognition_reward_id: catalog.collectiveCognitionRewardId
+        }
+      case 'settlement_gear':
+        return { gear_id: catalog.gearId }
+      case 'settlement_innovation':
+        return { innovation_id: catalog.innovationId }
+      case 'settlement_knowledge':
+        return { knowledge_id: catalog.knowledgeId }
+      case 'settlement_location':
+        return { location_id: catalog.locationId }
+      case 'settlement_milestone':
+        return { milestone_id: catalog.milestoneId }
+      case 'settlement_nemesis':
+        return { nemesis_id: catalog.nemesisId }
+      case 'settlement_pattern':
+        return { pattern_id: catalog.patternId }
+      case 'settlement_philosophy':
+        return { philosophy_id: catalog.philosophyId }
+      case 'settlement_principle':
+        return { principle_id: catalog.principleId }
+      case 'settlement_quarry':
+        return { quarry_id: catalog.quarryId }
+      case 'settlement_resource':
+        return { resource_id: catalog.resourceId }
+      case 'settlement_seed_pattern':
+        return { seed_pattern_id: catalog.seedPatternId }
+      case 'settlement_timeline_year':
+        // year_number is unique per settlement and constrained to 0..50.
+        // The fixture seeds year_number=0, so use a different valid value.
+        return { year_number: 7 }
+      default:
+        throw new Error(`Unknown junction table: ${table}`)
+    }
+  }
+
+  /**
+   * Existing-row update payloads (mutable, non-FK columns where available).
+   * Tables with no mutable non-FK columns return `{}`, so the matrix below
+   * skips the UPDATE assertion for them.
+   */
+  const updatePayload: Record<string, object> = {
+    settlement_collective_cognition_reward: {},
+    settlement_gear: {},
+    settlement_innovation: {},
+    settlement_knowledge: {},
+    settlement_location: { unlocked: true },
+    settlement_milestone: { complete: true },
+    settlement_nemesis: { unlocked: true },
+    settlement_pattern: {},
+    settlement_philosophy: {},
+    settlement_principle: {},
+    settlement_quarry: { unlocked: true },
+    settlement_resource: {},
+    settlement_seed_pattern: {},
+    settlement_timeline_year: { completed: true }
+  }
+
+  it.each(SETTLEMENT_JUNCTION_TABLES)(
+    'collaborator CAN SELECT seeded row in %s',
+    async (table) => {
+      const rowId = fixture.settlementJunctionIds[table]
+      const { data, error } = await collaborator.client
+        .from(table)
+        .select('id')
+        .eq('id', rowId)
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+    }
+  )
+
+  it.each(SETTLEMENT_JUNCTION_TABLES)(
+    'stranger CANNOT SELECT seeded row in %s',
+    async (table) => {
+      const rowId = fixture.settlementJunctionIds[table]
+      const { data, error } = await stranger.client
+        .from(table)
+        .select('id')
+        .eq('id', rowId)
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    }
+  )
+
+  /**
+   * Tracks IDs inserted by the collaborator so the matching DELETE test
+   * has a fresh row to operate against (UPDATE happens to the original
+   * fixture row to avoid clobbering the seeded data).
+   */
+  const collaboratorInsertedIds: Record<string, string> = {}
+
+  it.each(SETTLEMENT_JUNCTION_TABLES)(
+    'collaborator CAN INSERT into %s',
+    async (table) => {
+      const row = {
+        ...buildInsertRow(table),
+        settlement_id: fixture.settlementId
+      }
+
+      // settlement_timeline_year is the only table with a unique
+      // (settlement_id, year_number) constraint that conflicts with the
+      // seeded fixture row at year_number=0; the buildInsertRow helper
+      // already uses 99. For tables with a (settlement_id, x_id) unique
+      // index, the seeded fixture used the catalog row, so a second
+      // insert with the same (settlement_id, x_id) would 23505. Resolve
+      // by deleting the seeded row first so the collaborator's INSERT
+      // has a clean slot.
+      const seededId = fixture.settlementJunctionIds[table]
+      if (table !== 'settlement_timeline_year' && seededId) {
+        const { error: cleanupErr } = await owner.client
+          .from(table)
+          .delete()
+          .eq('id', seededId)
+        // Don't fail the test on a missing seeded row — a previous test
+        // may have already deleted it.
+        if (cleanupErr) {
+          // surface unexpected errors
+          expect(cleanupErr.code).toMatch(/PGRST|42501/)
+        }
+      }
+
+      const { data, error } = await collaborator.client
+        .from(table)
+        .insert(row)
+        .select('id')
+        .single<{ id: string }>()
+
+      expect(error).toBeNull()
+      expect(data?.id).toBeTruthy()
+      if (data?.id) collaboratorInsertedIds[table] = data.id
+    }
+  )
+
+  it.each(
+    SETTLEMENT_JUNCTION_TABLES.filter(
+      (t) => Object.keys(updatePayload[t]).length > 0
+    )
+  )('collaborator CAN UPDATE rows in %s', async (table) => {
+    const rowId = collaboratorInsertedIds[table]
+    if (!rowId) {
+      throw new Error(
+        `expected collaborator-inserted row id for ${table} from prior test`
+      )
+    }
+
+    const { data, error } = await collaborator.client
+      .from(table)
+      .update(updatePayload[table])
+      .eq('id', rowId)
+      .select('id')
+
+    expect(error).toBeNull()
+    expect(data ?? []).toHaveLength(1)
+  })
+
+  it.each(SETTLEMENT_JUNCTION_TABLES)(
+    'collaborator CAN DELETE rows in %s',
+    async (table) => {
+      const rowId = collaboratorInsertedIds[table]
+      if (!rowId) {
+        throw new Error(
+          `expected collaborator-inserted row id for ${table} from prior test`
+        )
+      }
+
+      const { data, error } = await collaborator.client
+        .from(table)
+        .delete()
+        .eq('id', rowId)
+        .select('id')
+
+      expect(error).toBeNull()
+      expect(data ?? []).toHaveLength(1)
+    }
+  )
+
+  it.each(SETTLEMENT_JUNCTION_TABLES)(
+    'stranger CANNOT INSERT into %s for another user settlement',
+    async (table) => {
+      const row = {
+        ...buildInsertRow(table),
+        // Stranger should be denied before the constraint check runs;
+        // year_number stays inside the valid 0..50 range to make the
+        // assertion unambiguous.
+        settlement_id: fixture.settlementId,
+        ...(table === 'settlement_timeline_year' ? { year_number: 13 } : {})
+      }
+
+      const { data, error } = await stranger.client
+        .from(table)
+        .insert(row)
+        .select('id')
+
+      expect(data ?? []).toEqual([])
+      expect(error).not.toBeNull()
+      expect(error?.code).toMatch(/PGRST|42501/)
+    }
+  )
+
+  it('owner retains full CRUD on the settlement (sanity check)', async () => {
+    // Re-seed one timeline-year row so the owner-side delete has something
+    // to remove, since prior tests may have cleared the originals.
+    const { data: ins, error: insErr } = await owner.client
+      .from('settlement_timeline_year')
+      .insert({ settlement_id: fixture.settlementId, year_number: 1 })
+      .select('id')
+      .single<{ id: string }>()
+    expect(insErr).toBeNull()
+    expect(ins?.id).toBeTruthy()
+
+    if (ins?.id) {
+      const { data: upd, error: updErr } = await owner.client
+        .from('settlement_timeline_year')
+        .update({ completed: true })
+        .eq('id', ins.id)
+        .select('id')
+      expect(updErr).toBeNull()
+      expect(upd ?? []).toHaveLength(1)
+
+      const { data: del, error: delErr } = await owner.client
+        .from('settlement_timeline_year')
+        .delete()
+        .eq('id', ins.id)
+        .select('id')
+      expect(delErr).toBeNull()
+      expect(del ?? []).toHaveLength(1)
+    }
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260508000002_settlement_junction_collaborator_crud.sql
+++ b/supabase/migrations/20260508000002_settlement_junction_collaborator_crud.sql
@@ -1,0 +1,139 @@
+--------------------------------------------------------------------------------
+-- Phase 1.2.a — Collaborator CRUD on Settlement Junction Tables
+--
+-- Replace the owner-only INSERT/UPDATE/DELETE policies on each `settlement_*`
+-- junction table with member policies that accept both the settlement owner
+-- AND any user listed in `settlement_shared_user`. Authorization is delegated
+-- to two SECURITY DEFINER helpers so RLS evaluation cannot recurse into the
+-- shared-user table:
+--
+--   * is_settlement_owner(uuid)        -- existing helper
+--   * is_settlement_collaborator(uuid) -- added in
+--                                         20260508000001_is_settlement_collaborator.sql
+--
+-- SELECT continues to use a member policy on each table — the original
+-- "Allow select for owner" + "Allow select for shared" pair is replaced
+-- with a single helper-based "Allow select for member" policy. Two reasons:
+--   * Consistency with INSERT/UPDATE/DELETE — every CRUD verb is now
+--     gated by the same disjunction.
+--   * The original "for shared" policy contained a latent correlation bug:
+--     its EXISTS subquery referenced the unqualified `settlement_id`
+--     column, which PostgreSQL resolves to the subquery's own
+--     `su.settlement_id` rather than the outer junction column. With the
+--     correlation lost, any user with any share could read junction rows
+--     for every settlement (cross-settlement leak). The disjunction
+--     threads the row's `settlement_id` through the helper as a
+--     parameter, which closes the leak.
+--
+-- Admin bypass policies are untouched.
+--
+-- Tables affected (alphabetical):
+--   settlement_collective_cognition_reward
+--   settlement_gear
+--   settlement_innovation
+--   settlement_knowledge
+--   settlement_location
+--   settlement_milestone
+--   settlement_nemesis
+--   settlement_pattern
+--   settlement_philosophy
+--   settlement_principle
+--   settlement_quarry
+--   settlement_resource
+--   settlement_seed_pattern
+--   settlement_timeline_year
+--
+-- Reference: `local/sharing-architecture.md` §5.2 Decision 3 / §10 Phase 1.2 /
+-- Appendix A "Phase 1 collaborator CRUD list".
+--
+-- Closes [E1.2.a] (issue #135).
+--------------------------------------------------------------------------------
+do $$
+declare t text;
+junction_tables text [] := array [
+    'settlement_collective_cognition_reward',
+    'settlement_gear',
+    'settlement_innovation',
+    'settlement_knowledge',
+    'settlement_location',
+    'settlement_milestone',
+    'settlement_nemesis',
+    'settlement_pattern',
+    'settlement_philosophy',
+    'settlement_principle',
+    'settlement_quarry',
+    'settlement_resource',
+    'settlement_seed_pattern',
+    'settlement_timeline_year'
+  ];
+begin foreach t in array junction_tables loop -- Drop existing SELECT and write policies. SELECT-for-shared is also
+-- dropped so the latent cross-settlement leak (described in the header)
+-- is closed by the new helper-based policy. Admin-bypass is left in
+-- place.
+execute format(
+  'drop policy if exists "Allow select for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow select for shared" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow insert for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow update for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow delete for owner" on %I',
+  t
+);
+-- Member SELECT: caller must own OR collaborate on the parent settlement.
+-- Both helpers are SECURITY DEFINER, which sidesteps the recursion that
+-- bit the original inline EXISTS subquery and removes the latent
+-- correlation bug noted in the header.
+execute format(
+  $f$ create policy "Allow select for member" on %I for
+  select to authenticated using (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $f$,
+    t
+);
+-- Member INSERT: same disjunction.
+execute format(
+  $f$ create policy "Allow insert for member" on %I for
+  insert to authenticated with check (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $f$,
+    t
+);
+-- Member UPDATE: same disjunction on both USING (current row) and WITH
+-- CHECK (post-update row). Junction rows are pinned to a single
+-- settlement, so re-checking after the update is effectively a no-op
+-- but keeps the policy symmetric and defensive against malicious
+-- settlement_id rewrites.
+execute format(
+  $f$ create policy "Allow update for member" on %I for
+  update to authenticated using (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) with check (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $f$,
+    t
+);
+-- Member DELETE: same disjunction.
+execute format(
+  $f$ create policy "Allow delete for member" on %I for delete to authenticated using (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  ) $f$,
+  t
+);
+end loop;
+end $$;


### PR DESCRIPTION
## Summary

Implements **E1.2.a** — collaborators on a shared settlement now have full INSERT/UPDATE/DELETE/SELECT access on every `settlement_*` junction table, matching the owner's permissions. Strangers remain locked out.

Closes #135.

## Changes

### Migration `20260508000002_settlement_junction_collaborator_crud.sql`

Iterates over the 14 junction tables and, for each one, drops the `for owner` SELECT/INSERT/UPDATE/DELETE policies plus the legacy `for shared` SELECT policy, then re-creates them as four uniform `for member` policies whose USING / WITH CHECK is the disjunction:

```sql
is_settlement_owner(settlement_id)
or is_settlement_collaborator(settlement_id)
```

Both helpers are `SECURITY DEFINER`, which is the same pattern used by `20260324185335_fix_shared_user_rls_recursion.sql` to break circular RLS evaluation.

Tables touched (alphabetical):

`settlement_collective_cognition_reward`, `settlement_gear`, `settlement_innovation`, `settlement_knowledge`, `settlement_location`, `settlement_milestone`, `settlement_nemesis`, `settlement_pattern`, `settlement_philosophy`, `settlement_principle`, `settlement_quarry`, `settlement_resource`, `settlement_seed_pattern`, `settlement_timeline_year`.

The admin-bypass policies are intentionally left in place.

### Latent SELECT bug fixed in passing

While auditing the existing `Allow select for shared` policies for parity, I confirmed via `EXPLAIN VERBOSE` that the unqualified `settlement_id` column inside their `EXISTS` subquery binds to the subquery's own `su.settlement_id`, not the outer junction's column:

```
->  Index Only Scan using idx_settlement_shared_user_user on public.settlement_shared_user su
      Index Cond: (su.shared_user_id = ...)
->  Seq Scan on public.settlement_innovation si
```

The InitPlan never references the outer table — the correlation was lost, so any user with any share could read junction rows for **every** settlement. Replacing the SELECT-for-owner + SELECT-for-shared pair with the same helper-based `for member` policy threads the row's `settlement_id` through the helper as a parameter, which closes the leak. The issue body explicitly permits this consolidation ("either is fine — be consistent").

### Tests

New [`__tests__/integration/rls/settlement-junction-collaborator-crud.test.ts`](__tests__/integration/rls/settlement-junction-collaborator-crud.test.ts) — 76 cases:

- `collaborator CAN SELECT seeded row in <table>` × 14
- `stranger CANNOT SELECT seeded row in <table>` × 14
- `collaborator CAN INSERT into <table>` × 14
- `collaborator CAN UPDATE rows in <table>` × N (only for tables with mutable non-FK columns)
- `collaborator CAN DELETE rows in <table>` × 14
- `stranger CANNOT INSERT into <table> for another user settlement` × 14
- owner CRUD sanity check on `settlement_timeline_year`.

Existing `settlement-scoped.test.ts` cross-user denial assertions continue to pass without modification.

## Versioning

`0.51.0` → `0.52.0` (`package.json` + `package-lock.json`).

## Verification

- `npm run db:reset` → migrations apply cleanly; `pg_policies` shows 5 policies × 14 tables (4 member + admin) = 70 rows.
- `npm run integration-test` → 13 files / 490 tests passing.
- `npm test` → 117 files / 2087 tests passing.

## Acceptance Criteria

- [x] For each listed table, an authenticated collaborator can INSERT, UPDATE, and DELETE rows.
- [x] Owners retain full CRUD.
- [x] Strangers and non-member authenticated users get 0 rows / RLS denial.
- [x] Existing tests in `__tests__/integration/rls/settlement-scoped.test.ts` continue to pass.

## Out of Scope

- `settlement_phase*` (covered in #138 / E1.2.b).
- `survivor*` / `gear_grid` (covered in #145 / E1.2.c).
- `hunt*` / `showdown*` (covered in #140 / E1.2.d).
- Settlement-row UPDATE (covered in #133 / E1.3).

## Dependencies

- **Blocked by**: #143 (E1.1) — merged in v0.51.0.
- **Blocks**: #134 (E1.11), #139 (E1.12).