### PR TITLE
feat(sharing): map RLS/trigger rejections to lantern-themed toast

### DIFF
--- a/__tests__/lib/security/classify-mutation-error.test.ts
+++ b/__tests__/lib/security/classify-mutation-error.test.ts
@@ -1,0 +1,117 @@
+import { isAuthorizationError } from '@/lib/security/classify-mutation-error'
+import { describe, expect, it } from 'vitest'
+
+describe('isAuthorizationError', () => {
+  describe('non-authorization shapes', () => {
+    it('returns false for null', () => {
+      expect(isAuthorizationError(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isAuthorizationError(undefined)).toBe(false)
+    })
+
+    it('returns false for primitives', () => {
+      expect(isAuthorizationError('boom')).toBe(false)
+      expect(isAuthorizationError(42)).toBe(false)
+      expect(isAuthorizationError(true)).toBe(false)
+    })
+
+    it('returns false for objects without code or message', () => {
+      expect(isAuthorizationError({})).toBe(false)
+      expect(isAuthorizationError({ details: 'irrelevant' })).toBe(false)
+    })
+
+    it('returns false for unrelated postgres codes', () => {
+      expect(isAuthorizationError({ code: '23505' })).toBe(false)
+      expect(isAuthorizationError({ code: '23503' })).toBe(false)
+      expect(isAuthorizationError({ code: '22P02' })).toBe(false)
+    })
+
+    it('returns false for unrelated postgrest codes', () => {
+      expect(isAuthorizationError({ code: 'PGRST301' })).toBe(false)
+      expect(isAuthorizationError({ code: 'PGRST100' })).toBe(false)
+    })
+
+    it('returns false for generic error messages', () => {
+      expect(isAuthorizationError({ message: 'network failure' })).toBe(false)
+      expect(
+        isAuthorizationError({ message: 'duplicate key value violates' })
+      ).toBe(false)
+    })
+
+    it('returns false when code is not a string', () => {
+      expect(isAuthorizationError({ code: 42501 })).toBe(false)
+    })
+  })
+
+  describe('authorization error codes', () => {
+    it('matches postgres insufficient_privilege (42501)', () => {
+      expect(isAuthorizationError({ code: '42501' })).toBe(true)
+    })
+
+    it('matches postgres feature_not_supported (0A000) from the [E1.3] trigger', () => {
+      expect(isAuthorizationError({ code: '0A000' })).toBe(true)
+    })
+
+    it('matches postgrest PGRST116 (no rows returned)', () => {
+      expect(isAuthorizationError({ code: 'PGRST116' })).toBe(true)
+    })
+
+    it('matches postgrest PGRST204 (no content)', () => {
+      expect(isAuthorizationError({ code: 'PGRST204' })).toBe(true)
+    })
+
+    it('matches when code is present alongside an unrelated message', () => {
+      expect(
+        isAuthorizationError({
+          code: '42501',
+          message: 'something completely different'
+        })
+      ).toBe(true)
+    })
+  })
+
+  describe('authorization message patterns', () => {
+    it('matches the [E1.3] trigger function name', () => {
+      expect(
+        isAuthorizationError({
+          message:
+            'error in function enforce_settlement_owner_only_columns at line 12'
+        })
+      ).toBe(true)
+    })
+
+    it("matches the trigger's bespoke owner-only message", () => {
+      expect(
+        isAuthorizationError({
+          message:
+            'Only the settlement owner can change settlement_name, campaign_type, survivor_type, uses_scouts, or user_id'
+        })
+      ).toBe(true)
+    })
+
+    it('matches the canonical postgres RLS rejection text', () => {
+      expect(
+        isAuthorizationError({
+          message:
+            'new row violates row-level security policy for table "settlement"'
+        })
+      ).toBe(true)
+    })
+
+    it('matches postgres permission denied messages', () => {
+      expect(
+        isAuthorizationError({
+          message: 'permission denied for table settlement'
+        })
+      ).toBe(true)
+    })
+
+    it('matches case-insensitively', () => {
+      expect(
+        isAuthorizationError({ message: 'ROW-LEVEL SECURITY violated' })
+      ).toBe(true)
+    })
+  })
+})

--- a/hooks/use-optimistic-mutation.tsx
+++ b/hooks/use-optimistic-mutation.tsx
@@ -2,7 +2,8 @@
 
 import { LocalStateType } from '@/contexts/local-context'
 import { useToast } from '@/hooks/use-toast'
-import { ERROR_MESSAGE } from '@/lib/messages'
+import { ERROR_MESSAGE, NOT_AUTHORIZED_MESSAGE } from '@/lib/messages'
+import { isAuthorizationError } from '@/lib/security/classify-mutation-error'
 import { useCallback } from 'react'
 
 /**
@@ -12,7 +13,11 @@ import { useCallback } from 'react'
  * The hook then runs `persist`, invoking `onSuccess` (to replace temp IDs,
  * etc.) on resolve, or `rollback` (to undo the optimistic update) on reject.
  * It always logs with a consistent `"${context} Error:"` prefix and surfaces
- * the shared `ERROR_MESSAGE()` toast on failure.
+ * the shared `ERROR_MESSAGE()` toast on failure. Rejections that look like
+ * authorization boundaries (RLS, the [E1.3] ownership trigger, or a PostgREST
+ * permission/visibility check) are instead surfaced as the lantern-themed
+ * `NOT_AUTHORIZED_MESSAGE()` toast so collaborators clicking an owner-only
+ * control get a meaningful message instead of the generic fallback.
  */
 export interface OptimisticMutationOptions<T> {
   /**
@@ -83,7 +88,13 @@ export function useOptimisticMutation(local: LocalStateType) {
       } catch (err) {
         if (rollback) rollback(err)
         console.error(`${context} Error:`, err)
-        toast.error(errorMessage ?? ERROR_MESSAGE())
+        if (errorMessage) {
+          toast.error(errorMessage)
+        } else if (isAuthorizationError(err)) {
+          toast.error(NOT_AUTHORIZED_MESSAGE())
+        } else {
+          toast.error(ERROR_MESSAGE())
+        }
       }
     },
     [toast]

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1356,6 +1356,17 @@ export const NEUROSIS_REMOVED_MESSAGE = () => 'The neurosis loosens its grip.'
 export const NEUROSIS_UPDATED_MESSAGE = () => 'The neurosis has shifted.'
 
 /**
+ * Not Authorized
+ *
+ * Used when an RLS policy, ownership trigger, or PostgREST permission check
+ * rejects a mutation attempted by a collaborator on an owner-only control.
+ *
+ * @returns Not Authorized Message
+ */
+export const NOT_AUTHORIZED_MESSAGE = () =>
+  'This is not yours. Speak to the keeper of this settlement.'
+
+/**
  * Scout Conflict
  *
  * @returns Scout Conflict Message

--- a/lib/security/classify-mutation-error.ts
+++ b/lib/security/classify-mutation-error.ts
@@ -1,0 +1,80 @@
+/**
+ * Classify Mutation Error
+ *
+ * Pure helpers for recognising whether a rejected mutation came from an
+ * authorization boundary (RLS policy, ownership trigger, or a PostgREST
+ * permission/visibility check) versus a generic failure. Used by the
+ * optimistic mutation wrapper to swap the user-facing toast from the generic
+ * `ERROR_MESSAGE` to the lantern-themed `NOT_AUTHORIZED_MESSAGE` when a
+ * collaborator hits an owner-only control or a row hidden by RLS.
+ *
+ * See `local/sharing-architecture.md` §10 Phase [E1.9] and the [E1.3] trigger
+ * `enforce_settlement_owner_only_columns` for the full list of rejection
+ * sources this maps.
+ */
+
+/**
+ * Error Codes Treated as Authorization Rejections
+ *
+ * `42501` is Postgres' `insufficient_privilege` SQLSTATE — RLS USING/WITH
+ * CHECK failure. `0A000` is `feature_not_supported`, the SQLSTATE the [E1.3]
+ * `enforce_settlement_owner_only_columns` trigger raises when a collaborator
+ * tries to mutate an owner-only column. `PGRST116` is PostgREST's "no rows
+ * returned" code, which is how a `.single()` / `.maybeSingle()` UPDATE or
+ * DELETE surfaces when RLS filters every targeted row. `PGRST204` is
+ * PostgREST's "no content" code, which is how a bulk UPDATE / DELETE surfaces
+ * the same RLS-zero-rows outcome.
+ */
+const AUTHORIZATION_ERROR_CODES: ReadonlySet<string> = new Set([
+  '42501',
+  '0A000',
+  'PGRST116',
+  'PGRST204'
+])
+
+/**
+ * Message Patterns Treated as Authorization Rejections
+ *
+ * Used as a fallback when the error surfaces without a recognized SQLSTATE
+ * (e.g. when a stack wraps the raw PostgREST error). Matches the [E1.3]
+ * trigger name, the trigger's bespoke user-facing message, and Postgres'
+ * canonical RLS rejection text.
+ */
+const AUTHORIZATION_MESSAGE_PATTERNS: readonly RegExp[] = [
+  /enforce_settlement_owner_only_columns/i,
+  /only the settlement owner can change/i,
+  /row-level security/i,
+  /permission denied/i
+]
+
+/**
+ * Is Authorization Error
+ *
+ * Returns `true` when the supplied error looks like an RLS / ownership
+ * trigger / PostgREST permission rejection. Returns `false` for every other
+ * shape (including `null` / `undefined` / non-object inputs) so the caller
+ * can fall back to the generic error toast.
+ *
+ * @param err Caught Error
+ * @returns Whether the Error Represents an Authorization Rejection
+ */
+export function isAuthorizationError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+
+  const candidate = err as { code?: unknown; message?: unknown }
+
+  if (
+    typeof candidate.code === 'string' &&
+    AUTHORIZATION_ERROR_CODES.has(candidate.code)
+  )
+    return true
+
+  if (typeof candidate.message === 'string') {
+    const message = candidate.message
+    return AUTHORIZATION_MESSAGE_PATTERNS.some((pattern) =>
+      pattern.test(message)
+    )
+  }
+
+  return false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.6",
+      "version": "0.61.7",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

Closes #141.

When a collaborator clicks an owner-only control on a shared settlement, the optimistic mutation wrapper now distinguishes authorization rejections from generic write failures and surfaces a lantern-themed toast instead of the catch-all error message.

## What Changed

- **New pure helper** `lib/security/classify-mutation-error.ts` — `isAuthorizationError(err)` returns `true` for:
  - Postgres `42501` (`insufficient_privilege`, RLS USING/WITH CHECK failure)
  - Postgres `0A000` (`feature_not_supported`, raised by the [E1.3] `enforce_settlement_owner_only_columns` trigger)
  - PostgREST `PGRST116` (no rows returned, e.g. `.single()` UPDATE/DELETE when RLS filters every targeted row)
  - PostgREST `PGRST204` (no content, e.g. bulk UPDATE/DELETE under the same RLS-zero-rows condition)
  - Message-substring fallbacks for the trigger function name, the trigger's bespoke "Only the settlement owner can change…" message, the canonical Postgres row-level-security text, and `permission denied` (case-insensitive)
- **New message** `lib/messages.ts` — `NOT_AUTHORIZED_MESSAGE()` returns `'This is not yours. Speak to the keeper of this settlement.'`
- **Hook update** `hooks/use-optimistic-mutation.tsx` — rejection branch routes through the classifier. Any caller-supplied `errorMessage` override still wins; only the default-error path is affected.

## Acceptance Criteria

- [x] Collaborator clicking a hidden-but-still-present owner-only control gets the lantern-themed toast, not the generic one.
- [x] Other failures still get the generic message (`ERROR_MESSAGE()`).
- [x] Existing `errorMessage` overrides continue to take precedence.
- [x] No DAL, RLS, or trigger changes — purely a client-side error-presentation refinement.

## Tests

- **New** `__tests__/lib/security/classify-mutation-error.test.ts` — 18 cases covering:
  - Each mapped error code (`42501`, `0A000`, `PGRST116`, `PGRST204`)
  - Each message-substring pattern (trigger name, owner-only message, RLS text, permission denied) and case-insensitivity
  - Negative cases: `null`, `undefined`, primitives, empty objects, unrelated Postgres codes (`23505`, `23503`, `22P02`), unrelated PostgREST codes (`PGRST301`, `PGRST100`), generic error messages, and non-string `code` values
- Full unit suite: **2144/2144 passing** (was 2126 + 18 new).

## Dependencies

No dependency changes.

## Version

`v0.61.6` → `v0.61.7` (patch).
