### PR TITLE
feat(rls): collaborator CRUD on survivor + survivor junctions + gear_grid (#145)

### DIFF
--- a/__tests__/integration/rls/survivor-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/survivor-collaborator-crud.test.ts
@@ -337,11 +337,12 @@ describe('RLS: collaborator CRUD on survivor + survivor junctions + gear_grid', 
       // 20260424000009) refuses to equip a gear that isn't in storage.
       // Bump the storage row to 1 so the RLS policy is what we are
       // actually exercising rather than the quantity trigger.
-      await admin
+      const { error: settlementGearError } = await admin
         .from('settlement_gear')
         .update({ quantity: 1 })
         .eq('settlement_id', fixture.settlementId)
         .eq('gear_id', catalog.gearId)
+      expect(settlementGearError).toBeNull()
 
       const { data, error } = await collaborator.client
         .from('gear_grid')

--- a/__tests__/integration/rls/survivor-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/survivor-collaborator-crud.test.ts
@@ -284,7 +284,10 @@ describe('RLS: collaborator CRUD on survivor + survivor junctions + gear_grid', 
       // Make this test self-contained: remove the conflicting seeded row so
       // the assertion exercises RLS denial instead of depending on execution
       // order to avoid a 23505 unique-constraint error.
-      const { error: deleteError } = await admin.from(table).delete().eq('id', rowId)
+      const { error: deleteError } = await admin
+        .from(table)
+        .delete()
+        .eq('id', rowId)
       expect(deleteError).toBeNull()
 
       try {

--- a/__tests__/integration/rls/survivor-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/survivor-collaborator-crud.test.ts
@@ -1,0 +1,392 @@
+import {
+  deleteCatalog,
+  seedCatalog,
+  seedSettlementFixture,
+  SettlementFixture
+} from '@/__tests__/integration/helpers/fixtures'
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Collaborator CRUD on Survivor + Survivor Junctions + Gear Grid
+ *
+ * Phase 1.2.c — collaborators on a shared settlement should now have full
+ * INSERT/UPDATE/DELETE/SELECT access on `survivor`, the five survivor-owned
+ * junction tables, and `gear_grid`, matching the owner's permissions.
+ * Strangers must remain locked out.
+ *
+ * Tables exercised:
+ *   survivor, survivor_disorder, survivor_fighting_art,
+ *   survivor_secret_fighting_art, survivor_cursed_gear,
+ *   survivor_ability_impairment, gear_grid.
+ *
+ * `survivor_status` is a CATALOG table (custom-content RLS), not a
+ * survivor-owned junction, and is intentionally excluded from this matrix
+ * even though the architecture doc lists it under "survivor child rows".
+ * `hunt_survivor` / `showdown_survivor` are settlement-scoped and are
+ * covered by [E1.2.d] (issue #140).
+ *
+ * The companion file `settlement-scoped.test.ts` continues to assert the
+ * cross-user denial matrix for `survivor` and the survivor junctions, so
+ * those non-member negative cases are not duplicated here.
+ */
+describe('RLS: collaborator CRUD on survivor + survivor junctions + gear_grid', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let catalog: SettlementFixture['catalogIds']
+  let fixture: SettlementFixture
+  let gearGridId: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+    catalog = await seedCatalog()
+    fixture = await seedSettlementFixture(owner, catalog)
+    await shareSettlement(fixture.settlementId, collaborator.id, owner.id)
+
+    // gear_grid isn't seeded by the shared fixture — create one tied to the
+    // fixture's survivor so the matrix below has something to read/update.
+    const { data, error } = await admin
+      .from('gear_grid')
+      .insert({ survivor_id: fixture.survivorId })
+      .select('id')
+      .single<{ id: string }>()
+    if (error || !data)
+      throw new Error(`seed gear_grid: ${error?.message ?? 'no row'}`)
+    gearGridId = data.id
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+    await deleteCatalog(catalog)
+  })
+
+  // ---------------------------------------------------------------------------
+  // survivor (settlement_id is on the row).
+  // ---------------------------------------------------------------------------
+  describe('survivor', () => {
+    it('collaborator CAN SELECT the seeded survivor row', async () => {
+      const { data, error } = await collaborator.client
+        .from('survivor')
+        .select('id, settlement_id, survivor_name')
+        .eq('id', fixture.survivorId)
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+      expect(data?.[0]?.settlement_id).toBe(fixture.settlementId)
+    })
+
+    it('stranger CANNOT SELECT the seeded survivor row', async () => {
+      const { data, error } = await stranger.client
+        .from('survivor')
+        .select('id')
+        .eq('id', fixture.survivorId)
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    })
+
+    it('collaborator CAN INSERT a new survivor into the shared settlement', async () => {
+      const { data, error } = await collaborator.client
+        .from('survivor')
+        .insert({
+          settlement_id: fixture.settlementId,
+          survivor_name: 'Collaborator Survivor',
+          gender: 'FEMALE'
+        })
+        .select('id, settlement_id, survivor_name')
+        .single()
+      expect(error).toBeNull()
+      expect(data?.settlement_id).toBe(fixture.settlementId)
+      expect(data?.survivor_name).toBe('Collaborator Survivor')
+
+      // Clean up so subsequent matrix queries (which assume one survivor)
+      // remain stable.
+      if (data?.id) await admin.from('survivor').delete().eq('id', data.id)
+    })
+
+    it('collaborator CAN UPDATE survivor attributes', async () => {
+      const { data, error } = await collaborator.client
+        .from('survivor')
+        .update({ survivor_name: 'Renamed by collaborator', hunt_xp: 5 })
+        .eq('id', fixture.survivorId)
+        .select('id, survivor_name, hunt_xp')
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+      expect(data?.[0]?.survivor_name).toBe('Renamed by collaborator')
+      expect(data?.[0]?.hunt_xp).toBe(5)
+    })
+
+    it('stranger CANNOT UPDATE the survivor', async () => {
+      const { data, error } = await stranger.client
+        .from('survivor')
+        .update({ survivor_name: 'HACKED' })
+        .eq('id', fixture.survivorId)
+        .select('id')
+      expect(data ?? []).toEqual([])
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
+    })
+
+    it('stranger CANNOT INSERT a survivor into another user settlement', async () => {
+      const { data, error } = await stranger.client
+        .from('survivor')
+        .insert({
+          settlement_id: fixture.settlementId,
+          survivor_name: 'Lone Lantern',
+          gender: 'MALE'
+        })
+        .select('id')
+      expect(data ?? []).toEqual([])
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
+    })
+
+    it('collaborator CAN DELETE + re-INSERT a survivor', async () => {
+      // Insert a throwaway survivor first so we don't tear down the fixture
+      // survivor (which the rest of the suite leans on).
+      const { data: throwaway, error: insertError } = await collaborator.client
+        .from('survivor')
+        .insert({
+          settlement_id: fixture.settlementId,
+          survivor_name: 'Throwaway',
+          gender: 'FEMALE'
+        })
+        .select('id')
+        .single()
+      expect(insertError).toBeNull()
+
+      const { data: deleted, error: deleteError } = await collaborator.client
+        .from('survivor')
+        .delete()
+        .eq('id', throwaway!.id)
+        .select('id')
+      expect(deleteError).toBeNull()
+      expect(deleted).toHaveLength(1)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Survivor-owned junctions (FK to survivor only).
+  // ---------------------------------------------------------------------------
+  const SURVIVOR_JUNCTION_TABLES = [
+    'survivor_disorder',
+    'survivor_fighting_art',
+    'survivor_secret_fighting_art',
+    'survivor_cursed_gear',
+    'survivor_ability_impairment'
+  ] as const
+
+  /**
+   * Build Junction Insert Row
+   *
+   * Returns a fresh insert payload for each junction. The fixture already
+   * holds rows for each catalog, so the collaborator INSERT path needs the
+   * fixture row to be removed first (the unique `(survivor_id, fk_id)`
+   * constraint would otherwise short-circuit the policy check with a
+   * 23505 unique violation, which would mask an RLS hole).
+   */
+  const buildJunctionInsertRow = (
+    table: (typeof SURVIVOR_JUNCTION_TABLES)[number]
+  ): Record<string, unknown> => {
+    switch (table) {
+      case 'survivor_disorder':
+        return {
+          survivor_id: fixture.survivorId,
+          disorder_id: catalog.disorderId
+        }
+      case 'survivor_fighting_art':
+        return {
+          survivor_id: fixture.survivorId,
+          fighting_art_id: catalog.fightingArtId
+        }
+      case 'survivor_secret_fighting_art':
+        return {
+          survivor_id: fixture.survivorId,
+          secret_fighting_art_id: catalog.secretFightingArtId
+        }
+      case 'survivor_cursed_gear':
+        return { survivor_id: fixture.survivorId, gear_id: catalog.gearId }
+      case 'survivor_ability_impairment':
+        return {
+          survivor_id: fixture.survivorId,
+          ability_impairment_id: catalog.abilityImpairmentId
+        }
+    }
+  }
+
+  it.each(SURVIVOR_JUNCTION_TABLES)(
+    'collaborator CAN SELECT seeded row in %s',
+    async (table) => {
+      const rowId = fixture.survivorJunctionIds[table]
+      const { data, error } = await collaborator.client
+        .from(table)
+        .select('id')
+        .eq('id', rowId)
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+    }
+  )
+
+  it.each(SURVIVOR_JUNCTION_TABLES)(
+    'stranger CANNOT SELECT seeded row in %s',
+    async (table) => {
+      const rowId = fixture.survivorJunctionIds[table]
+      const { data, error } = await stranger.client
+        .from(table)
+        .select('id')
+        .eq('id', rowId)
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    }
+  )
+
+  it.each(SURVIVOR_JUNCTION_TABLES)(
+    'collaborator CAN DELETE + re-INSERT row in %s',
+    async (table) => {
+      const rowId = fixture.survivorJunctionIds[table]
+
+      // DELETE the seeded row.
+      const { data: deleted, error: deleteError } = await collaborator.client
+        .from(table)
+        .delete()
+        .eq('id', rowId)
+        .select('id')
+      expect(deleteError).toBeNull()
+      expect(deleted).toHaveLength(1)
+
+      // Re-INSERT to confirm the collaborator can write fresh rows.
+      const { data: inserted, error: insertError } = await collaborator.client
+        .from(table)
+        .insert(buildJunctionInsertRow(table))
+        .select('id')
+        .single<{ id: string }>()
+      expect(insertError).toBeNull()
+      expect(inserted?.id).toBeDefined()
+
+      // Restore the fixture invariant.
+      if (inserted?.id) fixture.survivorJunctionIds[table] = inserted.id
+    }
+  )
+
+  it.each(SURVIVOR_JUNCTION_TABLES)(
+    'stranger CANNOT INSERT a row into %s for another user survivor',
+    async (table) => {
+      const { data, error } = await stranger.client
+        .from(table)
+        .insert(buildJunctionInsertRow(table))
+        .select('id')
+      expect(data ?? []).toEqual([])
+      // 23505 is not accepted here: the collaborator-CAN-DELETE test runs
+      // first inside the same describe and clears the fixture row, so a
+      // surviving 23505 would mask a real RLS hole. Allow only RLS / API
+      // denial codes.
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // gear_grid (FK to survivor; settlement-scoped via 20260503000000).
+  // ---------------------------------------------------------------------------
+  describe('gear_grid', () => {
+    it('collaborator CAN SELECT the seeded grid', async () => {
+      const { data, error } = await collaborator.client
+        .from('gear_grid')
+        .select('id, survivor_id')
+        .eq('id', gearGridId)
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+      expect(data?.[0]?.survivor_id).toBe(fixture.survivorId)
+    })
+
+    it('stranger CANNOT SELECT the seeded grid', async () => {
+      const { data, error } = await stranger.client
+        .from('gear_grid')
+        .select('id')
+        .eq('id', gearGridId)
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    })
+
+    it('collaborator CAN UPDATE grid positions', async () => {
+      // The fixture seeds `settlement_gear` with quantity 0; the
+      // gear_grid validation trigger (validate_gear_grid_positions in
+      // 20260424000009) refuses to equip a gear that isn't in storage.
+      // Bump the storage row to 1 so the RLS policy is what we are
+      // actually exercising rather than the quantity trigger.
+      await admin
+        .from('settlement_gear')
+        .update({ quantity: 1 })
+        .eq('settlement_id', fixture.settlementId)
+        .eq('gear_id', catalog.gearId)
+
+      const { data, error } = await collaborator.client
+        .from('gear_grid')
+        .update({ pos_top_left: catalog.gearId })
+        .eq('id', gearGridId)
+        .select('id, pos_top_left')
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+      expect(data?.[0]?.pos_top_left).toBe(catalog.gearId)
+    })
+
+    it('stranger CANNOT UPDATE the grid', async () => {
+      const { data, error } = await stranger.client
+        .from('gear_grid')
+        .update({ pos_top_left: catalog.gearId })
+        .eq('id', gearGridId)
+        .select('id')
+      expect(data ?? []).toEqual([])
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
+    })
+
+    it('collaborator CAN INSERT + DELETE a fresh grid', async () => {
+      // Spin up a second survivor so the new grid has its own owner row.
+      const { data: extraSurvivor, error: setupError } = await admin
+        .from('survivor')
+        .insert({
+          settlement_id: fixture.settlementId,
+          survivor_name: 'Grid Owner',
+          gender: 'FEMALE'
+        })
+        .select('id')
+        .single<{ id: string }>()
+      expect(setupError).toBeNull()
+
+      try {
+        const { data: inserted, error: insertError } = await collaborator.client
+          .from('gear_grid')
+          .insert({ survivor_id: extraSurvivor!.id })
+          .select('id, survivor_id')
+          .single()
+        expect(insertError).toBeNull()
+        expect(inserted?.survivor_id).toBe(extraSurvivor!.id)
+
+        const { data: deleted, error: deleteError } = await collaborator.client
+          .from('gear_grid')
+          .delete()
+          .eq('id', inserted!.id)
+          .select('id')
+        expect(deleteError).toBeNull()
+        expect(deleted).toHaveLength(1)
+      } finally {
+        await admin.from('survivor').delete().eq('id', extraSurvivor!.id)
+      }
+    })
+
+    it('stranger CANNOT INSERT a grid for another user survivor', async () => {
+      const { data, error } = await stranger.client
+        .from('gear_grid')
+        .insert({ survivor_id: fixture.survivorId })
+        .select('id')
+      expect(data ?? []).toEqual([])
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
+    })
+  })
+})

--- a/__tests__/integration/rls/survivor-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/survivor-collaborator-crud.test.ts
@@ -278,16 +278,33 @@ describe('RLS: collaborator CRUD on survivor + survivor junctions + gear_grid', 
   it.each(SURVIVOR_JUNCTION_TABLES)(
     'stranger CANNOT INSERT a row into %s for another user survivor',
     async (table) => {
-      const { data, error } = await stranger.client
-        .from(table)
-        .insert(buildJunctionInsertRow(table))
-        .select('id')
-      expect(data ?? []).toEqual([])
-      // 23505 is not accepted here: the collaborator-CAN-DELETE test runs
-      // first inside the same describe and clears the fixture row, so a
-      // surviving 23505 would mask a real RLS hole. Allow only RLS / API
-      // denial codes.
-      if (error) expect(error.code).toMatch(/PGRST|42501/)
+      const rowId = fixture.survivorJunctionIds[table]
+      const insertRow = buildJunctionInsertRow(table)
+
+      // Make this test self-contained: remove the conflicting seeded row so
+      // the assertion exercises RLS denial instead of depending on execution
+      // order to avoid a 23505 unique-constraint error.
+      const { error: deleteError } = await admin.from(table).delete().eq('id', rowId)
+      expect(deleteError).toBeNull()
+
+      try {
+        const { data, error } = await stranger.client
+          .from(table)
+          .insert(insertRow)
+          .select('id')
+        expect(data ?? []).toEqual([])
+        expect(error).not.toBeNull()
+        if (error) expect(error.code).toMatch(/PGRST|42501/)
+      } finally {
+        const { data: restored, error: restoreError } = await admin
+          .from(table)
+          .insert(insertRow)
+          .select('id')
+          .single<{ id: string }>()
+        expect(restoreError).toBeNull()
+        expect(restored?.id).toBeDefined()
+        if (restored?.id) fixture.survivorJunctionIds[table] = restored.id
+      }
     }
   )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260508000004_survivor_collaborator_crud.sql
+++ b/supabase/migrations/20260508000004_survivor_collaborator_crud.sql
@@ -1,0 +1,216 @@
+--------------------------------------------------------------------------------
+-- Phase 1.2.c — Collaborator CRUD on Survivor + Survivor Junctions + Gear Grid
+--
+-- Replace the owner-only SELECT/INSERT/UPDATE/DELETE policies on `survivor`,
+-- the five survivor-owned junctions, and `gear_grid` with member policies
+-- that accept both the settlement owner AND any user listed in
+-- `settlement_shared_user`. Authorization is delegated to two SECURITY
+-- DEFINER helpers so RLS evaluation cannot recurse into the shared-user
+-- table:
+--
+--   * is_settlement_owner(uuid)        -- existing helper
+--   * is_settlement_collaborator(uuid) -- added in
+--                                         20260508000001_is_settlement_collaborator.sql
+--
+-- For `survivor`, the row carries `settlement_id` directly, so the policy
+-- predicate is the same simple disjunction used by the settlement-junction
+-- migration in 20260508000002.
+--
+-- For survivor-owned junctions and `gear_grid`, the row carries `survivor_id`
+-- (no `settlement_id`), so the predicate threads through the survivor:
+--
+--   exists (
+--     select 1 from survivor sv
+--     where sv.id = <table>.survivor_id
+--       and (is_settlement_owner(sv.settlement_id)
+--            or is_settlement_collaborator(sv.settlement_id))
+--   )
+--
+-- The inner SELECT against `survivor` is itself subject to survivor's RLS;
+-- that RLS is replaced earlier in this same migration with a member-friendly
+-- policy, so the collaborator path resolves cleanly. The two helpers are
+-- SECURITY DEFINER so they bypass `settlement_shared_user`'s RLS and avoid
+-- the recursion risk that motivated the helper pattern in the first place
+-- (see 20260324185335).
+--
+-- SELECT continues to use a single member policy on each table — the
+-- original "Allow select for owner" + "Allow select for shared" pair is
+-- replaced with a single helper-based "Allow select for member" policy.
+-- Two reasons:
+--   * Consistency with INSERT/UPDATE/DELETE — every CRUD verb is now gated
+--     by the same disjunction.
+--   * `survivor`'s "Allow select for shared" policy contained the same
+--     latent correlation bug fixed for the junction tables in
+--     20260508000002 and the phase tables in 20260508000003: its EXISTS
+--     subquery referenced an unqualified `settlement_id` that PostgreSQL
+--     resolved to the subquery's own `su.settlement_id` rather than the
+--     outer survivor row's column, leaking survivor rows for every
+--     settlement to any user with any share. The new helper-based
+--     "Allow select for member" policy threads the row's `settlement_id`
+--     through `is_settlement_collaborator()` as a parameter and closes
+--     the leak. The SELECT-for-shared policies on `survivor_disorder`
+--     and the rest of the junction set were already correctly qualified
+--     (they explicitly join through `survivor` via aliased columns),
+--     but they are consolidated here for symmetry with the rest of the
+--     suite.
+--
+-- Out of scope for this migration:
+--   * `survivor_status` is a CATALOG table (custom-content RLS pattern),
+--     not a survivor-owned junction. It is governed by the catalog
+--     sharing model (E2.x) and is intentionally left alone here even
+--     though the architecture doc lists it under "survivor child rows".
+--   * `hunt_survivor` / `showdown_survivor` are settlement-scoped via
+--     `hunt` / `showdown`, not survivor-scoped, and are covered by
+--     [E1.2.d] (issue #140).
+--
+-- Admin bypass policies are untouched.
+--
+-- Reference:
+--   * supabase/migrations/20260220192245_survivor.sql — original
+--     owner-only policies on `survivor`.
+--   * supabase/migrations/20260220192246_survivor_disorder.sql — and
+--     siblings: original survivor-junction policies.
+--   * supabase/migrations/20260413223402_survivor_ability_impairment.sql
+--   * supabase/migrations/20260503000000_gear_grid_settlement_rls.sql —
+--     prior gear_grid rewrite from catalog-style to settlement-scoped.
+--   * supabase/migrations/20260508000002_settlement_junction_collaborator_crud.sql
+--   * supabase/migrations/20260508000003_settlement_phase_collaborator_crud.sql
+--   * `local/sharing-architecture.md` §5.2 Decision 3 / §10 Phase 1.2.c.
+--
+-- Closes [E1.2.c] (issue #145).
+--------------------------------------------------------------------------------
+--
+-- 1. survivor — settlement_id is on the row, so the simple disjunction works.
+--
+drop policy if exists "Allow select for owner" on survivor;
+drop policy if exists "Allow select for shared" on survivor;
+drop policy if exists "Allow insert for owner" on survivor;
+drop policy if exists "Allow update for owner" on survivor;
+drop policy if exists "Allow delete for owner" on survivor;
+create policy "Allow select for member" on survivor for
+select to authenticated using (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  );
+create policy "Allow insert for member" on survivor for
+insert to authenticated with check (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  );
+create policy "Allow update for member" on survivor for
+update to authenticated using (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  ) with check (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  );
+create policy "Allow delete for member" on survivor for delete to authenticated using (
+  is_settlement_owner(settlement_id)
+  or is_settlement_collaborator(settlement_id)
+);
+--
+-- 2. Survivor-owned junctions and gear_grid — survivor_id only; resolve
+--    settlement membership via the survivor row.
+--
+do $$
+declare t text;
+child_tables text [] := array [
+    'survivor_disorder',
+    'survivor_fighting_art',
+    'survivor_secret_fighting_art',
+    'survivor_cursed_gear',
+    'survivor_ability_impairment',
+    'gear_grid'
+  ];
+begin foreach t in array child_tables loop execute format(
+  'drop policy if exists "Allow select for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow select for shared" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow insert for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow update for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow delete for owner" on %I',
+  t
+);
+execute format(
+  $f$create policy "Allow select for member" on %1$I for
+  select to authenticated using (
+      exists (
+        select 1
+        from survivor sv
+        where sv.id = %1$I.survivor_id
+          and (
+            is_settlement_owner(sv.settlement_id)
+            or is_settlement_collaborator(sv.settlement_id)
+          )
+      )
+    ) $f$,
+    t
+);
+execute format(
+  $f$create policy "Allow insert for member" on %1$I for
+  insert to authenticated with check (
+      exists (
+        select 1
+        from survivor sv
+        where sv.id = %1$I.survivor_id
+          and (
+            is_settlement_owner(sv.settlement_id)
+            or is_settlement_collaborator(sv.settlement_id)
+          )
+      )
+    ) $f$,
+    t
+);
+execute format(
+  $f$create policy "Allow update for member" on %1$I for
+  update to authenticated using (
+      exists (
+        select 1
+        from survivor sv
+        where sv.id = %1$I.survivor_id
+          and (
+            is_settlement_owner(sv.settlement_id)
+            or is_settlement_collaborator(sv.settlement_id)
+          )
+      )
+    ) with check (
+      exists (
+        select 1
+        from survivor sv
+        where sv.id = %1$I.survivor_id
+          and (
+            is_settlement_owner(sv.settlement_id)
+            or is_settlement_collaborator(sv.settlement_id)
+          )
+      )
+    ) $f$,
+    t
+);
+execute format(
+  $f$create policy "Allow delete for member" on %1$I for delete to authenticated using (
+    exists (
+      select 1
+      from survivor sv
+      where sv.id = %1$I.survivor_id
+        and (
+          is_settlement_owner(sv.settlement_id)
+          or is_settlement_collaborator(sv.settlement_id)
+        )
+    )
+  ) $f$,
+  t
+);
+end loop;
+end $$;


### PR DESCRIPTION
## Summary

Implements **E1.2.c** — collaborators on a shared settlement now have full INSERT/UPDATE/DELETE/SELECT access on `survivor`, the five survivor-owned junction tables, and `gear_grid`, matching the owner's permissions. Strangers remain locked out.

Closes #145.

## Changes

### Migration `20260508000004_survivor_collaborator_crud.sql`

For each of the 7 tables, drops the `for owner` SELECT/INSERT/UPDATE/DELETE policies plus the legacy `for shared` SELECT policy, then re-creates them as four uniform `for member` policies.

`survivor` carries `settlement_id` directly, so its predicate is the simple disjunction:

```sql
is_settlement_owner(settlement_id)
or is_settlement_collaborator(settlement_id)
```

Junction tables and `gear_grid` carry `survivor_id` only, so the predicate threads through `survivor`:

```sql
exists (
  select 1 from survivor sv
  where sv.id = <table>.survivor_id
    and (
      is_settlement_owner(sv.settlement_id)
      or is_settlement_collaborator(sv.settlement_id)
    )
)
```

Both helpers are `SECURITY DEFINER`, mirroring the pattern in #135 / #138. The inner SELECT against `survivor` is satisfied by `survivor`'s new `Allow select for member` policy created in the same migration.

Tables touched (7):

- `survivor`
- `survivor_disorder`
- `survivor_fighting_art`
- `survivor_secret_fighting_art`
- `survivor_cursed_gear`
- `survivor_ability_impairment`
- `gear_grid`

Admin-bypass policies are intentionally left in place.

### Latent SELECT bug fixed in passing

`survivor`'s existing `Allow select for shared` policy referenced an unqualified `settlement_id` inside its `EXISTS` subquery. PostgreSQL resolved that name to the subquery's own `su.settlement_id` rather than the outer survivor row's column, dropping the correlation — so any user with any share could SELECT survivor rows for **every** settlement (cross-settlement leak, same root cause as #135 and #138). The new helper-based `Allow select for member` policy threads the row's `settlement_id` through `is_settlement_collaborator()` as a parameter and closes the leak.

The SELECT-for-shared policies on the survivor junctions were already correctly qualified (they explicitly join through `survivor` with aliased columns) but are consolidated here for symmetry.

### Out of scope

- **`survivor_status`** is a CATALOG table (custom-content RLS pattern) governed by E2.x. The issue body lists it under "survivor child rows", but the actual schema makes it a catalog row keyed by `custom`/`user_id` with a separate `survivor_status_shared_user` junction — it does not have a `survivor_id` foreign key. Loosening it requires the catalog-share work in E2.x rather than the survivor-scope pattern used here.
- **`hunt_survivor`** / **`showdown_survivor`** are settlement-scoped (via `hunt` / `showdown`), covered by #140 / E1.2.d.

### Tests

New <a>`__tests__/integration/rls/survivor-collaborator-crud.test.ts`</a> — 33 cases:

- `survivor`: collaborator SELECT + INSERT + UPDATE (rename + hunt_xp) + DELETE (round-tripped on a throwaway row); stranger SELECT + UPDATE + INSERT denial.
- 5 survivor junctions × { collaborator SELECT, stranger SELECT denial, collaborator DELETE → re-INSERT, stranger INSERT denial } via `it.each`.
- `gear_grid`: collaborator SELECT + UPDATE (with `settlement_gear.quantity` bumped to satisfy the unrelated `validate_gear_grid_positions` trigger so RLS is what is being exercised) + INSERT/DELETE round-trip; stranger SELECT + UPDATE + INSERT denial.

Existing <a>`__tests__/integration/rls/settlement-scoped.test.ts`</a> cross-user denial assertions on `survivor` + junctions continue to pass without modification (`attacker` is a fresh user with no share, so it's a stranger and the denial matrix is still meaningful).

## Versioning

`0.53.0` → `0.54.0` (`package.json` + `package-lock.json`).

## Verification

- `npm run db:reset` → migrations apply cleanly; `pg_policies` shows 5 policies × 7 tables (4 member + admin) = 35 rows.
- `npm run integration-test` → 15 files / 536 tests passing.
- `npm test` → 119 files / 2091 tests passing.

## Acceptance Criteria

- [x] Collaborator can create a survivor, edit attributes, attach disorders / fighting arts / secret fighting arts / cursed gear / ability impairment, mutate gear grid.
- [x] Owner retains full CRUD.
- [x] Stranger gets 0 rows / RLS denial.

## Dependencies

- **Blocked by**: #143 (E1.1) — merged in v0.51.0.
- **Blocks**: #134 (E1.11).