### PR TITLE
feat(realtime): add settlement_shared_user to supabase_realtime publication (#136)

### DIFF
--- a/__tests__/integration/realtime-publication.test.ts
+++ b/__tests__/integration/realtime-publication.test.ts
@@ -24,7 +24,11 @@ describe('Realtime publication membership', () => {
   /**
    * Source of truth: every settlement-scoped table that must broadcast
    * changes for the multiplayer experience to work. Keep this list in sync
-   * with the `TABLE_DOMAIN_MAP` in `hooks/use-realtime.tsx`.
+   * with the `TABLE_DOMAIN_MAP` in `hooks/use-realtime.tsx`, with one
+   * exception: `settlement_shared_user` is part of the `supabase_realtime`
+   * publication (added in E1.4) but is consumed by a user-level subscription
+   * landing in [E1.5], so it does not appear in the per-settlement
+   * `TABLE_DOMAIN_MAP`.
    */
   const EXPECTED_TABLES = [
     // Core settlement & junctions

--- a/__tests__/integration/realtime-publication.test.ts
+++ b/__tests__/integration/realtime-publication.test.ts
@@ -14,10 +14,11 @@ import { describe, expect, it } from 'vitest'
  * a much more actionable signal than discovering the gap in production when
  * a collaborator's UI silently goes stale.
  *
- * Catalog tables (`survivor_status`, `armor_set`, `wanderer*`, etc.) and
- * `settlement_shared_user` are intentionally out of scope: the former are
- * tracked under E2.4 and rely on a different subscription model, the latter
- * is tracked under E1.4 alongside its user-level subscription.
+ * Catalog tables (`survivor_status`, `armor_set`, `wanderer*`, etc.) are
+ * intentionally out of scope: they are tracked under E2.4 and rely on a
+ * different subscription model. `settlement_shared_user` is included here
+ * (added to the publication in E1.4) so user-level subscriptions receive
+ * invite / revoke events.
  */
 describe('Realtime publication membership', () => {
   /**
@@ -43,6 +44,7 @@ describe('Realtime publication membership', () => {
     'settlement_quarry',
     'settlement_resource',
     'settlement_seed_pattern',
+    'settlement_shared_user',
     'settlement_timeline_year',
 
     // Hunt
@@ -87,5 +89,16 @@ describe('Realtime publication membership', () => {
     const missing = EXPECTED_TABLES.filter((t) => !actual.has(t))
 
     expect(missing).toEqual([])
+  })
+
+  // E1.4 acceptance: the pg_publication_tables row exists for
+  // `settlement_shared_user`, mirroring the SQL predicate from issue #136.
+  it('includes `settlement_shared_user` in `supabase_realtime` (E1.4)', async () => {
+    const { data, error } = await admin.rpc('realtime_publication_tables')
+
+    expect(error).toBeNull()
+    const rows = (data ?? []) as { tablename: string }[]
+    const matches = rows.filter((r) => r.tablename === 'settlement_shared_user')
+    expect(matches).toHaveLength(1)
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.56.0",
+      "version": "0.57.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260509000001_settlement_shared_user_realtime.sql
+++ b/supabase/migrations/20260509000001_settlement_shared_user_realtime.sql
@@ -25,6 +25,7 @@ do $$ begin if not exists (
   where pubname = 'supabase_realtime'
     and schemaname = 'public'
     and tablename = 'settlement_shared_user'
-) then execute 'alter publication supabase_realtime add table settlement_shared_user';
+) then alter publication supabase_realtime
+add table settlement_shared_user;
 end if;
 end $$;

--- a/supabase/migrations/20260509000001_settlement_shared_user_realtime.sql
+++ b/supabase/migrations/20260509000001_settlement_shared_user_realtime.sql
@@ -1,0 +1,30 @@
+--------------------------------------------------------------------------------
+-- Phase 1.4 — Add `settlement_shared_user` to `supabase_realtime`
+--
+-- Allow user-level realtime subscriptions to receive INSERT/DELETE events
+-- when an invite is granted or revoked, so the recipient's settlement
+-- switcher updates without a full reload. Pairs with the per-user channel
+-- introduced in [E1.5].
+--
+-- Idempotent guard via `pg_publication_tables`: if the table is already a
+-- member of the publication (e.g. on a branch where someone added it
+-- manually for testing), skip the ALTER so the migration stays safe to
+-- re-run.
+--
+-- Reference:
+--   * `local/sharing-architecture.md` §5.2 Decision 5 / §3.2 / §10 Phase 1.4.
+--   * supabase/migrations/20260327000000_enable_realtime_gameplay_tables.sql
+--   * supabase/migrations/20260503000001_gear_grid_realtime.sql
+--   * supabase/migrations/20260506000000_audit_realtime_publication.sql
+--
+-- Closes [E1.4] (issue #136).
+--------------------------------------------------------------------------------
+do $$ begin if not exists (
+  select 1
+  from pg_publication_tables
+  where pubname = 'supabase_realtime'
+    and schemaname = 'public'
+    and tablename = 'settlement_shared_user'
+) then execute 'alter publication supabase_realtime add table settlement_shared_user';
+end if;
+end $$;


### PR DESCRIPTION
## Summary

Closes #136 (E1.4 of the sharing-architecture rollout).

Adds the `settlement_shared_user` junction table to the `supabase_realtime`
publication so user-level realtime subscriptions (introduced in [E1.5]) can
receive `INSERT` / `DELETE` events when an invite is granted or revoked.
Recipients' settlement switchers will update without a full reload.

## Changes

### Migration — `supabase/migrations/20260509000001_settlement_shared_user_realtime.sql`

Idempotent guard via `pg_publication_tables` so the migration is safe to
re-run on branches where someone added the table manually for testing:

```sql
do $$
begin
  if not exists (
    select 1
    from pg_publication_tables
    where pubname = 'supabase_realtime'
      and schemaname = 'public'
      and tablename = 'settlement_shared_user'
  ) then
    execute 'alter publication supabase_realtime add table settlement_shared_user';
  end if;
end $$;
```

### Tests — `__tests__/integration/realtime-publication.test.ts`

- Added `settlement_shared_user` to the `EXPECTED_TABLES` membership matrix
  (and removed the stale "out of scope, tracked under E1.4" exclusion note).
- Added a focused acceptance test that mirrors the SQL predicate from the
  issue body verbatim (`pubname='supabase_realtime' and
  tablename='settlement_shared_user'` returns one row).

### Versioning

`0.56.0` → `0.57.0`.

## Verification

- `npm run db:reset` — clean apply.
- `select tablename from pg_publication_tables where
  pubname='supabase_realtime' and tablename='settlement_shared_user'` → one
  row.
- `npm run integration-test` — 17 files / 616 tests passing (+1 from the new
  acceptance assertion).
- `npm test --silent -- --no-coverage` — 119 files / 2091 tests passing.

## Acceptance Criteria (from #136)

> `select tablename from pg_publication_tables where
> pubname='supabase_realtime' and tablename='settlement_shared_user'`
> returns one row.

✅ Asserted directly by the new acceptance test.

## Out of Scope

- Hook / client-side subscription wiring lives in [E1.5].

## Dependencies

- Blocked by: none (independent of [E1.1]).
- Blocks: [E1.5] — per-user realtime channel needs the publication active to
  receive INSERT / DELETE events.
