### PR TITLE
feat(rls): hybrid settlement UPDATE policy + owner-only column trigger (#133)

### DIFF
--- a/__tests__/integration/rls/settlement-hybrid-update.test.ts
+++ b/__tests__/integration/rls/settlement-hybrid-update.test.ts
@@ -112,7 +112,11 @@ describe('RLS: hybrid settlement UPDATE policy', () => {
         .select('id')
 
       expect(error).not.toBeNull()
-      expect(error?.code).toMatch(/0A000|PGRST/)
+      // Strict check on the exact SQLSTATE raised by
+      // `enforce_settlement_owner_only_columns` — a generic PGRST* error
+      // would mean the request was denied earlier (e.g. by RLS) and the
+      // trigger never fired.
+      expect(error?.code).toBe('0A000')
       expect(data ?? []).toHaveLength(0)
 
       const { data: after } = await admin
@@ -133,7 +137,7 @@ describe('RLS: hybrid settlement UPDATE policy', () => {
       .eq('id', settlementId)
       .select('id')
     expect(error).not.toBeNull()
-    expect(error?.code).toMatch(/0A000|PGRST/)
+    expect(error?.code).toBe('0A000')
     expect(data ?? []).toHaveLength(0)
 
     const { data: after } = await admin
@@ -175,6 +179,33 @@ describe('RLS: hybrid settlement UPDATE policy', () => {
         uses_scouts: false
       })
       .eq('id', settlementId)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Immutable columns — both owner and collaborator are blocked from
+  // changing `id` / `created_at`. The trigger raises before the
+  // owner-only-column branch is consulted, so the error code is the same.
+  // ---------------------------------------------------------------------------
+  it('owner CANNOT UPDATE created_at (immutable)', async () => {
+    const { data, error } = await owner.client
+      .from('settlement')
+      .update({ created_at: '2000-01-01T00:00:00Z' })
+      .eq('id', settlementId)
+      .select('id')
+    expect(error).not.toBeNull()
+    expect(error?.code).toBe('0A000')
+    expect(data ?? []).toHaveLength(0)
+  })
+
+  it('collaborator CANNOT UPDATE created_at (immutable)', async () => {
+    const { data, error } = await collaborator.client
+      .from('settlement')
+      .update({ created_at: '2000-01-01T00:00:00Z' })
+      .eq('id', settlementId)
+      .select('id')
+    expect(error).not.toBeNull()
+    expect(error?.code).toBe('0A000')
+    expect(data ?? []).toHaveLength(0)
   })
 
   // ---------------------------------------------------------------------------

--- a/__tests__/integration/rls/settlement-hybrid-update.test.ts
+++ b/__tests__/integration/rls/settlement-hybrid-update.test.ts
@@ -1,0 +1,202 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Hybrid `settlement` UPDATE Policy
+ *
+ * Phase 1.3 (issue #133) replaces the old "owner OR shared full" pair of
+ * UPDATE policies on `settlement` with a single helper-based "member"
+ * policy plus a BEFORE UPDATE trigger that guards owner-only metadata
+ * columns.
+ *
+ * Owner-only columns (collaborator UPDATE must raise `feature_not_supported`):
+ *   `settlement_name`, `campaign_type`, `survivor_type`, `uses_scouts`,
+ *   `user_id`.
+ *
+ * Collaborator-editable columns (collaborator UPDATE succeeds):
+ *   `arrival_bonuses`, `current_year`, `departing_bonuses`, `notes`,
+ *   `survival_limit`, `lantern_research`, `monster_volumes`.
+ *
+ * Stranger UPDATE on every column is denied by RLS (no member predicate).
+ */
+describe('RLS: hybrid settlement UPDATE policy', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let settlementId: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+    settlementId = await seedSettlement(owner.id, 'Hybrid Test Settlement')
+    await shareSettlement(settlementId, collaborator.id, owner.id)
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Collaborator-editable columns — UPDATE must succeed.
+  // ---------------------------------------------------------------------------
+  type EditableColumn = {
+    column: string
+    value: unknown
+    expected?: unknown
+  }
+  const editableColumns: EditableColumn[] = [
+    { column: 'arrival_bonuses', value: ['Arrival 1', 'Arrival 2'] },
+    { column: 'current_year', value: 5 },
+    { column: 'departing_bonuses', value: ['Departing 1'] },
+    { column: 'notes', value: 'Lanterns flicker against the dark.' },
+    { column: 'survival_limit', value: 9 },
+    { column: 'lantern_research', value: 3 },
+    { column: 'monster_volumes', value: ['White Lion'] }
+  ]
+
+  it.each(editableColumns)(
+    'collaborator CAN UPDATE $column',
+    async ({ column, value, expected }) => {
+      const { data, error } = await collaborator.client
+        .from('settlement')
+        .update({ [column]: value })
+        .eq('id', settlementId)
+        .select(`id, ${column}`)
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+      const row = data![0] as unknown as Record<string, unknown>
+      expect(row[column]).toEqual(expected ?? value)
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // Owner-only columns — collaborator UPDATE must raise the trigger error.
+  // ---------------------------------------------------------------------------
+  type OwnerOnlyColumn = {
+    column: string
+    value: unknown
+  }
+  const ownerOnlyColumns: OwnerOnlyColumn[] = [
+    { column: 'settlement_name', value: 'GUEST WAS HERE' },
+    { column: 'campaign_type', value: 'PEOPLE_OF_THE_SUN' },
+    { column: 'survivor_type', value: 'ARC' },
+    { column: 'uses_scouts', value: true }
+  ]
+
+  it.each(ownerOnlyColumns)(
+    'collaborator CANNOT UPDATE $column (trigger raises feature_not_supported)',
+    async ({ column, value }) => {
+      // Capture the current owner-controlled value so we can assert the
+      // trigger left it untouched.
+      const { data: before } = await admin
+        .from('settlement')
+        .select(column)
+        .eq('id', settlementId)
+        .single<Record<string, unknown>>()
+      const previousValue = before?.[column]
+
+      const { data, error } = await collaborator.client
+        .from('settlement')
+        .update({ [column]: value })
+        .eq('id', settlementId)
+        .select('id')
+
+      expect(error).not.toBeNull()
+      expect(error?.code).toMatch(/0A000|PGRST/)
+      expect(data ?? []).toHaveLength(0)
+
+      const { data: after } = await admin
+        .from('settlement')
+        .select(column)
+        .eq('id', settlementId)
+        .single<Record<string, unknown>>()
+      expect(after?.[column]).toEqual(previousValue)
+    }
+  )
+
+  // user_id needs a real, valid uuid to bypass FK; the trigger should fire
+  // regardless because the column is in the owner-only list.
+  it('collaborator CANNOT UPDATE user_id (trigger raises feature_not_supported)', async () => {
+    const { data, error } = await collaborator.client
+      .from('settlement')
+      .update({ user_id: collaborator.id })
+      .eq('id', settlementId)
+      .select('id')
+    expect(error).not.toBeNull()
+    expect(error?.code).toMatch(/0A000|PGRST/)
+    expect(data ?? []).toHaveLength(0)
+
+    const { data: after } = await admin
+      .from('settlement')
+      .select('user_id')
+      .eq('id', settlementId)
+      .single<{ user_id: string }>()
+    expect(after?.user_id).toBe(owner.id)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Owner — full CRUD on every column, including owner-only metadata.
+  // ---------------------------------------------------------------------------
+  it('owner CAN UPDATE every owner-only column', async () => {
+    const { data, error } = await owner.client
+      .from('settlement')
+      .update({
+        settlement_name: 'Renamed By Owner',
+        campaign_type: 'PEOPLE_OF_THE_SUN',
+        survivor_type: 'ARC',
+        uses_scouts: true
+      })
+      .eq('id', settlementId)
+      .select('id, settlement_name, campaign_type, survivor_type, uses_scouts')
+      .single()
+    expect(error).toBeNull()
+    expect(data?.settlement_name).toBe('Renamed By Owner')
+    expect(data?.campaign_type).toBe('PEOPLE_OF_THE_SUN')
+    expect(data?.survivor_type).toBe('ARC')
+    expect(data?.uses_scouts).toBe(true)
+
+    // Restore initial values for any later assertions.
+    await owner.client
+      .from('settlement')
+      .update({
+        settlement_name: 'Hybrid Test Settlement',
+        campaign_type: 'PEOPLE_OF_THE_LANTERN',
+        survivor_type: 'CORE',
+        uses_scouts: false
+      })
+      .eq('id', settlementId)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Stranger — RLS denies before the trigger ever runs.
+  // ---------------------------------------------------------------------------
+  it('stranger CANNOT UPDATE editable columns (RLS denial)', async () => {
+    const { data, error } = await stranger.client
+      .from('settlement')
+      .update({ notes: 'stranger edit' })
+      .eq('id', settlementId)
+      .select('id')
+    expect(data ?? []).toEqual([])
+    if (error) expect(error.code).toMatch(/PGRST|42501/)
+  })
+
+  it('stranger CANNOT UPDATE owner-only columns (RLS denial)', async () => {
+    const { data, error } = await stranger.client
+      .from('settlement')
+      .update({ settlement_name: 'stranger rename' })
+      .eq('id', settlementId)
+      .select('id')
+    expect(data ?? []).toEqual([])
+    if (error) expect(error.code).toMatch(/PGRST|42501/)
+  })
+})

--- a/__tests__/integration/rls/settlement-shared.test.ts
+++ b/__tests__/integration/rls/settlement-shared.test.ts
@@ -91,9 +91,11 @@ describe('RLS: shared-user access on settlement', () => {
       .select('id')
 
     expect(error).not.toBeNull()
-    // PGRST204 / 0A000 (feature_not_supported) — Postgres surfaces the
-    // raise in the trigger via PostgREST as the SQLSTATE code.
-    expect(error?.code).toMatch(/0A000|PGRST/)
+    // Strict check on the exact SQLSTATE raised by
+    // `enforce_settlement_owner_only_columns`. A generic PGRST* code would
+    // mean the request was denied earlier (e.g. by RLS), which is not what
+    // this test pins.
+    expect(error?.code).toBe('0A000')
     expect(data ?? []).toHaveLength(0)
 
     // Confirm the row was not modified.

--- a/__tests__/integration/rls/settlement-shared.test.ts
+++ b/__tests__/integration/rls/settlement-shared.test.ts
@@ -77,31 +77,31 @@ describe('RLS: shared-user access on settlement', () => {
     expect(data).toHaveLength(1)
   })
 
-  // The `Allow update for shared` RLS policy on `settlement` permits any user
-  // listed in `settlement_shared_user` to mutate the settlement, even though
-  // the DAL historically treated them as read-only. This test pins that
-  // decision so any future tightening is deliberate.
-  it('guest CAN update settlement_name (documents shared write-access)', async () => {
+  // Phase 1.3 (issue #133): the `Allow update for member` policy lets
+  // collaborators pass RLS, but the `enforce_settlement_owner_only_columns`
+  // BEFORE UPDATE trigger raises `feature_not_supported` (SQLSTATE 0A000)
+  // when a non-owner mutates settlement metadata. The previous version of
+  // this test pinned the looser behaviour; it is now an explicit denial
+  // assertion.
+  it('guest CANNOT update settlement_name (owner-only column)', async () => {
     const { data, error } = await guest.client
       .from('settlement')
       .update({ settlement_name: 'GUEST WAS HERE' })
       .eq('id', settlementId)
       .select('id')
-    expect(error).toBeNull()
-    expect(data ?? []).toHaveLength(1)
 
+    expect(error).not.toBeNull()
+    // PGRST204 / 0A000 (feature_not_supported) — Postgres surfaces the
+    // raise in the trigger via PostgREST as the SQLSTATE code.
+    expect(error?.code).toMatch(/0A000|PGRST/)
+    expect(data ?? []).toHaveLength(0)
+
+    // Confirm the row was not modified.
     const { data: check } = await owner.client
       .from('settlement')
       .select('settlement_name')
       .eq('id', settlementId)
       .single()
-    expect(check?.settlement_name).toBe('GUEST WAS HERE')
-
-    // Restore the original name so later assertions in this suite still
-    // observe the owner-provided value.
-    await owner.client
-      .from('settlement')
-      .update({ settlement_name: 'Shared Test Settlement' })
-      .eq('id', settlementId)
+    expect(check?.settlement_name).toBe('Shared Test Settlement')
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.55.0",
+      "version": "0.56.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260509000000_settlement_hybrid_update_policy.sql
+++ b/supabase/migrations/20260509000000_settlement_hybrid_update_policy.sql
@@ -1,0 +1,90 @@
+--------------------------------------------------------------------------------
+-- Phase 1.3 — Hybrid `settlement` UPDATE Policy (Decision 4 / OVERRIDE)
+--
+-- Replace the previous "owner-only OR shared-full" pair of UPDATE policies on
+-- `settlement` with a hybrid model: collaborators may update gameplay-relevant
+-- columns, while owner-only metadata is enforced by a row-level trigger that
+-- raises `feature_not_supported` when a non-owner tries to mutate it.
+--
+-- RLS layer
+-- ---------
+--   * Drop "Allow update for shared" (full-row update for any collaborator).
+--   * Drop "Allow update for owner".
+--   * Add "Allow update for member" — both `is_settlement_owner(id)` and
+--     `is_settlement_collaborator(id)` satisfy USING/WITH CHECK. Column-level
+--     enforcement happens in the trigger below.
+--
+-- Trigger
+-- -------
+--   * `enforce_settlement_owner_only_columns()` — BEFORE UPDATE row trigger,
+--     SECURITY INVOKER (default) so `auth.uid()` resolves to the calling
+--     user. If the caller is the row's owner (or the trigger is running
+--     outside an authenticated session, e.g. service role / direct DB
+--     access), it returns NEW unchanged. Otherwise it raises SQLSTATE
+--     `feature_not_supported` (0A000) when any of the owner-only columns
+--     would change between OLD and NEW.
+--   * `is_admin()` callers are also bypassed so the existing
+--     "Allow all for admin" policy continues to govern admin behaviour.
+--
+-- Owner-only columns (collaborators denied):
+--   `settlement_name`, `campaign_type`, `survivor_type`, `uses_scouts`,
+--   `user_id`.
+--
+-- Collaborator-editable columns (allowed by RLS, no trigger guard):
+--   `arrival_bonuses`, `current_year`, `departing_bonuses`, `notes`,
+--   `survival_limit`, `lantern_research`, `monster_volumes`.
+--
+-- Reference:
+--   * `local/sharing-architecture.md` §5.2 Decision 4 (with OVERRIDE) /
+--     §10 Phase 1.3.
+--   * supabase/migrations/20260220190650_settlement.sql — original RLS.
+--
+-- Closes [E1.3] (issue #133).
+--------------------------------------------------------------------------------
+--
+-- 1. Replace the UPDATE policies with a single helper-based "member" policy.
+--
+drop policy if exists "Allow update for shared" on settlement;
+drop policy if exists "Allow update for owner" on settlement;
+create policy "Allow update for member" on settlement for
+update to authenticated using (
+    is_settlement_owner(id)
+    or is_settlement_collaborator(id)
+  ) with check (
+    is_settlement_owner(id)
+    or is_settlement_collaborator(id)
+  );
+--
+-- 2. Trigger function — guard owner-only columns.
+--
+create or replace function enforce_settlement_owner_only_columns()
+returns trigger language plpgsql security invoker
+set search_path = '' as $$
+declare caller uuid := auth.uid();
+begin -- Bypass for service role / direct DB connections (no auth context),
+-- the row owner, or admins.
+if caller is null
+or caller = old.user_id
+or public.is_admin() then return new;
+end if;
+-- Non-owner caller: every owner-only column must remain unchanged.
+if new.settlement_name is distinct
+from old.settlement_name
+  or new.campaign_type is distinct
+from old.campaign_type
+  or new.survivor_type is distinct
+from old.survivor_type
+  or new.uses_scouts is distinct
+from old.uses_scouts
+  or new.user_id is distinct
+from old.user_id then raise exception 'Only the settlement owner can change settlement_name, campaign_type, survivor_type, uses_scouts, or user_id' using errcode = 'feature_not_supported';
+end if;
+return new;
+end;
+$$;
+--
+-- 3. Attach the trigger.
+--
+drop trigger if exists enforce_settlement_owner_only_columns on settlement;
+create trigger enforce_settlement_owner_only_columns before
+update on settlement for each row execute function enforce_settlement_owner_only_columns();

--- a/supabase/migrations/20260509000000_settlement_hybrid_update_policy.sql
+++ b/supabase/migrations/20260509000000_settlement_hybrid_update_policy.sql
@@ -18,17 +18,29 @@
 -- -------
 --   * `enforce_settlement_owner_only_columns()` — BEFORE UPDATE row trigger,
 --     SECURITY INVOKER (default) so `auth.uid()` resolves to the calling
---     user. If the caller is the row's owner (or the trigger is running
---     outside an authenticated session, e.g. service role / direct DB
---     access), it returns NEW unchanged. Otherwise it raises SQLSTATE
---     `feature_not_supported` (0A000) when any of the owner-only columns
---     would change between OLD and NEW.
---   * `is_admin()` callers are also bypassed so the existing
---     "Allow all for admin" policy continues to govern admin behaviour.
+--     user. Decision flow:
+--       1. Service role / direct-DB callers (`auth.uid() is null`) and
+--          admins return NEW unchanged. They may need to fix data via
+--          migrations.
+--       2. All other authenticated callers — owner included — are blocked
+--          from changing the immutable `id` / `created_at` columns.
+--       3. The owner returns NEW unchanged for everything else.
+--       4. Collaborators are blocked from mutating any of the owner-only
+--          columns.
+--     All blocking branches raise SQLSTATE `feature_not_supported`
+--     (`0A000`).
 --
 -- Owner-only columns (collaborators denied):
 --   `settlement_name`, `campaign_type`, `survivor_type`, `uses_scouts`,
 --   `user_id`.
+--
+-- Immutable columns (every non-owner caller denied; owner is also blocked
+-- because mutating the row's primary key or audit timestamp is never the
+-- intended UI flow):
+--   `id`, `created_at`.
+--
+-- `updated_at` is intentionally left unguarded; it is rewritten in place by
+-- the `set_updated_at` trigger that runs immediately after this one.
 --
 -- Collaborator-editable columns (allowed by RLS, no trigger guard):
 --   `arrival_bonuses`, `current_year`, `departing_bonuses`, `notes`,
@@ -61,13 +73,24 @@ create or replace function enforce_settlement_owner_only_columns()
 returns trigger language plpgsql security invoker
 set search_path = '' as $$
 declare caller uuid := auth.uid();
-begin -- Bypass for service role / direct DB connections (no auth context),
--- the row owner, or admins.
+begin -- Bypass for service role / direct DB connections (no auth context) and
+-- admins. They may need to fix or backfill data via migrations.
 if caller is null
-or caller = old.user_id
 or public.is_admin() then return new;
 end if;
--- Non-owner caller: every owner-only column must remain unchanged.
+-- Authenticated callers (owner OR collaborator) must not change the
+-- immutable identity / audit columns. There is no UI flow that mutates
+-- these.
+if new.id is distinct
+from old.id
+  or new.created_at is distinct
+from old.created_at then raise exception 'settlement.id and settlement.created_at are immutable' using errcode = 'feature_not_supported';
+end if;
+-- Owner has full authority over the remaining columns.
+if caller = old.user_id then return new;
+end if;
+-- Non-owner caller (collaborator): every owner-only column must remain
+-- unchanged.
 if new.settlement_name is distinct
 from old.settlement_name
   or new.campaign_type is distinct


### PR DESCRIPTION
## Summary

Closes #133 (E1.3 of the sharing-architecture rollout).

Replaces the prior "owner-only" + "shared-full" pair of UPDATE policies on
`settlement` with a single helper-based "member" policy plus a BEFORE UPDATE
trigger that guards owner-only metadata columns. Implements Decision 4 with
OVERRIDE from `local/sharing-architecture.md` §5.2 / §10 Phase 1.3.

## Changes

### Migration — `supabase/migrations/20260509000000_settlement_hybrid_update_policy.sql`

**RLS layer** — replaces the old policies with a single `Allow update for member`:

```sql
drop policy if exists "Allow update for shared"  on settlement;
drop policy if exists "Allow update for owner"   on settlement;

create policy "Allow update for member" on settlement for
update to authenticated using (
  is_settlement_owner(id)
  or is_settlement_collaborator(id)
) with check (
  is_settlement_owner(id)
  or is_settlement_collaborator(id)
);
```

**Trigger** — `enforce_settlement_owner_only_columns()` (BEFORE UPDATE, row,
SECURITY INVOKER, locked `search_path`). Bypasses for service role /
direct-DB callers (`auth.uid() is null`), the row owner, and admins. For
collaborators, raises SQLSTATE `feature_not_supported` (`0A000`) if any of
the owner-only columns would change.

| Group | Columns |
| --- | --- |
| Owner-only (collaborators denied) | `settlement_name`, `campaign_type`, `survivor_type`, `uses_scouts`, `user_id` |
| Collaborator-editable | `arrival_bonuses`, `current_year`, `departing_bonuses`, `notes`, `survival_limit`, `lantern_research`, `monster_volumes` |

### Tests

**New** — `__tests__/integration/rls/settlement-hybrid-update.test.ts` (15 cases):

- Collaborator CAN update each of the 7 gameplay-relevant columns.
- Collaborator CANNOT update each of the 5 owner-only columns; assertion checks
  `error.code` matches `/0A000|PGRST/` and that the original value is
  preserved (read back via the admin client).
- Owner CAN update every owner-only column (and is restored afterward).
- Stranger denied on both column groups via the unchanged RLS denial path.

**Inverted** — `__tests__/integration/rls/settlement-shared.test.ts:78-105`:
the previous "guest CAN update `settlement_name` (documents shared write
access)" pinning test is replaced with a denial assertion, matching the
acceptance criteria called out in #133.

### Versioning

`0.55.0` → `0.56.0`.

## Verification

- `npm run db:reset` — clean apply.
- `select policyname, cmd from pg_policies where tablename='settlement'` →
  6 policies, single `UPDATE / Allow update for member`.
- `select tgname from pg_trigger where tgrelid = 'public.settlement'::regclass` →
  `enforce_settlement_owner_only_columns`, `set_updated_at`.
- `npm run integration-test` — 17 files / 613 tests passing.
- `npm test` — 119 files / 2091 tests passing.

## Acceptance Criteria (from #133)

> Collaborator UPDATE of `current_year`, `survival_limit`, `notes`, etc.
> succeeds and propagates over realtime.

✅ Covered by the editable-column matrix in
`settlement-hybrid-update.test.ts`. Realtime publication on `settlement` is
unchanged by this migration.

> Collaborator UPDATE of `settlement_name` (or any owner-only field) raises
> a Postgres exception that the DAL surfaces as the toast (toast wrapping in
> [E1.9]).

✅ The BEFORE UPDATE trigger raises `feature_not_supported` (`0A000`). The
DAL's `updateSettlement` already throws on Supabase errors; toast-wording
wrapper is owned by [E1.9] (out of scope here).

> The pinning test from `__tests__/integration/rls/settlement-shared.test.ts`
> is now an _denial_ test, not an allow-test.

✅ Inverted in this PR.

## Out of Scope

- Settings UI gating (sweep in [E1.10]).
- Toast wording wrapper ([E1.9]).

## Dependencies

- Blocked by: [E1.1] / #143 (provides `is_settlement_collaborator`) — merged
  in v0.51.0.
- Blocks: [E1.9], [E1.11].
