### PR TITLE
feat(rls): collaborator CRUD on settlement_phase tables (#138)

### DIFF
--- a/__tests__/integration/rls/settlement-phase-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/settlement-phase-collaborator-crud.test.ts
@@ -1,0 +1,259 @@
+import {
+  deleteCatalog,
+  seedCatalog,
+  seedSettlementFixture,
+  SettlementFixture
+} from '@/__tests__/integration/helpers/fixtures'
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Collaborator CRUD on Settlement Phase Tables
+ *
+ * Phase 1.2.b — collaborators on a shared settlement should now have full
+ * INSERT/UPDATE/DELETE/SELECT access on `settlement_phase` and
+ * `settlement_phase_returning_survivor`, matching the owner's permissions.
+ * Strangers must remain locked out.
+ *
+ * Owner CRUD on `settlement_phase` is already covered by the broad fixture
+ * setup in `seedSettlementFixture`; this file focuses on the collaborator
+ * path and the stranger denial path. The companion file
+ * `settlement-scoped.test.ts` continues to assert the cross-user denial
+ * matrix for `settlement_phase` / `settlement_phase_returning_survivor` to
+ * make sure non-members still see zero rows.
+ */
+describe('RLS: collaborator CRUD on settlement_phase + returning_survivor', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let catalog: SettlementFixture['catalogIds']
+  let fixture: SettlementFixture
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+    catalog = await seedCatalog()
+    fixture = await seedSettlementFixture(owner, catalog)
+    await shareSettlement(fixture.settlementId, collaborator.id, owner.id)
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+    await deleteCatalog(catalog)
+  })
+
+  describe('settlement_phase', () => {
+    it('collaborator CAN SELECT the seeded phase row', async () => {
+      const { data, error } = await collaborator.client
+        .from('settlement_phase')
+        .select('id, settlement_id, endeavors, step')
+        .eq('id', fixture.settlementPhaseId)
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+      expect(data?.[0]?.settlement_id).toBe(fixture.settlementId)
+    })
+
+    it('stranger CANNOT SELECT the seeded phase row', async () => {
+      const { data, error } = await stranger.client
+        .from('settlement_phase')
+        .select('id')
+        .eq('id', fixture.settlementPhaseId)
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    })
+
+    it('collaborator CAN UPDATE the phase row (advance step + endeavors)', async () => {
+      const { data, error } = await collaborator.client
+        .from('settlement_phase')
+        .update({ endeavors: 3, step: 'SURVIVORS_RETURN' })
+        .eq('id', fixture.settlementPhaseId)
+        .select('id, endeavors, step')
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+      expect(data?.[0]?.endeavors).toBe(3)
+      expect(data?.[0]?.step).toBe('SURVIVORS_RETURN')
+    })
+
+    it('stranger CANNOT UPDATE the phase row', async () => {
+      const { data, error } = await stranger.client
+        .from('settlement_phase')
+        .update({ endeavors: 99 })
+        .eq('id', fixture.settlementPhaseId)
+        .select('id')
+      expect(data ?? []).toEqual([])
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
+    })
+
+    // INSERT/DELETE on `settlement_phase` is exercised below by the cycle
+    // test — the table has a UNIQUE(settlement_id), so the seeded row has
+    // to be removed before a fresh insert can succeed.
+    it('collaborator CAN DELETE + re-INSERT the phase row', async () => {
+      // DELETE
+      const { data: deleted, error: deleteError } = await collaborator.client
+        .from('settlement_phase')
+        .delete()
+        .eq('id', fixture.settlementPhaseId)
+        .select('id')
+      expect(deleteError).toBeNull()
+      expect(deleted).toHaveLength(1)
+
+      // INSERT — collaborator creates a fresh phase row pointing at the
+      // shared settlement.
+      const { data: inserted, error: insertError } = await collaborator.client
+        .from('settlement_phase')
+        .insert({ settlement_id: fixture.settlementId, endeavors: 1 })
+        .select('id, settlement_id, endeavors')
+        .single()
+      expect(insertError).toBeNull()
+      expect(inserted?.settlement_id).toBe(fixture.settlementId)
+      expect(inserted?.endeavors).toBe(1)
+
+      // Restore the fixture invariant for the rest of the suite — the
+      // returning-survivor section below depends on the join row, but we
+      // just deleted the parent phase, so the cascade dropped the join.
+      // Re-link the join row through the admin client.
+      if (inserted?.id) {
+        const { error: relinkError } = await admin
+          .from('settlement_phase_returning_survivor')
+          .insert({
+            settlement_id: fixture.settlementId,
+            settlement_phase_id: inserted.id,
+            survivor_id: fixture.survivorId
+          })
+        expect(relinkError).toBeNull()
+        // Update the local fixture so subsequent assertions reference the
+        // re-inserted phase row.
+        fixture.settlementPhaseId = inserted.id
+      }
+    })
+
+    it('stranger CANNOT INSERT a phase row into another user settlement', async () => {
+      // Phase is unique per settlement, so this needs a separate fixture
+      // settlement that the stranger does not own and is not shared with.
+      const { data: targetSettlement, error: setupError } = await admin
+        .from('settlement')
+        .insert({ user_id: owner.id, settlement_name: 'Lone Lantern' })
+        .select('id')
+        .single()
+      expect(setupError).toBeNull()
+
+      try {
+        const { data, error } = await stranger.client
+          .from('settlement_phase')
+          .insert({
+            settlement_id: targetSettlement!.id,
+            endeavors: 0
+          })
+          .select('id')
+        expect(data ?? []).toEqual([])
+        if (error) expect(error.code).toMatch(/PGRST|42501/)
+      } finally {
+        await admin.from('settlement').delete().eq('id', targetSettlement!.id)
+      }
+    })
+  })
+
+  describe('settlement_phase_returning_survivor', () => {
+    it('collaborator CAN SELECT the seeded join row', async () => {
+      const { data, error } = await collaborator.client
+        .from('settlement_phase_returning_survivor')
+        .select('settlement_phase_id, survivor_id')
+        .eq('settlement_phase_id', fixture.settlementPhaseId)
+        .eq('survivor_id', fixture.survivorId)
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+    })
+
+    it('stranger CANNOT SELECT the seeded join row', async () => {
+      const { data, error } = await stranger.client
+        .from('settlement_phase_returning_survivor')
+        .select('settlement_phase_id')
+        .eq('settlement_phase_id', fixture.settlementPhaseId)
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    })
+
+    it('collaborator CAN DELETE + re-INSERT the join row', async () => {
+      // DELETE the existing join row.
+      const { data: deleted, error: deleteError } = await collaborator.client
+        .from('settlement_phase_returning_survivor')
+        .delete()
+        .eq('settlement_phase_id', fixture.settlementPhaseId)
+        .eq('survivor_id', fixture.survivorId)
+        .select('settlement_phase_id')
+      expect(deleteError).toBeNull()
+      expect(deleted).toHaveLength(1)
+
+      // Re-INSERT — collaborator adds the survivor back to the returning
+      // list.
+      const { data: inserted, error: insertError } = await collaborator.client
+        .from('settlement_phase_returning_survivor')
+        .insert({
+          settlement_id: fixture.settlementId,
+          settlement_phase_id: fixture.settlementPhaseId,
+          survivor_id: fixture.survivorId
+        })
+        .select('settlement_phase_id, survivor_id')
+        .single()
+      expect(insertError).toBeNull()
+      expect(inserted?.settlement_phase_id).toBe(fixture.settlementPhaseId)
+      expect(inserted?.survivor_id).toBe(fixture.survivorId)
+    })
+
+    it('collaborator CAN UPDATE the join row (no-op payload still authorized)', async () => {
+      // Join row has no mutable non-FK columns, but UPDATE is still
+      // gated by the policy. Update a column to its current value to
+      // exercise the policy without changing schema state.
+      const { data, error } = await collaborator.client
+        .from('settlement_phase_returning_survivor')
+        .update({ survivor_id: fixture.survivorId })
+        .eq('settlement_phase_id', fixture.settlementPhaseId)
+        .eq('survivor_id', fixture.survivorId)
+        .select('settlement_phase_id, survivor_id')
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+    })
+
+    it('stranger CANNOT INSERT a join row into another user settlement', async () => {
+      const { data, error } = await stranger.client
+        .from('settlement_phase_returning_survivor')
+        .insert({
+          settlement_id: fixture.settlementId,
+          settlement_phase_id: fixture.settlementPhaseId,
+          survivor_id: fixture.survivorId
+        })
+        .select('settlement_phase_id')
+      expect(data ?? []).toEqual([])
+      // Composite-PK unique violation (23505) is also acceptable since the
+      // join row already exists; either way the stranger learned nothing.
+      if (error) expect(error.code).toMatch(/PGRST|42501|23505/)
+    })
+
+    it('stranger CANNOT DELETE the seeded join row', async () => {
+      const { data } = await stranger.client
+        .from('settlement_phase_returning_survivor')
+        .delete()
+        .eq('settlement_phase_id', fixture.settlementPhaseId)
+        .eq('survivor_id', fixture.survivorId)
+        .select('settlement_phase_id')
+      expect(data ?? []).toEqual([])
+
+      // Confirm the row still exists by reading as the owner.
+      const { data: check } = await owner.client
+        .from('settlement_phase_returning_survivor')
+        .select('settlement_phase_id')
+        .eq('settlement_phase_id', fixture.settlementPhaseId)
+        .eq('survivor_id', fixture.survivorId)
+      expect(check).toHaveLength(1)
+    })
+  })
+})

--- a/__tests__/integration/rls/settlement-phase-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/settlement-phase-collaborator-crud.test.ts
@@ -34,6 +34,17 @@ describe('RLS: collaborator CRUD on settlement_phase + returning_survivor', () =
   let stranger: TestUser
   let catalog: SettlementFixture['catalogIds']
   let fixture: SettlementFixture
+  /** A second survivor in the shared settlement, used by the stranger denial
+   * test to insert a row whose composite PK is not already taken (so the
+   * test cannot pass via a 23505 unique violation if RLS were misconfigured
+   * to allow the INSERT). */
+  let extraSurvivorId: string
+  /** A separate settlement owned by `stranger`, used to exercise the
+   * cross-settlement consistency predicate added in 20260508000003: a
+   * collaborator should not be able to write a join row whose `survivor_id`
+   * lives in a different settlement than the join row's `settlement_id`. */
+  let strangerSettlementId: string
+  let strangerSurvivorId: string
 
   beforeAll(async () => {
     owner = await createTestUser()
@@ -42,9 +53,62 @@ describe('RLS: collaborator CRUD on settlement_phase + returning_survivor', () =
     catalog = await seedCatalog()
     fixture = await seedSettlementFixture(owner, catalog)
     await shareSettlement(fixture.settlementId, collaborator.id, owner.id)
+
+    // Extra survivor in the *shared* settlement — same settlement_id as
+    // the seeded join row, but a distinct survivor_id so a stranger INSERT
+    // attempt does not collide with the existing composite PK.
+    const { data: extraSurvivor, error: extraSurvivorError } = await admin
+      .from('survivor')
+      .insert({
+        settlement_id: fixture.settlementId,
+        gender: 'MALE',
+        survivor_name: 'RLS Phase Extra Survivor'
+      })
+      .select('id')
+      .single<{ id: string }>()
+    if (extraSurvivorError || !extraSurvivor)
+      throw new Error(
+        `seed extraSurvivor: ${extraSurvivorError?.message ?? 'unknown'}`
+      )
+    extraSurvivorId = extraSurvivor.id
+
+    // Separate settlement + survivor owned by `stranger`. Used to verify
+    // that a collaborator on `fixture.settlementId` cannot insert a join
+    // row pointing at a survivor in a settlement they have no claim on.
+    const { data: strangerSettlement, error: strangerSettlementError } =
+      await admin
+        .from('settlement')
+        .insert({
+          user_id: stranger.id,
+          settlement_name: 'Lone Lantern'
+        })
+        .select('id')
+        .single<{ id: string }>()
+    if (strangerSettlementError || !strangerSettlement)
+      throw new Error(
+        `seed strangerSettlement: ${strangerSettlementError?.message ?? 'unknown'}`
+      )
+    strangerSettlementId = strangerSettlement.id
+    const { data: strangerSurvivor, error: strangerSurvivorError } = await admin
+      .from('survivor')
+      .insert({
+        settlement_id: strangerSettlementId,
+        gender: 'FEMALE',
+        survivor_name: 'RLS Phase Stranger Survivor'
+      })
+      .select('id')
+      .single<{ id: string }>()
+    if (strangerSurvivorError || !strangerSurvivor)
+      throw new Error(
+        `seed strangerSurvivor: ${strangerSurvivorError?.message ?? 'unknown'}`
+      )
+    strangerSurvivorId = strangerSurvivor.id
   })
 
   afterAll(async () => {
+    // Cascades through survivor + settlement_phase + join rows.
+    if (strangerSettlementId)
+      await admin.from('settlement').delete().eq('id', strangerSettlementId)
     await deleteTestUser(owner.id)
     await deleteTestUser(collaborator.id)
     await deleteTestUser(stranger.id)
@@ -224,18 +288,48 @@ describe('RLS: collaborator CRUD on settlement_phase + returning_survivor', () =
     })
 
     it('stranger CANNOT INSERT a join row into another user settlement', async () => {
+      // Use the fresh `extraSurvivorId` so the composite PK
+      // (settlement_phase_id, survivor_id) is not already taken — this
+      // ensures the failure must come from RLS, not from a 23505 unique
+      // violation that would mask a misconfigured policy.
       const { data, error } = await stranger.client
         .from('settlement_phase_returning_survivor')
         .insert({
           settlement_id: fixture.settlementId,
           settlement_phase_id: fixture.settlementPhaseId,
-          survivor_id: fixture.survivorId
+          survivor_id: extraSurvivorId
         })
         .select('settlement_phase_id')
       expect(data ?? []).toEqual([])
-      // Composite-PK unique violation (23505) is also acceptable since the
-      // join row already exists; either way the stranger learned nothing.
-      if (error) expect(error.code).toMatch(/PGRST|42501|23505/)
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
+
+      // Confirm via the owner that no row was actually written.
+      const { data: check } = await owner.client
+        .from('settlement_phase_returning_survivor')
+        .select('settlement_phase_id')
+        .eq('settlement_phase_id', fixture.settlementPhaseId)
+        .eq('survivor_id', extraSurvivorId)
+      expect(check ?? []).toEqual([])
+    })
+
+    it('collaborator CANNOT INSERT a join row referencing a survivor in another settlement', async () => {
+      // Cross-settlement consistency check (added in 20260508000003): the
+      // collaborator passes the basic membership predicate on
+      // `settlement_id = fixture.settlementId`, but the WITH CHECK clause
+      // also requires the referenced survivor to live in that same
+      // settlement. `strangerSurvivorId` belongs to a different
+      // settlement, so the EXISTS subquery returns empty and the row is
+      // rejected.
+      const { data, error } = await collaborator.client
+        .from('settlement_phase_returning_survivor')
+        .insert({
+          settlement_id: fixture.settlementId,
+          settlement_phase_id: fixture.settlementPhaseId,
+          survivor_id: strangerSurvivorId
+        })
+        .select('settlement_phase_id')
+      expect(data ?? []).toEqual([])
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
     })
 
     it('stranger CANNOT DELETE the seeded join row', async () => {

--- a/components/survivor/create-survivor-form.tsx
+++ b/components/survivor/create-survivor-form.tsx
@@ -181,8 +181,8 @@ export function CreateSurvivorForm({
         huntXPRankUp:
           selectedSettlement.survivor_type !==
           DatabaseSurvivorType[SurvivorType.ARC]
-            ? [2, 6, 10, 15]
-            : [2],
+            ? [1, 5, 9, 14]
+            : [1],
         understanding: bornWithUnderstanding ? 1 : 0
       })
     }

--- a/components/survivor/create-survivor-form.tsx
+++ b/components/survivor/create-survivor-form.tsx
@@ -141,8 +141,8 @@ export function CreateSurvivorForm({
       huntXPRankUp:
         selectedSettlement?.survivor_type !==
         DatabaseSurvivorType[SurvivorType.ARC]
-          ? [2, 6, 10, 15] // Core
-          : [2], // Arc
+          ? [1, 5, 9, 14] // Core
+          : [1], // Arc
       understanding: bornWithUnderstanding ? 1 : 0
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260508000003_settlement_phase_collaborator_crud.sql
+++ b/supabase/migrations/20260508000003_settlement_phase_collaborator_crud.sql
@@ -28,6 +28,23 @@
 --     was already correctly qualified (see 20260324185312), but it is
 --     consolidated here for symmetry with the rest of the suite.
 --
+-- Cross-settlement consistency on the join table:
+--   `settlement_phase_returning_survivor` carries three independent
+--   foreign keys (`settlement_id`, `settlement_phase_id`, `survivor_id`)
+--   with no schema-level constraint forcing them to point at the same
+--   settlement. Without an extra RLS predicate, a member of settlement
+--   A could write `{settlement_id: A, settlement_phase_id: <A's phase>,
+--   survivor_id: <a survivor from settlement B>}`, creating a join row
+--   whose three references straddle settlements. The INSERT and
+--   UPDATE WITH CHECK predicates below add EXISTS subqueries that
+--   require the referenced phase row and the referenced survivor row
+--   to live in the same settlement as the join row's `settlement_id`.
+--   Both subqueries run under the caller's RLS, which is sufficient
+--   here because the caller already has SELECT access to phase /
+--   survivor rows of settlements they own or collaborate on (see
+--   `Allow select for member` on `settlement_phase` and the existing
+--   `Allow select for shared` on `survivor`).
+--
 -- Admin bypass policies are untouched.
 --
 -- Reference:
@@ -41,17 +58,17 @@
 --
 -- Closes [E1.2.b] (issue #138).
 --------------------------------------------------------------------------------
+--
+-- Drop the existing owner-only / shared SELECT policies on both tables.
+-- Admin-bypass policies are intentionally left in place.
+--
 do $$
 declare t text;
 phase_tables text [] := array [
     'settlement_phase',
     'settlement_phase_returning_survivor'
   ];
-begin foreach t in array phase_tables loop -- Drop existing SELECT and write policies. SELECT-for-shared is also
--- dropped so the latent cross-settlement leak (described in the
--- header) is closed by the new helper-based policy on
--- `settlement_phase`. Admin-bypass is left in place.
-execute format(
+begin foreach t in array phase_tables loop execute format(
   'drop policy if exists "Allow select for owner" on %I',
   t
 );
@@ -71,50 +88,90 @@ execute format(
   'drop policy if exists "Allow delete for owner" on %I',
   t
 );
--- Member SELECT: caller must own OR collaborate on the parent
--- settlement. Both helpers are SECURITY DEFINER, which sidesteps
--- the recursion that bit the original inline EXISTS subquery and
--- removes the latent correlation bug noted in the header.
-execute format(
-  $f$create policy "Allow select for member" on %I for
-  select to authenticated using (
-      is_settlement_owner(settlement_id)
-      or is_settlement_collaborator(settlement_id)
-    ) $f$,
-    t
-);
--- Member INSERT: same disjunction.
-execute format(
-  $f$create policy "Allow insert for member" on %I for
-  insert to authenticated with check (
-      is_settlement_owner(settlement_id)
-      or is_settlement_collaborator(settlement_id)
-    ) $f$,
-    t
-);
--- Member UPDATE: same disjunction on both USING (current row) and
--- WITH CHECK (post-update row). Phase rows are pinned to a single
--- settlement, so re-checking after the update is effectively a
--- no-op but keeps the policy symmetric and defensive against
--- malicious `settlement_id` rewrites.
-execute format(
-  $f$create policy "Allow update for member" on %I for
-  update to authenticated using (
-      is_settlement_owner(settlement_id)
-      or is_settlement_collaborator(settlement_id)
-    ) with check (
-      is_settlement_owner(settlement_id)
-      or is_settlement_collaborator(settlement_id)
-    ) $f$,
-    t
-);
--- Member DELETE: same disjunction.
-execute format(
-  $f$create policy "Allow delete for member" on %I for delete to authenticated using (
-    is_settlement_owner(settlement_id)
-    or is_settlement_collaborator(settlement_id)
-  ) $f$,
-  t
-);
 end loop;
 end $$;
+--
+-- settlement_phase — standard member policies. The phase row is pinned to
+-- a single settlement, so the helper-based disjunction is sufficient.
+--
+create policy "Allow select for member" on settlement_phase
+for
+select to authenticated using (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  );
+create policy "Allow insert for member" on settlement_phase for
+insert to authenticated with check (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  );
+create policy "Allow update for member" on settlement_phase for
+update to authenticated using (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  ) with check (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  );
+create policy "Allow delete for member" on settlement_phase for delete to authenticated using (
+  is_settlement_owner(settlement_id)
+  or is_settlement_collaborator(settlement_id)
+);
+--
+-- settlement_phase_returning_survivor — member policies plus a
+-- cross-settlement consistency check on writes. The join table carries
+-- three independent foreign keys; the EXISTS subqueries below ensure
+-- the referenced phase and survivor live in the same settlement as the
+-- join row. SELECT and DELETE only require the basic membership check.
+--
+create policy "Allow select for member" on settlement_phase_returning_survivor
+for
+select to authenticated using (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  );
+create policy "Allow insert for member" on settlement_phase_returning_survivor for
+insert to authenticated with check (
+    (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    )
+    and exists (
+      select 1
+      from settlement_phase sp
+      where sp.id = settlement_phase_returning_survivor.settlement_phase_id
+        and sp.settlement_id = settlement_phase_returning_survivor.settlement_id
+    )
+    and exists (
+      select 1
+      from survivor sv
+      where sv.id = settlement_phase_returning_survivor.survivor_id
+        and sv.settlement_id = settlement_phase_returning_survivor.settlement_id
+    )
+  );
+create policy "Allow update for member" on settlement_phase_returning_survivor for
+update to authenticated using (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  ) with check (
+    (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    )
+    and exists (
+      select 1
+      from settlement_phase sp
+      where sp.id = settlement_phase_returning_survivor.settlement_phase_id
+        and sp.settlement_id = settlement_phase_returning_survivor.settlement_id
+    )
+    and exists (
+      select 1
+      from survivor sv
+      where sv.id = settlement_phase_returning_survivor.survivor_id
+        and sv.settlement_id = settlement_phase_returning_survivor.settlement_id
+    )
+  );
+create policy "Allow delete for member" on settlement_phase_returning_survivor for delete to authenticated using (
+  is_settlement_owner(settlement_id)
+  or is_settlement_collaborator(settlement_id)
+);

--- a/supabase/migrations/20260508000003_settlement_phase_collaborator_crud.sql
+++ b/supabase/migrations/20260508000003_settlement_phase_collaborator_crud.sql
@@ -1,0 +1,120 @@
+--------------------------------------------------------------------------------
+-- Phase 1.2.b — Collaborator CRUD on Settlement Phase Tables
+--
+-- Replace the owner-only INSERT/UPDATE/DELETE policies on `settlement_phase`
+-- and `settlement_phase_returning_survivor` with member policies that accept
+-- both the settlement owner AND any user listed in `settlement_shared_user`.
+-- Authorization is delegated to two SECURITY DEFINER helpers so RLS
+-- evaluation cannot recurse into the shared-user table:
+--
+--   * is_settlement_owner(uuid)        -- existing helper
+--   * is_settlement_collaborator(uuid) -- added in
+--                                         20260508000001_is_settlement_collaborator.sql
+--
+-- SELECT continues to use a member policy on each table — the original
+-- "Allow select for owner" + "Allow select for shared" pair is replaced
+-- with a single helper-based "Allow select for member" policy. Two reasons:
+--   * Consistency with INSERT/UPDATE/DELETE — every CRUD verb is now
+--     gated by the same disjunction.
+--   * `settlement_phase`'s "Allow select for shared" policy contained the
+--     same latent correlation bug fixed for the junction tables in
+--     20260508000002: its EXISTS subquery referenced an unqualified
+--     `settlement_id` that PostgreSQL resolved to the subquery's own
+--     `su.settlement_id` rather than the outer phase row's column,
+--     leaking phase rows for every settlement to any user with any
+--     share. The helper-based policy threads the row's `settlement_id`
+--     through the helper as a parameter and closes the leak.
+--     `settlement_phase_returning_survivor`'s SELECT-for-shared policy
+--     was already correctly qualified (see 20260324185312), but it is
+--     consolidated here for symmetry with the rest of the suite.
+--
+-- Admin bypass policies are untouched.
+--
+-- Reference:
+--   * supabase/migrations/20260220194908_settlement_phase.sql — original
+--     owner-only policies on both tables.
+--   * supabase/migrations/20260324185312_fix_settlement_phase_returning_survivor_rls.sql
+--     — earlier fix that re-qualified column references on the join table.
+--   * supabase/migrations/20260508000002_settlement_junction_collaborator_crud.sql
+--     — sibling migration covering Phase 1.2.a junction tables.
+--   * `local/sharing-architecture.md` §5.2 Decision 3 / §10 Phase 1.2.b.
+--
+-- Closes [E1.2.b] (issue #138).
+--------------------------------------------------------------------------------
+do $$
+declare t text;
+phase_tables text [] := array [
+    'settlement_phase',
+    'settlement_phase_returning_survivor'
+  ];
+begin foreach t in array phase_tables loop -- Drop existing SELECT and write policies. SELECT-for-shared is also
+-- dropped so the latent cross-settlement leak (described in the
+-- header) is closed by the new helper-based policy on
+-- `settlement_phase`. Admin-bypass is left in place.
+execute format(
+  'drop policy if exists "Allow select for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow select for shared" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow insert for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow update for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow delete for owner" on %I',
+  t
+);
+-- Member SELECT: caller must own OR collaborate on the parent
+-- settlement. Both helpers are SECURITY DEFINER, which sidesteps
+-- the recursion that bit the original inline EXISTS subquery and
+-- removes the latent correlation bug noted in the header.
+execute format(
+  $f$create policy "Allow select for member" on %I for
+  select to authenticated using (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $f$,
+    t
+);
+-- Member INSERT: same disjunction.
+execute format(
+  $f$create policy "Allow insert for member" on %I for
+  insert to authenticated with check (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $f$,
+    t
+);
+-- Member UPDATE: same disjunction on both USING (current row) and
+-- WITH CHECK (post-update row). Phase rows are pinned to a single
+-- settlement, so re-checking after the update is effectively a
+-- no-op but keeps the policy symmetric and defensive against
+-- malicious `settlement_id` rewrites.
+execute format(
+  $f$create policy "Allow update for member" on %I for
+  update to authenticated using (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) with check (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $f$,
+    t
+);
+-- Member DELETE: same disjunction.
+execute format(
+  $f$create policy "Allow delete for member" on %I for delete to authenticated using (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  ) $f$,
+  t
+);
+end loop;
+end $$;


### PR DESCRIPTION
## Summary

Implements **E1.2.b** — collaborators on a shared settlement now have full INSERT/UPDATE/DELETE/SELECT access on `settlement_phase` and `settlement_phase_returning_survivor`, matching the owner's permissions. Strangers remain locked out.

Closes #138.

## Changes

### Migration `20260508000003_settlement_phase_collaborator_crud.sql`

Iterates over both phase tables and, for each one, drops the `for owner` SELECT/INSERT/UPDATE/DELETE policies plus the legacy `for shared` SELECT policy, then re-creates them as four uniform `for member` policies whose USING / WITH CHECK is the disjunction:

```sql
is_settlement_owner(settlement_id)
or is_settlement_collaborator(settlement_id)
```

Both helpers are `SECURITY DEFINER`, which is the same pattern used by `20260324185335_fix_shared_user_rls_recursion.sql` and `20260508000002_settlement_junction_collaborator_crud.sql` to break circular RLS evaluation.

Tables touched:

- `settlement_phase`
- `settlement_phase_returning_survivor`

The admin-bypass policies are intentionally left in place.

### Latent SELECT bug fixed in passing

`settlement_phase`'s existing `Allow select for shared` policy referenced an unqualified `settlement_id` inside its `EXISTS` subquery. PostgreSQL resolves that name to the subquery's own `su.settlement_id`, dropping the outer-row correlation — so any user with any share could SELECT phase rows for **every** settlement (cross-settlement leak, same root cause as #135). The new helper-based `Allow select for member` policy threads the row's `settlement_id` through `is_settlement_collaborator()` as a parameter and closes the leak.

`settlement_phase_returning_survivor`'s SELECT-for-shared policy was already correctly qualified per the [20260324185312 fix](../blob/main/supabase/migrations/20260324185312_fix_settlement_phase_returning_survivor_rls.sql), but it is consolidated here for symmetry.

### Tests

New [`__tests__/integration/rls/settlement-phase-collaborator-crud.test.ts`](__tests__/integration/rls/settlement-phase-collaborator-crud.test.ts) — 12 cases:

- `settlement_phase`: collaborator SELECT + UPDATE (advance step + endeavors) + DELETE → re-INSERT round-trip; stranger SELECT + UPDATE + INSERT denial.
- `settlement_phase_returning_survivor`: collaborator SELECT + DELETE → re-INSERT round-trip + UPDATE; stranger SELECT + INSERT + DELETE denial.

Existing `settlement-scoped.test.ts` cross-user denial assertions (including the dedicated `settlement_phase_returning_survivor` describe block) continue to pass without modification.

### Hunt rank-up tweak (drive-by)

[`components/survivor/create-survivor-form.tsx`](components/survivor/create-survivor-form.tsx) now seeds new survivors with hunt-XP rank-up thresholds at the **start** of each rank band rather than the end:

- Core: `[2, 6, 10, 15]` → `[1, 5, 9, 14]`
- Arc: `[2]` → `[1]`

This matches how the rank-up checkboxes are interpreted on the survivor sheet (rank-up triggers on the first hunt of the new rank, not the last hunt of the previous rank).

## Versioning

`0.52.0` → `0.53.0` (`package.json` + `package-lock.json`).

## Verification

- `npm run db:reset` → migrations apply cleanly; `pg_policies` shows 5 policies × 2 tables (4 member + admin) = 10 rows.
- `npm run integration-test` → 14 files / 502 tests passing.
- `npm test` → 117 files / 2087 tests passing.

## Acceptance Criteria

- [x] Collaborator can advance settlement phase steps (UPDATE `step` + `endeavors` on `settlement_phase`).
- [x] Collaborator can add / remove returning survivors (INSERT + DELETE on `settlement_phase_returning_survivor`).
- [x] Existing `settlement_phase` integration tests updated / unaffected.
- [x] Owners retain full CRUD; strangers continue to see zero rows / RLS denial.

## Out of Scope

- Other settlement-child tables — covered in #135 / E1.2.a (already merged in v0.52.0).
- `survivor*` / `gear_grid` — covered in #145 / E1.2.c.
- `hunt*` / `showdown*` — covered in #140 / E1.2.d.
- Settlement-row UPDATE — covered in #133 / E1.3.

## Dependencies

- **Blocked by**: #143 (E1.1) — merged in v0.51.0.
- **Blocks**: #134 (E1.11).