### PR TITLE
feat(realtime): per-user share-channel for live invites/revokes (#144)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -122,7 +122,10 @@ function MainPage(): ReactElement {
     updateLocal,
 
     userSettings,
-    setUserSettings
+    setUserSettings,
+
+    settlementList,
+    isSettlementListLoading
   } = useLocal()
 
   return (
@@ -131,14 +134,15 @@ function MainPage(): ReactElement {
         <SiteHeader />
 
         <AppSidebar
-          local={local}
           isCreatingNewSettlement={isCreatingNewSettlement}
+          isSettlementListLoading={isSettlementListLoading}
           selectedHuntId={selectedHuntId}
           selectedSettlement={selectedSettlement}
           selectedSettlementId={selectedSettlementId}
           selectedSettlementPhaseId={selectedSettlementPhaseId}
           selectedShowdownId={selectedShowdownId}
           selectedTab={selectedTab}
+          settlementList={settlementList}
           setIsCreatingNewSettlement={setIsCreatingNewSettlement}
           setSelectedHuntId={setSelectedHuntId}
           setSelectedSettlementId={setSelectedSettlementId}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -10,7 +10,6 @@ import {
   SidebarHeader,
   SidebarRail
 } from '@/components/ui/sidebar'
-import { LocalStateType } from '@/contexts/local-context'
 import {
   CampaignType,
   DatabaseCampaignType,
@@ -18,7 +17,7 @@ import {
   SurvivorType,
   TabType
 } from '@/lib/enums'
-import { SettlementDetail } from '@/lib/types'
+import { SettlementDetail, SettlementListEntry } from '@/lib/types'
 import {
   CircleQuestionMarkIcon,
   HourglassIcon,
@@ -156,8 +155,8 @@ const navSettings = [
 interface AppSidebarProps extends ComponentProps<typeof Sidebar> {
   /** Is Creating New Settlement */
   isCreatingNewSettlement: boolean
-  /** Local State */
-  local: LocalStateType
+  /** Whether the settlement list is still on its initial fetch */
+  isSettlementListLoading: boolean
   /** Selected Hunt ID */
   selectedHuntId: string | null
   /** Selected Settlement */
@@ -170,6 +169,8 @@ interface AppSidebarProps extends ComponentProps<typeof Sidebar> {
   selectedShowdownId: string | null
   /** Selected Tab */
   selectedTab: TabType
+  /** Settlement List (live, sourced from LocalContext) */
+  settlementList: SettlementListEntry[]
   /** Set Is Creating New Settlement */
   setIsCreatingNewSettlement: (isCreating: boolean) => void
   /** Set Selected Hunt ID */
@@ -194,13 +195,14 @@ interface AppSidebarProps extends ComponentProps<typeof Sidebar> {
  */
 export function AppSidebar({
   isCreatingNewSettlement,
-  local,
+  isSettlementListLoading,
   selectedHuntId,
   selectedSettlement,
   selectedSettlementId,
   selectedSettlementPhaseId,
   selectedShowdownId,
   selectedTab,
+  settlementList,
   setIsCreatingNewSettlement,
   setSelectedHuntId,
   setSelectedSettlementId,
@@ -244,12 +246,13 @@ export function AppSidebar({
       <SidebarHeader>
         <SettlementSwitcher
           isCreatingNewSettlement={isCreatingNewSettlement}
-          local={local}
+          isSettlementListLoading={isSettlementListLoading}
           selectedHuntId={selectedHuntId}
           selectedSettlement={selectedSettlement}
           selectedSettlementId={selectedSettlementId}
           selectedSettlementPhaseId={selectedSettlementPhaseId}
           selectedShowdownId={selectedShowdownId}
+          settlementList={settlementList}
           setIsCreatingNewSettlement={setIsCreatingNewSettlement}
           setSelectedHuntId={setSelectedHuntId}
           setSelectedSettlementId={setSelectedSettlementId}

--- a/components/menu/settlement-switcher.tsx
+++ b/components/menu/settlement-switcher.tsx
@@ -20,20 +20,10 @@ import {
   TooltipContent,
   TooltipTrigger
 } from '@/components/ui/tooltip'
-import { LocalStateType } from '@/contexts/local-context'
-import { useToast } from '@/hooks/use-toast'
-import { getSettlementForUser } from '@/lib/dal/user'
-import { CampaignType, DatabaseCampaignType } from '@/lib/enums'
-import { ERROR_MESSAGE } from '@/lib/messages'
-import { SettlementDetail, SettlementRole } from '@/lib/types'
+import { CampaignType } from '@/lib/enums'
+import { SettlementDetail, SettlementListEntry } from '@/lib/types'
 import { Check, ChevronsUpDown, House, Plus } from 'lucide-react'
-import {
-  ComponentProps,
-  ReactElement,
-  useEffect,
-  useRef,
-  useState
-} from 'react'
+import { ComponentProps, ReactElement } from 'react'
 
 /**
  * Settlement Switcher Properties
@@ -41,8 +31,12 @@ import {
 interface SettlementSwitcherProps extends ComponentProps<typeof Sidebar> {
   /** Is Creating New Settlement */
   isCreatingNewSettlement: boolean
-  /** Local State */
-  local: LocalStateType
+  /**
+   * Whether the settlement list is still loading its initial fetch.
+   * Subsequent realtime-driven refreshes do not toggle this flag, so the
+   * skeleton only appears on first mount.
+   */
+  isSettlementListLoading: boolean
   /** Selected Hunt ID */
   selectedHuntId: string | null
   /** Selected Settlement */
@@ -53,6 +47,14 @@ interface SettlementSwitcherProps extends ComponentProps<typeof Sidebar> {
   selectedSettlementPhaseId: string | null
   /** Selected Showdown ID */
   selectedShowdownId: string | null
+  /**
+   * Settlement List
+   *
+   * Owned + shared settlements available to the current user. Sourced from
+   * `LocalContext` so updates from the per-user realtime channel
+   * (#144 / E1.5) propagate without an extra fetch.
+   */
+  settlementList: SettlementListEntry[]
   /** Set Is Creating New Settlement */
   setIsCreatingNewSettlement: (isCreating: boolean) => void
   /** Set Selected Hunt ID */
@@ -80,12 +82,13 @@ interface SettlementSwitcherProps extends ComponentProps<typeof Sidebar> {
  */
 export function SettlementSwitcher({
   isCreatingNewSettlement,
-  local,
+  isSettlementListLoading,
   selectedHuntId,
   selectedSettlement,
   selectedSettlementId,
   selectedSettlementPhaseId,
   selectedShowdownId,
+  settlementList,
   setIsCreatingNewSettlement,
   setSelectedHuntId,
   setSelectedSettlementId,
@@ -93,53 +96,6 @@ export function SettlementSwitcher({
   setSelectedShowdownId,
   setSelectedSurvivorId
 }: SettlementSwitcherProps): ReactElement {
-  const { toast } = useToast(local)
-
-  const [settlementList, setSettlementList] = useState<
-    {
-      campaign_type: DatabaseCampaignType
-      id: string
-      settlement_name: string
-      role: SettlementRole
-      owner_username: string | null
-    }[]
-  >([])
-  const [isLoading, setIsLoading] = useState(true)
-  const fetchedRef = useRef(false)
-
-  /**
-   * Load Settlements
-   *
-   * Gather the list of settlements available to the user. Uses a ref to
-   * prevent redundant fetches on re-renders while still refetching when the
-   * selected settlement changes.
-   */
-  useEffect(() => {
-    // Always refetch when selectedSettlementId changes, but track initial load
-    fetchedRef.current = false
-
-    let isCancelled = false
-
-    getSettlementForUser()
-      .then((data) => {
-        if (isCancelled) return
-        setSettlementList(data)
-        fetchedRef.current = true
-      })
-      .catch((err: unknown) => {
-        if (isCancelled) return
-        console.error('Settlement List Fetch Error:', err)
-        toast.error(ERROR_MESSAGE())
-      })
-      .finally(() => {
-        if (!isCancelled) setIsLoading(false)
-      })
-
-    return () => {
-      isCancelled = true
-    }
-  }, [selectedSettlementId, toast])
-
   /**
    * Handle Settlement Selection
    *
@@ -150,7 +106,7 @@ export function SettlementSwitcher({
     setSelectedSettlementId(settlementId)
   }
 
-  if (isLoading)
+  if (isSettlementListLoading)
     return (
       <SidebarMenu>
         <SidebarMenuItem>

--- a/contexts/local-context.tsx
+++ b/contexts/local-context.tsx
@@ -1,19 +1,25 @@
 'use client'
 
-import { useRealtimeSubscriptions } from '@/hooks/use-realtime'
+import {
+  ShareChangeEvent,
+  useRealtimeSubscriptions,
+  useUserRealtimeSubscriptions
+} from '@/hooks/use-realtime'
 import { LOCAL_STORAGE_KEY } from '@/lib/common'
 import { getHunt } from '@/lib/dal/hunt'
 import { getSettlement } from '@/lib/dal/settlement'
 import { getSettlementPhase } from '@/lib/dal/settlement-phase'
 import { getShowdown } from '@/lib/dal/showdown'
 import { getSurvivor, getSurvivors } from '@/lib/dal/survivor'
-import { getUserSettings } from '@/lib/dal/user'
+import { getSettlementForUser, getUserSettings } from '@/lib/dal/user'
 import { TabType } from '@/lib/enums'
+import { ERROR_MESSAGE } from '@/lib/messages'
 import { createClient } from '@/lib/supabase/client'
 import {
   HuntDetail,
   HuntStateSetter,
   SettlementDetail,
+  SettlementListEntry,
   SettlementPhaseDetail,
   SettlementStateSetter,
   ShowdownDetail,
@@ -32,8 +38,10 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from 'react'
+import { toast as sonnerToast } from 'sonner'
 
 /**
  * Local State Type
@@ -177,6 +185,17 @@ interface LocalContextType {
   userSettings: UserSettingsDetail | null
   /** Set User Settings */
   setUserSettings: (settings: UserSettingsDetail | null) => void
+
+  /**
+   * Settlement List
+   *
+   * Cached result of `getSettlementForUser`. Refreshed automatically when
+   * the user-level realtime channel observes share grants / revokes
+   * targeting the current user (Phase 1.5 — issue #144).
+   */
+  settlementList: SettlementListEntry[]
+  /** Whether the initial settlement-list fetch is still pending */
+  isSettlementListLoading: boolean
 }
 
 /**
@@ -276,6 +295,29 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
   // issuing a redundant `auth.getUser()` call.
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null)
 
+  // Authenticated user ID — drives the per-user realtime channel that
+  // delivers share grant / revoke notifications. Mirrors the lifecycle of
+  // `isAuthenticated` and is captured from the same `auth.getUser()` call
+  // to avoid a redundant round trip.
+  const [userId, setUserId] = useState<string | null>(null)
+
+  // Settlement list shown in the switcher. Held at the context layer so the
+  // user-level realtime channel can refresh it from a single source of
+  // truth when a share is granted to or revoked from the current user
+  // (Phase 1.5 — issue #144).
+  const [settlementList, setSettlementList] = useState<SettlementListEntry[]>(
+    []
+  )
+  const [isSettlementListLoading, setIsSettlementListLoading] =
+    useState<boolean>(true)
+
+  // Toast helpers used by the share-change handler. Sonner is imported
+  // directly here (rather than via `useToast`) to avoid a circular import
+  // — `hooks/use-toast.tsx` already imports `LocalStateType` from this
+  // module. The `disableToasts` gating from `useToast` is reproduced inline
+  // for success / info events; errors are always shown.
+  const disableToasts = local.disableToasts === true
+
   useEffect(() => {
     let isCancelled = false
 
@@ -283,7 +325,9 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
 
     supabase.auth.getUser().then(({ data, error }) => {
       if (isCancelled) return
+      const authedUserId = !error ? (data?.user?.id ?? null) : null
       setIsAuthenticated(!error && !!data?.user)
+      setUserId(authedUserId)
     })
 
     // Re-evaluate when the auth state changes (e.g. login/logout).
@@ -296,6 +340,7 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
 
       if (!session?.user) {
         setIsAuthenticated(false)
+        setUserId(null)
         return
       }
 
@@ -306,10 +351,12 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
           // Stale session — sign out to clear the invalid token.
           supabase.auth.signOut()
           setIsAuthenticated(false)
+          setUserId(null)
           return
         }
 
         setIsAuthenticated(true)
+        setUserId(data.user.id)
       })
     })
 
@@ -487,6 +534,131 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
           })
       }
     }
+  })
+
+  // Fetch the settlement list once authentication is confirmed and again on
+  // every share grant / revoke event delivered through the user-level
+  // realtime channel below. Wrapped in a callback so the realtime handler
+  // can refresh on demand.
+  const refetchSettlementList = useCallback(() => {
+    getSettlementForUser()
+      .then((data) => setSettlementList(data))
+      .catch((err: unknown) => {
+        console.error('Settlement List Fetch Error:', err)
+        sonnerToast.error(ERROR_MESSAGE())
+      })
+  }, [])
+
+  useEffect(() => {
+    let isCancelled = false
+
+    if (!isAuthenticated)
+      return () => {
+        isCancelled = true
+      }
+
+    getSettlementForUser()
+      .then((data) => {
+        if (isCancelled) return
+        setSettlementList(data)
+      })
+      .catch((err: unknown) => {
+        if (isCancelled) return
+        console.error('Settlement List Fetch Error:', err)
+        sonnerToast.error(ERROR_MESSAGE())
+      })
+      .finally(() => {
+        if (!isCancelled) setIsSettlementListLoading(false)
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [isAuthenticated])
+
+  // Per-user realtime channel listening for inserts / deletes on
+  // `settlement_shared_user` where `shared_user_id = userId`. Toasts the
+  // recipient on grant / revoke and refreshes the cached settlement list.
+  // When the active settlement is the one being revoked, the existing
+  // settlement-channel cascade clears all derived state via a fresh
+  // `getSettlement` fetch (RLS will return null post-revoke).
+  //
+  // A short debounce on the refetch coalesces bursts (e.g. an owner mass
+  // revoking) into a single list refresh while still firing one toast per
+  // event for clarity.
+  const shareChangeRefetchTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+
+  const handleShareChange = useCallback(
+    (event: ShareChangeEvent) => {
+      if (event.event === 'INSERT') {
+        if (!disableToasts)
+          sonnerToast.success('A new lantern joins the watch.')
+      } else {
+        if (!disableToasts) sonnerToast.info('A lantern dims. Its watch ends.')
+
+        // If the active settlement is the one being revoked, force a
+        // fresh fetch so the existing onSettlementChange cascade clears
+        // derived state. RLS will return null post-revoke.
+        if (event.settlementId === selectedSettlementId) {
+          getSettlement(event.settlementId)
+            .then((settlement) => {
+              if (!settlement) {
+                setSelectedSettlementState(null)
+                setSelectedSettlementIdState(null)
+                setSelectedHuntState(null)
+                setSelectedHuntIdState(null)
+                setSelectedHuntMonsterIndexState(0)
+                setSelectedSettlementPhaseState(null)
+                setSelectedSettlementPhaseIdState(null)
+                setSelectedShowdownState(null)
+                setSelectedShowdownIdState(null)
+                setSelectedShowdownMonsterIndexState(0)
+                setSelectedSurvivorState(null)
+                setSelectedSurvivorIdState(null)
+                setSurvivors([])
+
+                setLocalState((prev) => ({
+                  ...prev,
+                  selectedSettlementId: null,
+                  selectedHuntId: null,
+                  selectedHuntMonsterIndex: 0,
+                  selectedSettlementPhaseId: null,
+                  selectedShowdownId: null,
+                  selectedShowdownMonsterIndex: 0,
+                  selectedSurvivorId: null
+                }))
+              }
+            })
+            .catch((err: unknown) => {
+              console.error('Revoked Settlement Refetch Error:', err)
+            })
+        }
+      }
+
+      if (shareChangeRefetchTimerRef.current)
+        clearTimeout(shareChangeRefetchTimerRef.current)
+
+      shareChangeRefetchTimerRef.current = setTimeout(() => {
+        shareChangeRefetchTimerRef.current = null
+        refetchSettlementList()
+      }, 300)
+    },
+    [disableToasts, refetchSettlementList, selectedSettlementId]
+  )
+
+  useEffect(() => {
+    return () => {
+      if (shareChangeRefetchTimerRef.current)
+        clearTimeout(shareChangeRefetchTimerRef.current)
+    }
+  }, [])
+
+  useUserRealtimeSubscriptions({
+    enabled: isAuthenticated === true,
+    userId,
+    onShareChange: handleShareChange
   })
 
   /**
@@ -1282,7 +1454,10 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
       updateLocal,
 
       userSettings,
-      setUserSettings
+      setUserSettings,
+
+      settlementList,
+      isSettlementListLoading
     }),
     [
       isAuthenticated,
@@ -1307,6 +1482,8 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
       survivors,
       local,
       userSettings,
+      settlementList,
+      isSettlementListLoading,
       setSelectedHunt,
       setSelectedHuntId,
       setSelectedHuntMonsterIndex,

--- a/hooks/use-realtime.tsx
+++ b/hooks/use-realtime.tsx
@@ -279,3 +279,108 @@ export function useRealtimeSubscriptions(
     }
   }, [options.enabled, options.settlementId])
 }
+
+/**
+ * Share Change Event
+ *
+ * Payload delivered to `onShareChange` when a row in
+ * `settlement_shared_user` involving the current user is inserted or
+ * deleted. `settlementId` is the affected settlement on either side of
+ * the event so the caller can refresh the settlement list and (on
+ * `DELETE`) decide whether to clear the active selection.
+ */
+export interface ShareChangeEvent {
+  /** Realtime Event Type */
+  event: 'INSERT' | 'DELETE'
+  /** Affected Settlement ID */
+  settlementId: string
+}
+
+/**
+ * User Realtime Subscriptions Options
+ */
+interface UseUserRealtimeSubscriptionsOptions {
+  /** Whether the subscription should be active */
+  enabled: boolean
+  /** Authenticated user ID; subscription is skipped while `null` */
+  userId: string | null
+  /** Called when a share is granted to or revoked from the current user */
+  onShareChange: (event: ShareChangeEvent) => void
+}
+
+/**
+ * User Realtime Subscriptions Hook
+ *
+ * Subscribes a per-user channel to INSERT / DELETE events on
+ * `settlement_shared_user` filtered to rows where
+ * `shared_user_id = userId`. Pairs with the per-settlement channel from
+ * `useRealtimeSubscriptions` to deliver share-grant / share-revoke
+ * notifications to the recipient without a manual reload (Phase 1.5 of
+ * the sharing architecture rollout — see issue #144).
+ *
+ * Events are delivered one-for-one to `onShareChange`; the caller is
+ * responsible for any debouncing or state cascades (e.g. clearing the
+ * active settlement selection on revoke).
+ *
+ * @param options Subscription configuration
+ */
+export function useUserRealtimeSubscriptions(
+  options: UseUserRealtimeSubscriptionsOptions
+) {
+  const callbackRef = useRef(options.onShareChange)
+
+  useEffect(() => {
+    callbackRef.current = options.onShareChange
+  })
+
+  useEffect(() => {
+    if (!options.enabled || !options.userId) return
+
+    const supabase = createClient()
+    const userId = options.userId
+
+    const channel = supabase
+      .channel(`user-${userId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'settlement_shared_user',
+          filter: `shared_user_id=eq.${userId}`
+        },
+        (payload) => {
+          const row = payload.new as { settlement_id?: string } | undefined
+          if (!row?.settlement_id) return
+          callbackRef.current({
+            event: 'INSERT',
+            settlementId: row.settlement_id
+          })
+        }
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'DELETE',
+          schema: 'public',
+          table: 'settlement_shared_user',
+          filter: `shared_user_id=eq.${userId}`
+        },
+        (payload) => {
+          const row = payload.old as { settlement_id?: string } | undefined
+          if (!row?.settlement_id) return
+          callbackRef.current({
+            event: 'DELETE',
+            settlementId: row.settlement_id
+          })
+        }
+      )
+      .subscribe((status) => {
+        console.debug('User realtime subscription status:', status)
+      })
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [options.enabled, options.userId])
+}

--- a/lib/dal/user.ts
+++ b/lib/dal/user.ts
@@ -1,7 +1,6 @@
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
-import { DatabaseCampaignType } from '@/lib/enums'
 import { createClient } from '@/lib/supabase/client'
-import { SettlementRole, UserSettingsDetail } from '@/lib/types'
+import { SettlementListEntry, UserSettingsDetail } from '@/lib/types'
 import { SupabaseClient } from '@supabase/supabase-js'
 
 /**
@@ -180,15 +179,7 @@ export async function getUserSettings(): Promise<UserSettingsDetail | null> {
  *
  * @returns List of Settlement(s)
  */
-export async function getSettlementForUser(): Promise<
-  {
-    campaign_type: DatabaseCampaignType
-    id: string
-    settlement_name: string
-    role: SettlementRole
-    owner_username: string | null
-  }[]
-> {
+export async function getSettlementForUser(): Promise<SettlementListEntry[]> {
   const userId = await getUserId()
   const supabase = createClient()
 
@@ -229,13 +220,7 @@ export async function getSettlementForUser(): Promise<
     )
   )
 
-  const results: {
-    campaign_type: DatabaseCampaignType
-    id: string
-    settlement_name: string
-    role: SettlementRole
-    owner_username: string | null
-  }[] = []
+  const results: SettlementListEntry[] = []
 
   for (const s of ownedResult.data ?? [])
     results.push({ ...s, role: 'owner', owner_username: null })

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
 import { Database, Tables } from '@/lib/database.types'
-import { HuntEventType } from '@/lib/enums'
+import { DatabaseCampaignType, HuntEventType } from '@/lib/enums'
 
 /**
  * Campaign Template
@@ -750,6 +750,26 @@ export type SettlementStateSetter = (
  * `settlement_shared_user` and are subject to the shared-user permission set.
  */
 export type SettlementRole = 'owner' | 'collaborator'
+
+/**
+ * Settlement List Entry
+ *
+ * Lightweight row shape returned by `getSettlementForUser` and used by the
+ * settlement switcher. Each entry is tagged with the caller's `role`; for
+ * collaborator rows, `owner_username` resolves the owner's display handle.
+ */
+export interface SettlementListEntry {
+  /** Campaign Type */
+  campaign_type: DatabaseCampaignType
+  /** Settlement ID */
+  id: string
+  /** Settlement Name */
+  settlement_name: string
+  /** Caller's Role on This Settlement */
+  role: SettlementRole
+  /** Owner Username (Collaborator Rows Only) */
+  owner_username: string | null
+}
 
 /**
  * Settlement Detail

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.57.0",
+      "version": "0.58.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

Closes #144 (E1.5 of the sharing-architecture rollout).

Adds a per-user realtime channel that listens for INSERT / DELETE events
on `settlement_shared_user` filtered to rows where
`shared_user_id = auth.uid()`, so an invite shows up in the recipient's
settlement switcher (and a revoked share disappears) without a manual
reload. Pairs with the publication membership added in #202 / E1.4.

## Changes

### Hook — [hooks/use-realtime.tsx](hooks/use-realtime.tsx)

- New `useUserRealtimeSubscriptions({ enabled, userId, onShareChange })`
  alongside the existing per-settlement hook.
- Attaches a single channel as `user-{uid}` with two `postgres_changes`
  listeners (INSERT and DELETE) filtered by
  `shared_user_id=eq.{uid}`. DELETE payloads carry `settlement_id`
  through the table's primary key, so the filter and `payload.old`
  read are both valid under the default `REPLICA IDENTITY`.
- Tracks the latest closure through a ref, matching the existing
  per-settlement hook.
- Adds a small `ShareChangeEvent` type (`event: 'INSERT' | 'DELETE'`,
  `settlementId: string`) so callers can dispatch on direction without
  inventing their own union.

### Wiring — [contexts/local-context.tsx](contexts/local-context.tsx)

- Captures the authenticated user id (`userId`) alongside
  `isAuthenticated` from the same `auth.getUser()` / `onAuthStateChange`
  pair so the per-user channel stays in lockstep with auth state.
- Owns the cached settlement list (`settlementList`,
  `isSettlementListLoading`) and refetches it once authentication is
  confirmed plus on every share-change event.
- `handleShareChange`:
  - INSERT → success toast `"A new lantern joins the watch."`
  - DELETE → info toast `"A lantern dims. Its watch ends."` and, when
    the active settlement is the one being revoked, forces a fresh
    `getSettlement()` so the existing settlement-channel cascade
    clears all derived state (RLS will return `null` post-revoke;
    settlement / hunt / showdown / phase / survivor selections are
    all cleared and persisted to local storage).
  - Refetch is debounced 300 ms to coalesce bursts (e.g. an owner mass
    revoke), while toasts still fire one-per-event for clarity.
- Provides `settlementList` + `isSettlementListLoading` through context.

### Surface — [components/menu/settlement-switcher.tsx](components/menu/settlement-switcher.tsx)

- Now a presentational consumer driven by `settlementList` /
  `isSettlementListLoading` props instead of running its own fetch.
- Skeleton shows only on the initial load; subsequent realtime-driven
  refreshes update the list in place.
- [components/app-sidebar.tsx](components/app-sidebar.tsx) and
  [app/page.tsx](app/page.tsx) forward the new context fields to the
  switcher.

### Type — [lib/types.ts](lib/types.ts) / [lib/dal/user.ts](lib/dal/user.ts)

- Promoted the row shape used by `getSettlementForUser` into a shared
  `SettlementListEntry` type so the context, switcher, and DAL all
  reference one source of truth instead of duplicating the inline
  anonymous type.

## Additional changes worth noting

- **User id captured in auth handler.** Avoids a second round trip just
  to feed the per-user channel — both `isAuthenticated` and `userId`
  are set atomically from the same `getUser()` response.
- **`local` prop dropped from switcher and app-sidebar.** Toasts moved
  to the context layer, so the prop became dead weight.
- **`sonner` imported directly in `local-context.tsx`** for the
  share-change toasts. Going through the existing `useToast` hook
  introduced a circular import (`hooks/use-toast.tsx` already imports
  `LocalStateType` from this module), which manifested as a Turbopack
  chunk-load failure in dev. The `disableToasts` gate from `useToast`
  is reproduced inline so success / info events still respect the
  per-user setting; error toasts fire regardless, matching `useToast`.
- **Versioning.** `0.57.0` → `0.58.0`.

## Verification

- `npm test --silent -- --no-coverage` — 119 files / 2091 tests passing.
- `npm run integration-test` — 17 files / 616 tests passing.
- Manual smoke test in two browsers:
  - Owner shares → recipient switcher updates within ~300 ms with the
    success toast.
  - Owner revokes → recipient switcher row disappears with the info
    toast; if the recipient was viewing the revoked settlement, the
    full clear-and-redirect cascade fires cleanly.

## Acceptance Criteria (from #144)

- [x] New hook `useUserRealtimeSubscriptions` extending `use-realtime.tsx`.
- [x] Subscribes to `postgres_changes` on `public.settlement_shared_user`
  filtered by `shared_user_id=eq.{uid}`.
- [x] Wired into `contexts/local-context.tsx`; settlement-list refetch
  fires on event.
- [x] `components/menu/settlement-switcher.tsx` consumes the live list.
- [x] Toast on share received: success → `"A new lantern joins the watch."`
- [x] Toast on share revoked: info → `"A lantern dims. Its watch ends."`
- [x] Two browsers: recipient switcher shows the new settlement within
  ~300 ms with toast.
- [x] Revoke removes the row; selecting the revoked settlement before
  reload is handled gracefully (selection cleared, derived state
  cascaded down).

## Out of scope

- Bell badge / persistent notifications — [E4.5].

## Dependencies

- Blocked by: [E1.4] (#136 / PR #202) — merged.
- Blocks: [E1.7], [E1.11], [E1.12].
