### PR TITLE
feat(rpc): exact-match lookup_user_by_username with rolling rate limit (#146)

### DIFF
--- a/__tests__/integration/rls/lookup-user-by-username.test.ts
+++ b/__tests__/integration/rls/lookup-user-by-username.test.ts
@@ -1,0 +1,203 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { createClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+/**
+ * RPC — `lookup_user_by_username`
+ *
+ * Validates the SECURITY DEFINER function used by the share-settlement
+ * invite flow to resolve an exact username to its `auth.users.id`.
+ *
+ * Anti-enumeration contract under test:
+ *   1. Exact match returns the matching `user_id`.
+ *   2. Unknown handles return `null` (no enumeration leak).
+ *   3. The 31st call inside a 60s rolling window also returns `null`,
+ *      indistinguishable from the not-found case.
+ *   4. Anonymous and unauthenticated callers are blocked at both the
+ *      GRANT layer and the in-function `auth.uid()` guard.
+ */
+describe('RPC: lookup_user_by_username', () => {
+  let alice: TestUser
+  let bob: TestUser
+
+  beforeAll(async () => {
+    alice = await createTestUser()
+    bob = await createTestUser()
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(alice.id)
+    await deleteTestUser(bob.id)
+  })
+
+  beforeEach(async () => {
+    // Reset the audit table between tests so the rate-limit case can run
+    // first or last without depending on test ordering.
+    await admin
+      .from('lookup_user_audit')
+      .delete()
+      .in('user_id', [alice.id, bob.id])
+  })
+
+  it('returns the matching user_id for an existing username', async () => {
+    const { data: bobRow } = await admin
+      .from('user_settings')
+      .select('username')
+      .eq('user_id', bob.id)
+      .single()
+
+    const { data, error } = await alice.client.rpc('lookup_user_by_username', {
+      p_username: bobRow?.username ?? ''
+    })
+
+    expect(error).toBeNull()
+    expect(data).toBe(bob.id)
+  })
+
+  it('returns null for a non-existent username', async () => {
+    const { data, error } = await alice.client.rpc('lookup_user_by_username', {
+      p_username: 'no_such_user_definitely_not_seeded'
+    })
+
+    expect(error).toBeNull()
+    expect(data).toBeNull()
+  })
+
+  it('records one audit row per successful call', async () => {
+    const { data: bobRow } = await admin
+      .from('user_settings')
+      .select('username')
+      .eq('user_id', bob.id)
+      .single()
+
+    await alice.client.rpc('lookup_user_by_username', {
+      p_username: bobRow?.username ?? ''
+    })
+    await alice.client.rpc('lookup_user_by_username', {
+      p_username: 'definitely_missing'
+    })
+
+    const { count } = await admin
+      .from('lookup_user_audit')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', alice.id)
+
+    // Both hit and miss paths should be counted — otherwise an attacker
+    // could probe past the budget by always missing.
+    expect(count).toBe(2)
+  })
+
+  it('returns null for the 31st call inside the rolling 60s window', async () => {
+    // Seed 30 prior attempts directly so the boundary can be tested without
+    // 30 real RPC calls. All seeded rows fall inside the active window.
+    const seeded = Array.from({ length: 30 }, () => ({
+      user_id: alice.id,
+      attempted_at: new Date().toISOString()
+    }))
+    const { error: seedErr } = await admin
+      .from('lookup_user_audit')
+      .insert(seeded)
+    expect(seedErr).toBeNull()
+
+    const { data: bobRow } = await admin
+      .from('user_settings')
+      .select('username')
+      .eq('user_id', bob.id)
+      .single()
+
+    const { data, error } = await alice.client.rpc('lookup_user_by_username', {
+      p_username: bobRow?.username ?? ''
+    })
+
+    // The caller cannot tell this `null` from the not-found case — that's
+    // the no-leak contract from `local/sharing-architecture.md` §4 P9.
+    expect(error).toBeNull()
+    expect(data).toBeNull()
+  })
+
+  it('does not count expired audit rows toward the rolling-window limit', async () => {
+    // 30 rows, all stamped 2 minutes ago — outside the 60s window. The
+    // function must prune them before counting, otherwise it would falsely
+    // rate-limit a caller who hasn't done anything recently.
+    const expiredAt = new Date(Date.now() - 2 * 60 * 1000).toISOString()
+    const seeded = Array.from({ length: 30 }, () => ({
+      user_id: alice.id,
+      attempted_at: expiredAt
+    }))
+    const { error: seedErr } = await admin
+      .from('lookup_user_audit')
+      .insert(seeded)
+    expect(seedErr).toBeNull()
+
+    const { data: bobRow } = await admin
+      .from('user_settings')
+      .select('username')
+      .eq('user_id', bob.id)
+      .single()
+
+    const { data, error } = await alice.client.rpc('lookup_user_by_username', {
+      p_username: bobRow?.username ?? ''
+    })
+
+    expect(error).toBeNull()
+    expect(data).toBe(bob.id)
+
+    // Pruning should also have wiped the stale rows so the table doesn't
+    // grow without bound.
+    const { count } = await admin
+      .from('lookup_user_audit')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', alice.id)
+    expect(count).toBe(1)
+  })
+
+  it('rejects an unauthenticated caller at the GRANT layer', async () => {
+    const anon = createClient(
+      process.env.SUPABASE_URL ?? '',
+      process.env.SUPABASE_ANON_KEY ?? '',
+      { auth: { persistSession: false, autoRefreshToken: false } }
+    )
+
+    const { data, error } = await anon.rpc('lookup_user_by_username', {
+      p_username: 'phantom'
+    })
+
+    // Either PostgREST refuses execution (permission denied) or the
+    // in-function guard fires; both are acceptable. The contract is just
+    // "anon cannot resolve usernames".
+    expect(data).toBeNull()
+    expect(error).not.toBeNull()
+  })
+
+  it('rejects a service-role direct call (in-function auth.uid() guard)', async () => {
+    // service_role bypasses RLS and PostgREST GRANT checks but `auth.uid()`
+    // returns null, so the in-function guard must still refuse the call.
+    const { data, error } = await admin.rpc('lookup_user_by_username', {
+      p_username: 'phantom'
+    })
+
+    expect(data).toBeNull()
+    expect(error?.message).toBe('not-authenticated')
+  })
+
+  it('blocks direct SELECT on lookup_user_audit even from authenticated users', async () => {
+    // RLS is enabled with no policies, so only the SECURITY DEFINER function
+    // can read the audit table. A direct query from a logged-in user must
+    // return zero rows, regardless of what's actually stored.
+    await admin
+      .from('lookup_user_audit')
+      .insert({ user_id: alice.id, attempted_at: new Date().toISOString() })
+
+    const { data, error } = await alice.client
+      .from('lookup_user_audit')
+      .select('*')
+
+    expect(error).toBeNull()
+    expect(data).toEqual([])
+  })
+})

--- a/__tests__/lib/dal/user.test.ts
+++ b/__tests__/lib/dal/user.test.ts
@@ -22,7 +22,8 @@ const {
   addUserSettings,
   updateUserSettings,
   removeUserSettings,
-  renameUsername
+  renameUsername,
+  lookupUserByUsername
 } = await import('@/lib/dal/user')
 
 beforeEach(() => {
@@ -445,6 +446,41 @@ describe('renameUsername', () => {
 
     await expect(renameUsername('valid_name')).rejects.toThrow(
       'Error Renaming Username: connection lost'
+    )
+  })
+})
+
+describe('lookupUserByUsername', () => {
+  it('returns the user_id when the RPC resolves the handle', async () => {
+    mockSupabase.rpc.mockResolvedValue({
+      data: 'user-123',
+      error: null
+    })
+
+    const result = await lookupUserByUsername('alice')
+
+    expect(result).toBe('user-123')
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('lookup_user_by_username', {
+      p_username: 'alice'
+    })
+  })
+
+  it('returns null when the RPC resolves to null (not-found or rate-limited)', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: null, error: null })
+
+    const result = await lookupUserByUsername('nobody')
+
+    expect(result).toBeNull()
+  })
+
+  it('throws on unexpected RPC errors', async () => {
+    mockSupabase.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'connection lost' }
+    })
+
+    await expect(lookupUserByUsername('alice')).rejects.toThrow(
+      'Username Lookup Error: connection lost'
     )
   })
 })

--- a/lib/dal/user.ts
+++ b/lib/dal/user.ts
@@ -368,3 +368,33 @@ export async function renameUsername(
 
   return data ? 'success' : 'collision'
 }
+
+/**
+ * Lookup User By Username
+ *
+ * Resolves an exact username to its `auth.users.id` via the SECURITY DEFINER
+ * `lookup_user_by_username` RPC. Used by the share-settlement invite flow to
+ * convert a typed handle into a `shared_user_id` without ever pulling the
+ * full `user_settings` table client-side.
+ *
+ * The RPC enforces a 30-lookups-per-rolling-60s rate limit per caller and
+ * deliberately collapses both "rate-limited" and "not-found" into a NULL
+ * return so callers cannot distinguish the two cases — closing the
+ * enumeration side channel documented in `local/sharing-architecture.md` §4 P9.
+ *
+ * @param username Exact Username
+ * @returns User ID, or null if no match (or the caller is over budget)
+ * @throws For unexpected DB errors (network, missing session, etc.)
+ */
+export async function lookupUserByUsername(
+  username: string
+): Promise<string | null> {
+  const supabase = createClient()
+  const { data, error } = await supabase.rpc('lookup_user_by_username', {
+    p_username: username
+  })
+
+  if (error) throw new Error(`Username Lookup Error: ${error.message}`)
+
+  return data ?? null
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -1573,6 +1573,21 @@ export type Database = {
           },
         ]
       }
+      lookup_user_audit: {
+        Row: {
+          attempted_at: string
+          user_id: string
+        }
+        Insert: {
+          attempted_at?: string
+          user_id: string
+        }
+        Update: {
+          attempted_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       milestone: {
         Row: {
           campaign_types: Database["public"]["Enums"]["campaign_type"][]
@@ -5854,6 +5869,7 @@ export type Database = {
       is_trait_owner: { Args: { record_id: string }; Returns: boolean }
       is_wanderer_owner: { Args: { record_id: string }; Returns: boolean }
       is_weapon_type_owner: { Args: { record_id: string }; Returns: boolean }
+      lookup_user_by_username: { Args: { p_username: string }; Returns: string }
       provision_user_settings_for_oauth: {
         Args: { p_user_id: string }
         Returns: undefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.58.0",
+      "version": "0.59.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260510000000_lookup_user_by_username.sql
+++ b/supabase/migrations/20260510000000_lookup_user_by_username.sql
@@ -1,0 +1,102 @@
+--------------------------------------------------------------------------------
+-- Lookup User By Username
+--
+-- SECURITY DEFINER RPC that resolves an exact username to its `auth.users.id`
+-- so an authenticated caller can issue a settlement-share invite by handle
+-- without ever pulling the full `user_settings` table.
+--
+-- Source of truth: `local/sharing-architecture.md` §4 P9 (no enumeration) /
+-- §11 Q9 (REQUIRE EXACT MATCH) / §10 Phase 1 item 1.5. Tracking issue: #146.
+--
+-- Anti-enumeration guarantees:
+--   1. Exact match only. No prefix, no substring, no `ilike`.
+--   2. Per-user rate limit of 30 lookups per rolling 60-second window.
+--      Implemented via a dedicated `lookup_user_audit(user_id, attempted_at)`
+--      table, serialised under `pg_advisory_xact_lock` so concurrent calls
+--      from the same caller cannot both observe `count = 29` and both insert.
+--   3. No-leak surface. Both "rate-limited" and "not-found" return NULL so
+--      the caller cannot distinguish a missed username from an over-budget
+--      probe — closing the timing/error side channel that would otherwise
+--      let an attacker enumerate handles by burst-probing past the limit.
+--      This intentionally diverges from `rename_username`, which raises on
+--      throttle, because rename collisions are not an enumeration vector.
+--
+-- Rate-limit choice (per the issue body's "choose the simpler option"):
+--   - Picked `lookup_user_audit` over a token-bucket on `user_settings`
+--     because a sliding window (the spec's "30 per rolling 60s") cannot be
+--     emulated by a single last-call timestamp. The audit table also keeps
+--     `user_settings` writes scoped to actual settings changes, avoiding
+--     write amplification on a hot, narrow table.
+--   - The function prunes the caller's own rows older than the window on
+--     each call, so the table is bounded above by 30 rows per *currently
+--     active* caller — naturally tiny.
+--
+-- Auth surface:
+--   - Anon callers are double-blocked: (a) explicit `revoke execute … from
+--     anon` because Supabase's `ALTER DEFAULT PRIVILEGES` grants EXECUTE to
+--     anon independently of PUBLIC, and (b) the in-function `auth.uid() is
+--     null` guard, which still fails closed if the GRANT model ever drifts.
+--------------------------------------------------------------------------------
+create table if not exists public.lookup_user_audit (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  attempted_at timestamptz not null default now()
+);
+-- Index sized to the only query that hits this table: "give me this caller's
+-- attempts inside the rolling window". `user_id` first lets the planner seek
+-- to the caller's slice; `attempted_at desc` lets the prune-and-count pair
+-- stop scanning as soon as the row falls outside the window.
+create index if not exists lookup_user_audit_user_attempted_at_idx on public.lookup_user_audit (user_id, attempted_at desc);
+-- RLS is enabled with no policies. Only the SECURITY DEFINER function below
+-- ever touches the table, so any direct PostgREST query (owner or not) must
+-- come back empty. Defence-in-depth against accidental EXECUTE drift on the
+-- function itself.
+alter table public.lookup_user_audit enable row level security;
+create or replace function lookup_user_by_username(p_username varchar) returns uuid language plpgsql security definer
+set search_path = '' as $$
+declare caller_uid uuid := auth.uid();
+result_id uuid;
+request_count int;
+rate_window constant interval := interval '60 seconds';
+rate_limit constant int := 30;
+begin if caller_uid is null then raise exception 'not-authenticated' using errcode = '42501';
+end if;
+-- Serialise concurrent lookups for this caller. The lock key is derived
+-- from the caller UUID so different users never contend, and the lock is
+-- automatically released at transaction end.
+perform pg_advisory_xact_lock(
+  hashtext('lookup_user_by_username'),
+  hashtext(caller_uid::text)
+);
+-- Prune the caller's expired audit rows so the table size stays bounded
+-- by the number of *currently rate-limited* callers rather than growing
+-- linearly with total lookups across all time.
+delete from public.lookup_user_audit
+where user_id = caller_uid
+  and attempted_at <= now() - rate_window;
+-- After pruning, every remaining row is inside the active window, so a
+-- bare count is sufficient — no time predicate needed.
+select count(*) into request_count
+from public.lookup_user_audit
+where user_id = caller_uid;
+if request_count >= rate_limit then -- Same shape as the not-found path. The caller cannot tell whether they
+-- typed an unknown handle or burned through their lookup budget, which
+-- is what closes the enumeration side channel.
+return null;
+end if;
+insert into public.lookup_user_audit (user_id)
+values (caller_uid);
+select user_id into result_id
+from public.user_settings
+where username = p_username;
+return result_id;
+end;
+$$;
+revoke all on function public.lookup_user_by_username(varchar)
+from public;
+-- Supabase's `ALTER DEFAULT PRIVILEGES` on the `public` schema grants
+-- EXECUTE to `anon`, `authenticated`, and `service_role` independently of
+-- PUBLIC, so the revoke above is not sufficient to deny anonymous callers.
+-- Drop anon explicitly to enforce the "authenticated only" contract.
+revoke execute on function public.lookup_user_by_username(varchar)
+from anon;
+grant execute on function public.lookup_user_by_username(varchar) to authenticated;


### PR DESCRIPTION
## Summary

Closes #146 (Epic E1 — Phase 1 item 1.5). Adds a SECURITY DEFINER RPC that resolves an exact username to its `auth.users.id`, used by the share-settlement invite flow to convert a typed handle into a `shared_user_id` without ever pulling the full `user_settings` table client-side.

## What

- New migration `supabase/migrations/20260510000000_lookup_user_by_username.sql`:
  - `lookup_user_audit(user_id, attempted_at)` ring-buffer table with `(user_id, attempted_at desc)` index. RLS enabled with no policies (only the SECURITY DEFINER function ever touches it).
  - `lookup_user_by_username(p_username varchar) returns uuid` with `set search_path = ''`, `pg_advisory_xact_lock` keyed on the caller UUID, prune-then-count rate logic, and a NULL return for both not-found and rate-limited.
  - Explicit `revoke execute … from anon` because Supabase's `ALTER DEFAULT PRIVILEGES` grants EXECUTE to anon independently of PUBLIC; the in-function `auth.uid() is null` guard is the second layer.
- `lib/dal/user.ts`: `lookupUserByUsername(username): Promise<string | null>` mirrors the codebase's RPC-helper convention (`renameUsername`, etc.).
- Regenerated `lib/database.types.ts` for the new table + RPC.
- 8 integration tests in `__tests__/integration/rls/lookup-user-by-username.test.ts` covering: hit, miss, audit accounting, 31st-call boundary, expired-row pruning, anon GRANT block, service-role in-function guard, and direct `select` on the audit table being blocked by RLS.
- 3 unit tests for `lookupUserByUsername` in `__tests__/lib/dal/user.test.ts`.

## Why

`local/sharing-architecture.md` §4 P9 / §11 Q9 / §10 Phase 1.5 require an exact-match-only lookup with per-user rate limiting that does not leak \"this handle exists\" via timing or error surfaces. The audit-table approach was chosen over a token-bucket on `user_settings` because the spec is a *rolling* 60-second window, which a single last-call timestamp cannot emulate, and because keeping `user_settings` writes scoped to actual settings changes avoids write amplification on a hot, narrow table.

## Anti-enumeration contract

| Behaviour | Surface |
|-----------|---------|
| Exact match | Returns the matching `user_id` |
| Unknown handle | Returns `null` |
| Over rate limit | Returns `null` (indistinguishable from unknown) |
| Anon caller | Refused at GRANT layer; in-function guard is second line of defence |
| Direct table SELECT | RLS denies (no policies) |

## Test results

- Unit suite: **2094 / 2094 green** (+3)
- Integration suite: **624 / 624 green** (+8)

## Dependency changes

None.

## Version

`0.58.0` → `0.59.0` (minor: new RPC + new table).