### PR TITLE
feat(rls): collaborator CRUD on hunt_* and showdown_* tables (#140)

### DIFF
--- a/__tests__/integration/rls/hunt-showdown-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/hunt-showdown-collaborator-crud.test.ts
@@ -252,8 +252,7 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
       parentColumn: 'hunt_monster_id',
       catalogColumn: 'survivor_status_id',
       catalogId: () => catalog.survivorStatusId,
-      seededRowId: () =>
-        fixture.monsterJunctionIds.hunt_monster_survivor_status
+      seededRowId: () => fixture.monsterJunctionIds.hunt_monster_survivor_status
     },
     {
       table: 'showdown_monster_trait',
@@ -351,16 +350,15 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
       expect(setupError).toBeNull()
 
       try {
-        const { data: inserted, error: insertError } =
-          await collaborator.client
-            .from('hunt_survivor')
-            .insert({
-              hunt_id: fixture.huntId,
-              settlement_id: fixture.settlementId,
-              survivor_id: extraSurvivor!.id
-            })
-            .select('id, hunt_id, survivor_id')
-            .single()
+        const { data: inserted, error: insertError } = await collaborator.client
+          .from('hunt_survivor')
+          .insert({
+            hunt_id: fixture.huntId,
+            settlement_id: fixture.settlementId,
+            survivor_id: extraSurvivor!.id
+          })
+          .select('id, hunt_id, survivor_id')
+          .single()
         expect(insertError).toBeNull()
         expect(inserted?.hunt_id).toBe(fixture.huntId)
         expect(inserted?.survivor_id).toBe(extraSurvivor!.id)

--- a/__tests__/integration/rls/hunt-showdown-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/hunt-showdown-collaborator-crud.test.ts
@@ -41,6 +41,11 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
   let catalog: SettlementFixture['catalogIds']
   let fixture: SettlementFixture
   let showdownSettlementId: string
+  // Fresh catalog rows reserved for the stranger INSERT denial assertions.
+  // Using these guarantees the (monster_id, catalog_id) pair has never
+  // existed, so a 23505 unique-violation cannot mask an RLS hole. Each id is
+  // cleaned up in afterAll via the admin client.
+  const strangerCatalog: { trait?: string; mood?: string; status?: string } = {}
 
   beforeAll(async () => {
     owner = await createTestUser()
@@ -62,12 +67,49 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
 
     await shareSettlement(fixture.settlementId, collaborator.id, owner.id)
     await shareSettlement(showdownSettlementId, collaborator.id, owner.id)
+
+    // Seed dedicated catalog rows for the stranger INSERT denial cases —
+    // see comment on `strangerCatalog` above.
+    const seedExtra = async (
+      table: string,
+      row: Record<string, unknown>
+    ): Promise<string> => {
+      const { data: extra, error: extraErr } = await admin
+        .from(table)
+        .insert(row)
+        .select('id')
+        .single<{ id: string }>()
+      if (extraErr || !extra)
+        throw new Error(`seed extra ${table}: ${extraErr?.message}`)
+      return extra.id
+    }
+    strangerCatalog.trait = await seedExtra('trait', {
+      custom: false,
+      trait_name: 'RLS Stranger Trait'
+    })
+    strangerCatalog.mood = await seedExtra('mood', {
+      custom: false,
+      mood_name: 'RLS Stranger Mood'
+    })
+    strangerCatalog.status = await seedExtra('survivor_status', {
+      custom: false,
+      survivor_status_name: 'RLS Stranger Status'
+    })
   })
 
   afterAll(async () => {
     await deleteTestUser(owner.id)
     await deleteTestUser(collaborator.id)
     await deleteTestUser(stranger.id)
+    if (strangerCatalog.trait)
+      await admin.from('trait').delete().eq('id', strangerCatalog.trait)
+    if (strangerCatalog.mood)
+      await admin.from('mood').delete().eq('id', strangerCatalog.mood)
+    if (strangerCatalog.status)
+      await admin
+        .from('survivor_status')
+        .delete()
+        .eq('id', strangerCatalog.status)
     await deleteCatalog(catalog)
   })
 
@@ -226,6 +268,11 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
     parentColumn: string
     catalogColumn: string
     catalogId: () => string
+    // A separate catalog id reserved for the stranger INSERT denial test.
+    // Pairing this with `parentMonsterId` produces a composite that has
+    // never existed in the table, so a 23505 unique violation is impossible
+    // and any insert failure must come from RLS.
+    strangerCatalogId: () => string
     seededRowId: () => string
   }
 
@@ -236,6 +283,7 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
       parentColumn: 'hunt_monster_id',
       catalogColumn: 'trait_id',
       catalogId: () => catalog.traitId,
+      strangerCatalogId: () => strangerCatalog.trait!,
       seededRowId: () => fixture.monsterJunctionIds.hunt_monster_trait
     },
     {
@@ -244,6 +292,7 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
       parentColumn: 'hunt_monster_id',
       catalogColumn: 'mood_id',
       catalogId: () => catalog.moodId,
+      strangerCatalogId: () => strangerCatalog.mood!,
       seededRowId: () => fixture.monsterJunctionIds.hunt_monster_mood
     },
     {
@@ -252,6 +301,7 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
       parentColumn: 'hunt_monster_id',
       catalogColumn: 'survivor_status_id',
       catalogId: () => catalog.survivorStatusId,
+      strangerCatalogId: () => strangerCatalog.status!,
       seededRowId: () => fixture.monsterJunctionIds.hunt_monster_survivor_status
     },
     {
@@ -260,6 +310,7 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
       parentColumn: 'showdown_monster_id',
       catalogColumn: 'trait_id',
       catalogId: () => catalog.traitId,
+      strangerCatalogId: () => strangerCatalog.trait!,
       seededRowId: () => fixture.monsterJunctionIds.showdown_monster_trait
     },
     {
@@ -268,6 +319,7 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
       parentColumn: 'showdown_monster_id',
       catalogColumn: 'mood_id',
       catalogId: () => catalog.moodId,
+      strangerCatalogId: () => strangerCatalog.mood!,
       seededRowId: () => fixture.monsterJunctionIds.showdown_monster_mood
     },
     {
@@ -276,6 +328,7 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
       parentColumn: 'showdown_monster_id',
       catalogColumn: 'survivor_status_id',
       catalogId: () => catalog.survivorStatusId,
+      strangerCatalogId: () => strangerCatalog.status!,
       seededRowId: () =>
         fixture.monsterJunctionIds.showdown_monster_survivor_status
     }
@@ -314,18 +367,19 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
   it.each(monsterJunctions)(
     'stranger CANNOT INSERT into $table for another user monster',
     async (row) => {
+      // Pair the foreign monster with a catalog id reserved for the
+      // stranger denial cases (seeded in beforeAll). The composite has
+      // never existed in this table, so a 23505 unique-violation is
+      // impossible — only an RLS denial can produce a failure.
       const insertRow: Record<string, unknown> = {
         [row.parentColumn]: row.parentMonsterId(),
-        [row.catalogColumn]: row.catalogId()
+        [row.catalogColumn]: row.strangerCatalogId()
       }
       const { data, error } = await stranger.client
         .from(row.table)
         .insert(insertRow)
         .select('id')
       expect(data ?? []).toEqual([])
-      // The collaborator DELETE test above clears the fixture row, so a
-      // stale 23505 unique violation can no longer mask an RLS hole — only
-      // the API / RLS denial codes are accepted.
       if (error) expect(error.code).toMatch(/PGRST|42501/)
     }
   )

--- a/__tests__/integration/rls/hunt-showdown-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/hunt-showdown-collaborator-crud.test.ts
@@ -1,0 +1,396 @@
+import {
+  deleteCatalog,
+  seedCatalog,
+  seedSettlementFixture,
+  SettlementFixture
+} from '@/__tests__/integration/helpers/fixtures'
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Collaborator CRUD on Hunt + Showdown Tables
+ *
+ * Phase 1.2.d — collaborators on a shared settlement should now have full
+ * INSERT/UPDATE/DELETE/SELECT access on every hunt and showdown table,
+ * matching the owner's permissions. Strangers must remain locked out.
+ *
+ * Tables exercised (15):
+ *   Direct-settlement (9): hunt, hunt_ai_deck, hunt_hunt_board,
+ *     hunt_monster, hunt_survivor, showdown, showdown_ai_deck,
+ *     showdown_monster, showdown_survivor.
+ *   Monster-scoped (6): hunt_monster_trait, hunt_monster_mood,
+ *     hunt_monster_survivor_status, showdown_monster_trait,
+ *     showdown_monster_mood, showdown_monster_survivor_status.
+ *
+ * The fixture seeds the hunt graph against `settlementId` and the showdown
+ * graph against a separate `showdownSettlementId` (because both `hunt` and
+ * `showdown` carry a unique constraint on `settlement_id`). Both settlements
+ * are shared with the collaborator so the matrix below is symmetric across
+ * the hunt and showdown halves.
+ */
+describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let catalog: SettlementFixture['catalogIds']
+  let fixture: SettlementFixture
+  let showdownSettlementId: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+    catalog = await seedCatalog()
+    fixture = await seedSettlementFixture(owner, catalog)
+
+    // The fixture seeds the showdown graph on a separate settlement; resolve
+    // its id by walking back from the seeded showdown row.
+    const { data, error } = await admin
+      .from('showdown')
+      .select('settlement_id')
+      .eq('id', fixture.showdownId)
+      .single<{ settlement_id: string }>()
+    if (error || !data)
+      throw new Error(`resolve showdown settlement: ${error?.message}`)
+    showdownSettlementId = data.settlement_id
+
+    await shareSettlement(fixture.settlementId, collaborator.id, owner.id)
+    await shareSettlement(showdownSettlementId, collaborator.id, owner.id)
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+    await deleteCatalog(catalog)
+  })
+
+  // ---------------------------------------------------------------------------
+  // SELECT matrix.
+  // ---------------------------------------------------------------------------
+  type Row = { table: string; rowId: () => string }
+  const buildSelectMatrix = (): Row[] => [
+    // Direct-settlement (9)
+    { table: 'hunt', rowId: () => fixture.huntId },
+    { table: 'hunt_ai_deck', rowId: () => fixture.huntAiDeckId },
+    { table: 'hunt_hunt_board', rowId: () => fixture.huntHuntBoardId },
+    { table: 'hunt_monster', rowId: () => fixture.huntMonsterId },
+    { table: 'hunt_survivor', rowId: () => fixture.huntSurvivorId },
+    { table: 'showdown', rowId: () => fixture.showdownId },
+    { table: 'showdown_ai_deck', rowId: () => fixture.showdownAiDeckId },
+    { table: 'showdown_monster', rowId: () => fixture.showdownMonsterId },
+    { table: 'showdown_survivor', rowId: () => fixture.showdownSurvivorId },
+    // Monster-scoped (6)
+    {
+      table: 'hunt_monster_trait',
+      rowId: () => fixture.monsterJunctionIds.hunt_monster_trait
+    },
+    {
+      table: 'hunt_monster_mood',
+      rowId: () => fixture.monsterJunctionIds.hunt_monster_mood
+    },
+    {
+      table: 'hunt_monster_survivor_status',
+      rowId: () => fixture.monsterJunctionIds.hunt_monster_survivor_status
+    },
+    {
+      table: 'showdown_monster_trait',
+      rowId: () => fixture.monsterJunctionIds.showdown_monster_trait
+    },
+    {
+      table: 'showdown_monster_mood',
+      rowId: () => fixture.monsterJunctionIds.showdown_monster_mood
+    },
+    {
+      table: 'showdown_monster_survivor_status',
+      rowId: () => fixture.monsterJunctionIds.showdown_monster_survivor_status
+    }
+  ]
+
+  it.each(buildSelectMatrix())(
+    'collaborator CAN SELECT seeded row in %s',
+    async ({ table, rowId }) => {
+      const { data, error } = await collaborator.client
+        .from(table)
+        .select('id')
+        .eq('id', rowId())
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+    }
+  )
+
+  it.each(buildSelectMatrix())(
+    'stranger CANNOT SELECT seeded row in %s',
+    async ({ table, rowId }) => {
+      const { data, error } = await stranger.client
+        .from(table)
+        .select('id')
+        .eq('id', rowId())
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // UPDATE matrix — only tables with a mutable non-FK column.
+  // ---------------------------------------------------------------------------
+  type UpdateRow = Row & { update: object }
+  const buildUpdateMatrix = (): UpdateRow[] => [
+    {
+      table: 'hunt',
+      rowId: () => fixture.huntId,
+      update: { monster_level: 9 }
+    },
+    {
+      table: 'hunt_ai_deck',
+      rowId: () => fixture.huntAiDeckId,
+      update: { basic_cards: 7 }
+    },
+    {
+      table: 'hunt_hunt_board',
+      rowId: () => fixture.huntHuntBoardId,
+      update: { pos_1: 'BASIC' }
+    },
+    {
+      table: 'hunt_monster',
+      rowId: () => fixture.huntMonsterId,
+      update: { wounds: 2 }
+    },
+    {
+      table: 'hunt_survivor',
+      rowId: () => fixture.huntSurvivorId,
+      update: { notes: 'collab edit' }
+    },
+    {
+      table: 'showdown',
+      rowId: () => fixture.showdownId,
+      update: { monster_level: 9 }
+    },
+    {
+      table: 'showdown_ai_deck',
+      rowId: () => fixture.showdownAiDeckId,
+      update: { basic_cards: 7 }
+    },
+    {
+      table: 'showdown_monster',
+      rowId: () => fixture.showdownMonsterId,
+      update: { wounds: 2 }
+    },
+    {
+      table: 'showdown_survivor',
+      rowId: () => fixture.showdownSurvivorId,
+      update: { notes: 'collab edit' }
+    }
+  ]
+
+  it.each(buildUpdateMatrix())(
+    'collaborator CAN UPDATE %s',
+    async ({ table, rowId, update }) => {
+      const { data, error } = await collaborator.client
+        .from(table)
+        .update(update)
+        .eq('id', rowId())
+        .select('id')
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+    }
+  )
+
+  it.each(buildUpdateMatrix())(
+    'stranger CANNOT UPDATE %s',
+    async ({ table, rowId, update }) => {
+      const { data, error } = await stranger.client
+        .from(table)
+        .update(update)
+        .eq('id', rowId())
+        .select('id')
+      expect(data ?? []).toEqual([])
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // INSERT/DELETE matrix — monster-scoped junctions delete + re-insert
+  // cleanly because the seeded row's composite (monster_id, catalog_id)
+  // isn't repeated by anything else in the fixture.
+  // ---------------------------------------------------------------------------
+  type MonsterJunctionRow = {
+    table: string
+    parentMonsterId: () => string
+    parentColumn: string
+    catalogColumn: string
+    catalogId: () => string
+    seededRowId: () => string
+  }
+
+  const monsterJunctions: MonsterJunctionRow[] = [
+    {
+      table: 'hunt_monster_trait',
+      parentMonsterId: () => fixture.huntMonsterId,
+      parentColumn: 'hunt_monster_id',
+      catalogColumn: 'trait_id',
+      catalogId: () => catalog.traitId,
+      seededRowId: () => fixture.monsterJunctionIds.hunt_monster_trait
+    },
+    {
+      table: 'hunt_monster_mood',
+      parentMonsterId: () => fixture.huntMonsterId,
+      parentColumn: 'hunt_monster_id',
+      catalogColumn: 'mood_id',
+      catalogId: () => catalog.moodId,
+      seededRowId: () => fixture.monsterJunctionIds.hunt_monster_mood
+    },
+    {
+      table: 'hunt_monster_survivor_status',
+      parentMonsterId: () => fixture.huntMonsterId,
+      parentColumn: 'hunt_monster_id',
+      catalogColumn: 'survivor_status_id',
+      catalogId: () => catalog.survivorStatusId,
+      seededRowId: () =>
+        fixture.monsterJunctionIds.hunt_monster_survivor_status
+    },
+    {
+      table: 'showdown_monster_trait',
+      parentMonsterId: () => fixture.showdownMonsterId,
+      parentColumn: 'showdown_monster_id',
+      catalogColumn: 'trait_id',
+      catalogId: () => catalog.traitId,
+      seededRowId: () => fixture.monsterJunctionIds.showdown_monster_trait
+    },
+    {
+      table: 'showdown_monster_mood',
+      parentMonsterId: () => fixture.showdownMonsterId,
+      parentColumn: 'showdown_monster_id',
+      catalogColumn: 'mood_id',
+      catalogId: () => catalog.moodId,
+      seededRowId: () => fixture.monsterJunctionIds.showdown_monster_mood
+    },
+    {
+      table: 'showdown_monster_survivor_status',
+      parentMonsterId: () => fixture.showdownMonsterId,
+      parentColumn: 'showdown_monster_id',
+      catalogColumn: 'survivor_status_id',
+      catalogId: () => catalog.survivorStatusId,
+      seededRowId: () =>
+        fixture.monsterJunctionIds.showdown_monster_survivor_status
+    }
+  ]
+
+  it.each(monsterJunctions)(
+    'collaborator CAN DELETE + re-INSERT row in $table',
+    async (row) => {
+      // DELETE the seeded row.
+      const { data: deleted, error: deleteError } = await collaborator.client
+        .from(row.table)
+        .delete()
+        .eq('id', row.seededRowId())
+        .select('id')
+      expect(deleteError).toBeNull()
+      expect(deleted).toHaveLength(1)
+
+      // Re-INSERT to confirm the collaborator can write fresh rows.
+      const insertRow: Record<string, unknown> = {
+        [row.parentColumn]: row.parentMonsterId(),
+        [row.catalogColumn]: row.catalogId()
+      }
+      const { data: inserted, error: insertError } = await collaborator.client
+        .from(row.table)
+        .insert(insertRow)
+        .select('id')
+        .single<{ id: string }>()
+      expect(insertError).toBeNull()
+      expect(inserted?.id).toBeDefined()
+
+      // Restore the fixture invariant for any tests below.
+      if (inserted?.id) fixture.monsterJunctionIds[row.table] = inserted.id
+    }
+  )
+
+  it.each(monsterJunctions)(
+    'stranger CANNOT INSERT into $table for another user monster',
+    async (row) => {
+      const insertRow: Record<string, unknown> = {
+        [row.parentColumn]: row.parentMonsterId(),
+        [row.catalogColumn]: row.catalogId()
+      }
+      const { data, error } = await stranger.client
+        .from(row.table)
+        .insert(insertRow)
+        .select('id')
+      expect(data ?? []).toEqual([])
+      // The collaborator DELETE test above clears the fixture row, so a
+      // stale 23505 unique violation can no longer mask an RLS hole — only
+      // the API / RLS denial codes are accepted.
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // Acceptance scenarios from the issue body.
+  // ---------------------------------------------------------------------------
+  describe('acceptance: gameplay actions', () => {
+    it('collaborator CAN INSERT a fresh hunt_survivor row (start a hunt)', async () => {
+      // Create a second survivor on the shared settlement so the new
+      // hunt_survivor row doesn't collide with the seeded one
+      // (unique on hunt_id, survivor_id).
+      const { data: extraSurvivor, error: setupError } = await admin
+        .from('survivor')
+        .insert({
+          settlement_id: fixture.settlementId,
+          gender: 'FEMALE',
+          survivor_name: 'Hunt-Phase Recruit'
+        })
+        .select('id')
+        .single<{ id: string }>()
+      expect(setupError).toBeNull()
+
+      try {
+        const { data: inserted, error: insertError } =
+          await collaborator.client
+            .from('hunt_survivor')
+            .insert({
+              hunt_id: fixture.huntId,
+              settlement_id: fixture.settlementId,
+              survivor_id: extraSurvivor!.id
+            })
+            .select('id, hunt_id, survivor_id')
+            .single()
+        expect(insertError).toBeNull()
+        expect(inserted?.hunt_id).toBe(fixture.huntId)
+        expect(inserted?.survivor_id).toBe(extraSurvivor!.id)
+
+        // Cleanup so the fixture remains stable for subsequent tests.
+        if (inserted?.id)
+          await admin.from('hunt_survivor').delete().eq('id', inserted.id)
+      } finally {
+        await admin.from('survivor').delete().eq('id', extraSurvivor!.id)
+      }
+    })
+
+    it('collaborator CAN advance the showdown (update monster_level + wounds)', async () => {
+      const { data: showdownUpdate, error: showdownErr } =
+        await collaborator.client
+          .from('showdown')
+          .update({ monster_level: 4 })
+          .eq('id', fixture.showdownId)
+          .select('id, monster_level')
+      expect(showdownErr).toBeNull()
+      expect(showdownUpdate?.[0]?.monster_level).toBe(4)
+
+      const { data: monsterUpdate, error: monsterErr } =
+        await collaborator.client
+          .from('showdown_monster')
+          .update({ wounds: 5 })
+          .eq('id', fixture.showdownMonsterId)
+          .select('id, wounds')
+      expect(monsterErr).toBeNull()
+      expect(monsterUpdate?.[0]?.wounds).toBe(5)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.53.0",
+  "version": "0.55.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.53.0",
+      "version": "0.55.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.53.0",
+  "version": "0.55.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260508000005_hunt_showdown_collaborator_crud.sql
+++ b/supabase/migrations/20260508000005_hunt_showdown_collaborator_crud.sql
@@ -1,0 +1,249 @@
+--------------------------------------------------------------------------------
+-- Phase 1.2.d — Collaborator CRUD on Hunt + Showdown Tables
+--
+-- Replace the owner-only SELECT/INSERT/UPDATE/DELETE policies on every hunt
+-- and showdown table with member policies that accept both the settlement
+-- owner AND any user listed in `settlement_shared_user`. Authorization is
+-- delegated to two SECURITY DEFINER helpers so RLS evaluation cannot recurse
+-- into the shared-user table:
+--
+--   * is_settlement_owner(uuid)        -- existing helper
+--   * is_settlement_collaborator(uuid) -- added in
+--                                         20260508000001_is_settlement_collaborator.sql
+--
+-- Two table groupings:
+--
+--   1. Direct-settlement tables (9): the row carries `settlement_id`.
+--      Predicate is the simple disjunction
+--        is_settlement_owner(settlement_id)
+--        or is_settlement_collaborator(settlement_id)
+--      Tables: hunt, hunt_ai_deck, hunt_hunt_board, hunt_monster,
+--              hunt_survivor, showdown, showdown_ai_deck,
+--              showdown_monster, showdown_survivor.
+--
+--   2. Monster-scoped junctions (6): the row carries `hunt_monster_id` or
+--      `showdown_monster_id` (no `settlement_id`). The predicate threads
+--      through the parent monster row:
+--        exists (
+--          select 1 from <hunt|showdown>_monster m
+--          where m.id = <table>.<hunt|showdown>_monster_id
+--            and (
+--              is_settlement_owner(m.settlement_id)
+--              or is_settlement_collaborator(m.settlement_id)
+--            )
+--        )
+--      The inner SELECT against the parent monster is satisfied by the
+--      "Allow select for member" policy created in this same migration.
+--      Tables: hunt_monster_trait, hunt_monster_mood,
+--              hunt_monster_survivor_status, showdown_monster_trait,
+--              showdown_monster_mood, showdown_monster_survivor_status.
+--
+-- SELECT continues to use a single member policy on each table — the
+-- original "Allow select for owner" + "Allow select for shared" pair is
+-- replaced with a single helper-based "Allow select for member" policy.
+-- Two reasons:
+--   * Consistency with INSERT/UPDATE/DELETE — every CRUD verb is now gated
+--     by the same disjunction.
+--   * The 9 direct-settlement tables' "Allow select for shared" policies
+--     contained the same latent correlation bug fixed for the junction
+--     tables in 20260508000002, the phase tables in 20260508000003, and
+--     `survivor` in 20260508000004: their EXISTS subqueries referenced
+--     the unqualified `settlement_id` column, which PostgreSQL resolved
+--     to the subquery's own `su.settlement_id` rather than the outer
+--     row's column. With the correlation lost, any user with any share
+--     could read hunt / showdown rows for every settlement
+--     (cross-settlement leak). The new helper-based policy threads the
+--     row's `settlement_id` through `is_settlement_collaborator()` as a
+--     parameter and closes the leak.
+--
+--     The 6 monster-scoped junctions' SELECT-for-shared policies were
+--     already correctly qualified (they explicitly join through the
+--     parent monster row with an aliased `su`), but they are
+--     consolidated here for symmetry.
+--
+-- Admin bypass policies are untouched.
+--
+-- Reference:
+--   * supabase/migrations/20260223215817_hunt.sql — and siblings: original
+--     owner-only policies on the direct-settlement tables.
+--   * supabase/migrations/20260422000005_hunt_monster_trait_mood.sql,
+--     20260422000006_showdown_monster_trait_mood.sql,
+--     20260424000006_hunt_showdown_monster_survivor_status.sql — original
+--     owner-only policies on the monster-scoped junctions.
+--   * supabase/migrations/20260508000002_settlement_junction_collaborator_crud.sql
+--   * supabase/migrations/20260508000003_settlement_phase_collaborator_crud.sql
+--   * supabase/migrations/20260508000004_survivor_collaborator_crud.sql
+--   * `local/sharing-architecture.md` §5.2 Decision 3 / §10 Phase 1.2.d.
+--
+-- Closes [E1.2.d] (issue #140).
+--------------------------------------------------------------------------------
+--
+-- 1. Direct-settlement tables — settlement_id is on the row.
+--
+do $$
+declare
+  t text;
+  direct_tables text[] := array[
+    'hunt',
+    'hunt_ai_deck',
+    'hunt_hunt_board',
+    'hunt_monster',
+    'hunt_survivor',
+    'showdown',
+    'showdown_ai_deck',
+    'showdown_monster',
+    'showdown_survivor'
+  ];
+begin
+  foreach t in array direct_tables loop
+    execute format('drop policy if exists "Allow select for owner" on %I', t);
+    execute format('drop policy if exists "Allow select for shared" on %I', t);
+    execute format('drop policy if exists "Allow insert for owner" on %I', t);
+    execute format('drop policy if exists "Allow update for owner" on %I', t);
+    execute format('drop policy if exists "Allow delete for owner" on %I', t);
+
+    execute format(
+      $f$create policy "Allow select for member" on %I
+        for select to authenticated using (
+          is_settlement_owner(settlement_id)
+          or is_settlement_collaborator(settlement_id)
+        )$f$,
+      t
+    );
+    execute format(
+      $f$create policy "Allow insert for member" on %I
+        for insert to authenticated with check (
+          is_settlement_owner(settlement_id)
+          or is_settlement_collaborator(settlement_id)
+        )$f$,
+      t
+    );
+    execute format(
+      $f$create policy "Allow update for member" on %I
+        for update to authenticated using (
+          is_settlement_owner(settlement_id)
+          or is_settlement_collaborator(settlement_id)
+        ) with check (
+          is_settlement_owner(settlement_id)
+          or is_settlement_collaborator(settlement_id)
+        )$f$,
+      t
+    );
+    execute format(
+      $f$create policy "Allow delete for member" on %I
+        for delete to authenticated using (
+          is_settlement_owner(settlement_id)
+          or is_settlement_collaborator(settlement_id)
+        )$f$,
+      t
+    );
+  end loop;
+end $$;
+--
+-- 2. Monster-scoped junctions — resolve membership via the parent
+--    hunt_monster / showdown_monster row.
+--
+do $$
+declare
+  spec record;
+begin
+  for spec in
+    select *
+    from (values
+      ('hunt_monster_trait',               'hunt_monster',     'hunt_monster_id'),
+      ('hunt_monster_mood',                'hunt_monster',     'hunt_monster_id'),
+      ('hunt_monster_survivor_status',     'hunt_monster',     'hunt_monster_id'),
+      ('showdown_monster_trait',           'showdown_monster', 'showdown_monster_id'),
+      ('showdown_monster_mood',            'showdown_monster', 'showdown_monster_id'),
+      ('showdown_monster_survivor_status', 'showdown_monster', 'showdown_monster_id')
+    ) as t (child, parent, fk)
+  loop
+    execute format(
+      'drop policy if exists "Allow select for owner" on %I',
+      spec.child
+    );
+    execute format(
+      'drop policy if exists "Allow select for shared" on %I',
+      spec.child
+    );
+    execute format(
+      'drop policy if exists "Allow insert for owner" on %I',
+      spec.child
+    );
+    execute format(
+      'drop policy if exists "Allow update for owner" on %I',
+      spec.child
+    );
+    execute format(
+      'drop policy if exists "Allow delete for owner" on %I',
+      spec.child
+    );
+
+    -- %1 child table, %2 parent table, %3 FK column.
+    execute format(
+      $f$create policy "Allow select for member" on %1$I
+        for select to authenticated using (
+          exists (
+            select 1 from %2$I m
+            where m.id = %1$I.%3$I
+              and (
+                is_settlement_owner(m.settlement_id)
+                or is_settlement_collaborator(m.settlement_id)
+              )
+          )
+        )$f$,
+      spec.child, spec.parent, spec.fk
+    );
+    execute format(
+      $f$create policy "Allow insert for member" on %1$I
+        for insert to authenticated with check (
+          exists (
+            select 1 from %2$I m
+            where m.id = %1$I.%3$I
+              and (
+                is_settlement_owner(m.settlement_id)
+                or is_settlement_collaborator(m.settlement_id)
+              )
+          )
+        )$f$,
+      spec.child, spec.parent, spec.fk
+    );
+    execute format(
+      $f$create policy "Allow update for member" on %1$I
+        for update to authenticated using (
+          exists (
+            select 1 from %2$I m
+            where m.id = %1$I.%3$I
+              and (
+                is_settlement_owner(m.settlement_id)
+                or is_settlement_collaborator(m.settlement_id)
+              )
+          )
+        ) with check (
+          exists (
+            select 1 from %2$I m
+            where m.id = %1$I.%3$I
+              and (
+                is_settlement_owner(m.settlement_id)
+                or is_settlement_collaborator(m.settlement_id)
+              )
+          )
+        )$f$,
+      spec.child, spec.parent, spec.fk
+    );
+    execute format(
+      $f$create policy "Allow delete for member" on %1$I
+        for delete to authenticated using (
+          exists (
+            select 1 from %2$I m
+            where m.id = %1$I.%3$I
+              and (
+                is_settlement_owner(m.settlement_id)
+                or is_settlement_collaborator(m.settlement_id)
+              )
+          )
+        )$f$,
+      spec.child, spec.parent, spec.fk
+    );
+  end loop;
+end $$;

--- a/supabase/migrations/20260508000005_hunt_showdown_collaborator_crud.sql
+++ b/supabase/migrations/20260508000005_hunt_showdown_collaborator_crud.sql
@@ -81,9 +81,8 @@
 -- 1. Direct-settlement tables — settlement_id is on the row.
 --
 do $$
-declare
-  t text;
-  direct_tables text[] := array[
+declare t text;
+direct_tables text [] := array [
     'hunt',
     'hunt_ai_deck',
     'hunt_hunt_board',
@@ -94,156 +93,198 @@ declare
     'showdown_monster',
     'showdown_survivor'
   ];
-begin
-  foreach t in array direct_tables loop
-    execute format('drop policy if exists "Allow select for owner" on %I', t);
-    execute format('drop policy if exists "Allow select for shared" on %I', t);
-    execute format('drop policy if exists "Allow insert for owner" on %I', t);
-    execute format('drop policy if exists "Allow update for owner" on %I', t);
-    execute format('drop policy if exists "Allow delete for owner" on %I', t);
-
-    execute format(
-      $f$create policy "Allow select for member" on %I
-        for select to authenticated using (
-          is_settlement_owner(settlement_id)
-          or is_settlement_collaborator(settlement_id)
-        )$f$,
-      t
-    );
-    execute format(
-      $f$create policy "Allow insert for member" on %I
-        for insert to authenticated with check (
-          is_settlement_owner(settlement_id)
-          or is_settlement_collaborator(settlement_id)
-        )$f$,
-      t
-    );
-    execute format(
-      $f$create policy "Allow update for member" on %I
-        for update to authenticated using (
-          is_settlement_owner(settlement_id)
-          or is_settlement_collaborator(settlement_id)
-        ) with check (
-          is_settlement_owner(settlement_id)
-          or is_settlement_collaborator(settlement_id)
-        )$f$,
-      t
-    );
-    execute format(
-      $f$create policy "Allow delete for member" on %I
-        for delete to authenticated using (
-          is_settlement_owner(settlement_id)
-          or is_settlement_collaborator(settlement_id)
-        )$f$,
-      t
-    );
-  end loop;
+begin foreach t in array direct_tables loop execute format(
+  'drop policy if exists "Allow select for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow select for shared" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow insert for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow update for owner" on %I',
+  t
+);
+execute format(
+  'drop policy if exists "Allow delete for owner" on %I',
+  t
+);
+execute format(
+  $f$create policy "Allow select for member" on %I for
+  select to authenticated using (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $f$,
+    t
+);
+execute format(
+  $f$create policy "Allow insert for member" on %I for
+  insert to authenticated with check (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $f$,
+    t
+);
+execute format(
+  $f$create policy "Allow update for member" on %I for
+  update to authenticated using (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) with check (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $f$,
+    t
+);
+execute format(
+  $f$create policy "Allow delete for member" on %I for delete to authenticated using (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  ) $f$,
+  t
+);
+end loop;
 end $$;
 --
 -- 2. Monster-scoped junctions — resolve membership via the parent
 --    hunt_monster / showdown_monster row.
 --
 do $$
-declare
-  spec record;
-begin
-  for spec in
-    select *
-    from (values
-      ('hunt_monster_trait',               'hunt_monster',     'hunt_monster_id'),
-      ('hunt_monster_mood',                'hunt_monster',     'hunt_monster_id'),
-      ('hunt_monster_survivor_status',     'hunt_monster',     'hunt_monster_id'),
-      ('showdown_monster_trait',           'showdown_monster', 'showdown_monster_id'),
-      ('showdown_monster_mood',            'showdown_monster', 'showdown_monster_id'),
-      ('showdown_monster_survivor_status', 'showdown_monster', 'showdown_monster_id')
-    ) as t (child, parent, fk)
-  loop
-    execute format(
-      'drop policy if exists "Allow select for owner" on %I',
-      spec.child
-    );
-    execute format(
-      'drop policy if exists "Allow select for shared" on %I',
-      spec.child
-    );
-    execute format(
-      'drop policy if exists "Allow insert for owner" on %I',
-      spec.child
-    );
-    execute format(
-      'drop policy if exists "Allow update for owner" on %I',
-      spec.child
-    );
-    execute format(
-      'drop policy if exists "Allow delete for owner" on %I',
-      spec.child
-    );
-
-    -- %1 child table, %2 parent table, %3 FK column.
-    execute format(
-      $f$create policy "Allow select for member" on %1$I
-        for select to authenticated using (
-          exists (
-            select 1 from %2$I m
-            where m.id = %1$I.%3$I
-              and (
-                is_settlement_owner(m.settlement_id)
-                or is_settlement_collaborator(m.settlement_id)
-              )
+declare spec record;
+begin for spec in
+select *
+from (
+    values (
+        'hunt_monster_trait',
+        'hunt_monster',
+        'hunt_monster_id'
+      ),
+      (
+        'hunt_monster_mood',
+        'hunt_monster',
+        'hunt_monster_id'
+      ),
+      (
+        'hunt_monster_survivor_status',
+        'hunt_monster',
+        'hunt_monster_id'
+      ),
+      (
+        'showdown_monster_trait',
+        'showdown_monster',
+        'showdown_monster_id'
+      ),
+      (
+        'showdown_monster_mood',
+        'showdown_monster',
+        'showdown_monster_id'
+      ),
+      (
+        'showdown_monster_survivor_status',
+        'showdown_monster',
+        'showdown_monster_id'
+      )
+  ) as t (child, parent, fk) loop execute format(
+    'drop policy if exists "Allow select for owner" on %I',
+    spec.child
+  );
+execute format(
+  'drop policy if exists "Allow select for shared" on %I',
+  spec.child
+);
+execute format(
+  'drop policy if exists "Allow insert for owner" on %I',
+  spec.child
+);
+execute format(
+  'drop policy if exists "Allow update for owner" on %I',
+  spec.child
+);
+execute format(
+  'drop policy if exists "Allow delete for owner" on %I',
+  spec.child
+);
+-- %1 child table, %2 parent table, %3 FK column.
+execute format(
+  $f$create policy "Allow select for member" on %1$I for
+  select to authenticated using (
+      exists (
+        select 1
+        from %2$I m
+        where m.id = %1$I. %3$I
+          and (
+            is_settlement_owner(m.settlement_id)
+            or is_settlement_collaborator(m.settlement_id)
           )
-        )$f$,
-      spec.child, spec.parent, spec.fk
-    );
-    execute format(
-      $f$create policy "Allow insert for member" on %1$I
-        for insert to authenticated with check (
-          exists (
-            select 1 from %2$I m
-            where m.id = %1$I.%3$I
-              and (
-                is_settlement_owner(m.settlement_id)
-                or is_settlement_collaborator(m.settlement_id)
-              )
+      )
+    ) $f$,
+    spec.child,
+    spec.parent,
+    spec.fk
+);
+execute format(
+  $f$create policy "Allow insert for member" on %1$I for
+  insert to authenticated with check (
+      exists (
+        select 1
+        from %2$I m
+        where m.id = %1$I. %3$I
+          and (
+            is_settlement_owner(m.settlement_id)
+            or is_settlement_collaborator(m.settlement_id)
           )
-        )$f$,
-      spec.child, spec.parent, spec.fk
-    );
-    execute format(
-      $f$create policy "Allow update for member" on %1$I
-        for update to authenticated using (
-          exists (
-            select 1 from %2$I m
-            where m.id = %1$I.%3$I
-              and (
-                is_settlement_owner(m.settlement_id)
-                or is_settlement_collaborator(m.settlement_id)
-              )
+      )
+    ) $f$,
+    spec.child,
+    spec.parent,
+    spec.fk
+);
+execute format(
+  $f$create policy "Allow update for member" on %1$I for
+  update to authenticated using (
+      exists (
+        select 1
+        from %2$I m
+        where m.id = %1$I. %3$I
+          and (
+            is_settlement_owner(m.settlement_id)
+            or is_settlement_collaborator(m.settlement_id)
           )
-        ) with check (
-          exists (
-            select 1 from %2$I m
-            where m.id = %1$I.%3$I
-              and (
-                is_settlement_owner(m.settlement_id)
-                or is_settlement_collaborator(m.settlement_id)
-              )
+      )
+    ) with check (
+      exists (
+        select 1
+        from %2$I m
+        where m.id = %1$I. %3$I
+          and (
+            is_settlement_owner(m.settlement_id)
+            or is_settlement_collaborator(m.settlement_id)
           )
-        )$f$,
-      spec.child, spec.parent, spec.fk
-    );
-    execute format(
-      $f$create policy "Allow delete for member" on %1$I
-        for delete to authenticated using (
-          exists (
-            select 1 from %2$I m
-            where m.id = %1$I.%3$I
-              and (
-                is_settlement_owner(m.settlement_id)
-                or is_settlement_collaborator(m.settlement_id)
-              )
-          )
-        )$f$,
-      spec.child, spec.parent, spec.fk
-    );
-  end loop;
+      )
+    ) $f$,
+    spec.child,
+    spec.parent,
+    spec.fk
+);
+execute format(
+  $f$create policy "Allow delete for member" on %1$I for delete to authenticated using (
+    exists (
+      select 1
+      from %2$I m
+      where m.id = %1$I. %3$I
+        and (
+          is_settlement_owner(m.settlement_id)
+          or is_settlement_collaborator(m.settlement_id)
+        )
+    )
+  ) $f$,
+  spec.child,
+  spec.parent,
+  spec.fk
+);
+end loop;
 end $$;


### PR DESCRIPTION
## Summary

Closes #140 (E1.2.d of the sharing-architecture rollout).

Loosens RLS on every hunt and showdown table from owner-only to "owner OR
collaborator" CRUD, mirroring the helper-based pattern adopted in #135 (E1.2.a),
#138 (E1.2.b), and #145 (E1.2.c). Collaborators on a shared settlement can now
start hunts, edit AI decks, mutate the hunt board, and advance showdowns
exactly as the owner does. Strangers remain locked out, and admins keep their
bypass.

## Changes

### Migration — `supabase/migrations/20260508000005_hunt_showdown_collaborator_crud.sql`

Two `do` blocks rewrite the policies on 15 tables.

**Direct-settlement (9 tables)** — predicate is the simple disjunction
`is_settlement_owner(settlement_id) or is_settlement_collaborator(settlement_id)`:

- `hunt`
- `hunt_ai_deck`
- `hunt_hunt_board`
- `hunt_monster`
- `hunt_survivor`
- `showdown`
- `showdown_ai_deck`
- `showdown_monster`
- `showdown_survivor`

**Monster-scoped junctions (6 tables)** — predicate threads through the parent
`hunt_monster` / `showdown_monster` row's `settlement_id`:

- `hunt_monster_trait`, `hunt_monster_mood`, `hunt_monster_survivor_status`
- `showdown_monster_trait`, `showdown_monster_mood`, `showdown_monster_survivor_status`

The 6 monster junctions were already correctly qualified pre-rewrite, but they
are consolidated into the same helper-based form so the matrix is symmetric and
future audits stay simple.

### Latent SELECT-for-shared correlation bug — fixed

The original policies on the 9 direct-settlement tables used:

```sql
exists (
  select 1 from settlement_shared_user su
  where settlement_id = su.settlement_id and su.shared_user_id = auth.uid()
)
```

PostgreSQL resolves both unqualified `settlement_id` references to the inner
`su.settlement_id`, dropping outer-row correlation entirely. The result was a
cross-settlement read leak for any user with at least one accepted share — the
exact same root cause already fixed in #135, #138, and #145. The new
helper-based policies thread `settlement_id` through a function argument, so
the leak cannot recur.

### Tests — `__tests__/integration/rls/hunt-showdown-collaborator-crud.test.ts`

62 cases covering, across all 15 tables:

- collaborator CAN SELECT seeded rows; stranger CANNOT
- collaborator CAN UPDATE every table with a mutable column; stranger CANNOT
- collaborator CAN DELETE + re-INSERT each monster-scoped junction; stranger
  cannot INSERT against a foreign monster (and the seeded row is removed
  before that assertion, so a stale `23505` cannot mask an RLS hole)
- acceptance scenarios from the issue body: collaborator starts a hunt
  (`hunt_survivor` insert) and advances the showdown (`showdown.monster_level`
  + `showdown_monster.wounds` updates)

The existing cross-user denial matrix in
`__tests__/integration/rls/settlement-scoped.test.ts` continues to pass
unmodified — strangers remain denied across all 15 tables.

### Versioning

`0.53.0` → `0.55.0` (skipping `0.54.0` because PR #199 / E1.2.c already
reserves it; this avoids a parallel-PR merge conflict).

## Verification

- `npm run db:reset` — clean apply.
- `select tablename, count(*) from pg_policies where tablename in (...)` — 5
  policies × 15 tables = 75 rows, all named `Allow {select|insert|update|delete}
  for member` plus `Allow all for admin`.
- `npm run integration-test` — 15 files, 565 tests, all passing.
- `npm test --silent -- --no-coverage` — 119 files, 2091 tests, all passing.

## Acceptance Criteria (from #140)

> Collaborator can start a hunt, edit AI deck, mutate hunt board, advance
> showdown. Owner retains full CRUD.

✅ Direct INSERT (start a hunt) — covered by the `hunt_survivor` acceptance
test.<br>
✅ Edit AI deck — covered by the `hunt_ai_deck` / `showdown_ai_deck` UPDATE
matrix.<br>
✅ Mutate hunt board — covered by the `hunt_hunt_board` UPDATE matrix.<br>
✅ Advance showdown — covered by the showdown acceptance test.<br>
✅ Owner CRUD untouched — owner predicate disjuncts the existing
`is_settlement_owner` helper, identical to pre-PR behavior for owners.

## Out of Scope

Other gameplay tables — handled in #135 / #138 / #145 (E1.2.a / E1.2.b /
E1.2.c).

## Dependencies

- Blocked by: #143 (E1.1, merged in v0.51.0) — provides the
  `is_settlement_collaborator` helper.
- Blocks: #134 (E1.11) — UI/DAL audit can now assume collaborator parity on
  hunt + showdown.
