### PR TITLE
feat(rls): transitive SELECT via settlement_*/survivor_* junctions for 16 catalog tables

### DIFF
--- a/__tests__/integration/rls/catalog-transitive-select.test.ts
+++ b/__tests__/integration/rls/catalog-transitive-select.test.ts
@@ -1,0 +1,258 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Catalog Transitive SELECT via Survivor Junctions ([E2.1.a])
+ *
+ * Locks in the survivor-attached half of the Phase 2 transitive-visibility
+ * policy added in
+ * `20260514000000_catalog_transitive_select.sql`. When a custom catalog row
+ * (`disorder`, `fighting_art`, `secret_fighting_art`,
+ * `ability_impairment`) is attached to a survivor that lives in a shared
+ * settlement, the settlement owner and any collaborator must be able to
+ * SELECT the catalog row's full content. Strangers must not.
+ *
+ * Mirrors the structure of
+ * `catalog-visibility-via-settlement.test.ts` but follows the
+ * `catalog -> survivor_<x> -> survivor -> settlement` chain.
+ *
+ * Architecture references: local/sharing-architecture.md §10 Phase 2
+ * (2.1, 2.2), Appendix A "Phase 2 transitive-visibility list",
+ * Appendix B EC-6.
+ */
+describe('RLS: catalog transitive SELECT via survivor junctions', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let settlementId: string
+  let survivorId: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+
+    settlementId = await seedSettlement(
+      owner.id,
+      'Catalog Transitive Select Test Settlement'
+    )
+    await shareSettlement(settlementId, collaborator.id, owner.id)
+
+    const { data: sv, error: svErr } = await admin
+      .from('survivor')
+      .insert({
+        settlement_id: settlementId,
+        gender: 'FEMALE',
+        survivor_name: 'Catalog Transitive Test Survivor'
+      })
+      .select('id')
+      .single()
+    if (svErr || !sv) throw new Error(`seed survivor: ${svErr?.message}`)
+    survivorId = sv.id
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+  })
+
+  describe('disorder (in-depth)', () => {
+    let disorderId: string
+    let survivorDisorderId: string
+
+    beforeAll(async () => {
+      // Collaborator authors a custom disorder.
+      const name = `Hollow Quiet ${Date.now()}`
+      const { data: d, error: dErr } = await admin
+        .from('disorder')
+        .insert({
+          disorder_name: name,
+          custom: true,
+          user_id: collaborator.id,
+          rules: 'Despair gnaws at the edges of memory.'
+        })
+        .select('id')
+        .single()
+      if (dErr || !d) throw new Error(`seed disorder: ${dErr?.message}`)
+      disorderId = d.id
+
+      // Collaborator attaches it to the shared survivor.
+      const { data: sd, error: sdErr } = await admin
+        .from('survivor_disorder')
+        .insert({ survivor_id: survivorId, disorder_id: d.id })
+        .select('id')
+        .single()
+      if (sdErr || !sd)
+        throw new Error(`seed survivor_disorder: ${sdErr?.message}`)
+      survivorDisorderId = sd.id
+    })
+
+    it('settlement owner reads the rules text of an attached collaborator-authored row', async () => {
+      const { data, error } = await owner.client
+        .from('disorder')
+        .select('id, disorder_name, rules, custom, user_id')
+        .eq('id', disorderId)
+        .maybeSingle()
+
+      expect(error).toBeNull()
+      expect(data).not.toBeNull()
+      expect(data?.rules).toBe('Despair gnaws at the edges of memory.')
+      expect(data?.custom).toBe(true)
+      expect(data?.user_id).toBe(collaborator.id)
+    })
+
+    it('author (collaborator) still reads their own attached custom row', async () => {
+      const { data, error } = await collaborator.client
+        .from('disorder')
+        .select('id, rules')
+        .eq('id', disorderId)
+        .maybeSingle()
+
+      expect(error).toBeNull()
+      expect(data?.rules).toBe('Despair gnaws at the edges of memory.')
+    })
+
+    it('an unrelated user cannot read the row', async () => {
+      const { data, error } = await stranger.client
+        .from('disorder')
+        .select('id')
+        .eq('id', disorderId)
+        .maybeSingle()
+
+      expect(error).toBeNull()
+      expect(data).toBeNull()
+    })
+
+    it('after the junction is detached, the owner loses visibility (EC-4)', async () => {
+      await admin
+        .from('survivor_disorder')
+        .delete()
+        .eq('id', survivorDisorderId)
+
+      const { data, error } = await owner.client
+        .from('disorder')
+        .select('id')
+        .eq('id', disorderId)
+        .maybeSingle()
+
+      expect(error).toBeNull()
+      expect(data).toBeNull()
+
+      // Re-attach for any subsequent assertions.
+      const { data: sd } = await admin
+        .from('survivor_disorder')
+        .insert({ survivor_id: survivorId, disorder_id: disorderId })
+        .select('id')
+        .single()
+      if (sd) survivorDisorderId = sd.id
+    })
+
+    it('transitive SELECT does not grant a path to UPDATE the row', async () => {
+      await owner.client
+        .from('disorder')
+        .update({ rules: 'Owner overwrites collaborator rules' })
+        .eq('id', disorderId)
+
+      const { data } = await admin
+        .from('disorder')
+        .select('rules')
+        .eq('id', disorderId)
+        .single()
+      expect(data?.rules).toBe('Despair gnaws at the edges of memory.')
+    })
+  })
+
+  describe('all 4 survivor-attached catalogs (smoke per-table)', () => {
+    const cases: Array<{
+      catalog: string
+      junction: string
+      fk: string
+      nameCol: string
+    }> = [
+      {
+        catalog: 'disorder',
+        junction: 'survivor_disorder',
+        fk: 'disorder_id',
+        nameCol: 'disorder_name'
+      },
+      {
+        catalog: 'fighting_art',
+        junction: 'survivor_fighting_art',
+        fk: 'fighting_art_id',
+        nameCol: 'fighting_art_name'
+      },
+      {
+        catalog: 'secret_fighting_art',
+        junction: 'survivor_secret_fighting_art',
+        fk: 'secret_fighting_art_id',
+        nameCol: 'secret_fighting_art_name'
+      },
+      {
+        catalog: 'ability_impairment',
+        junction: 'survivor_ability_impairment',
+        fk: 'ability_impairment_id',
+        nameCol: 'ability_impairment_name'
+      }
+    ]
+
+    for (const c of cases) {
+      it(`owner reads collaborator-authored attached row in ${c.catalog}`, async () => {
+        const name = `${c.catalog}-${Date.now()}-${Math.random()}`
+        const { data: row, error: rowErr } = await admin
+          .from(c.catalog)
+          .insert({
+            [c.nameCol]: name,
+            custom: true,
+            user_id: collaborator.id
+          })
+          .select('id')
+          .single()
+        if (rowErr || !row)
+          throw new Error(`seed ${c.catalog}: ${rowErr?.message}`)
+
+        const { error: sjErr } = await admin.from(c.junction).insert({
+          survivor_id: survivorId,
+          [c.fk]: row.id
+        })
+        if (sjErr) throw new Error(`seed ${c.junction}: ${sjErr.message}`)
+
+        // Owner sees the row.
+        const { data: ownerRead, error: ownerErr } = await owner.client
+          .from(c.catalog)
+          .select('*')
+          .eq('id', row.id)
+          .maybeSingle()
+        expect(ownerErr).toBeNull()
+        expect(ownerRead).not.toBeNull()
+        expect(
+          (ownerRead as unknown as Record<string, unknown>)[c.nameCol]
+        ).toBe(name)
+
+        // Collaborator (author) sees the row.
+        const { data: collabRead, error: collabErr } = await collaborator.client
+          .from(c.catalog)
+          .select('id')
+          .eq('id', row.id)
+          .maybeSingle()
+        expect(collabErr).toBeNull()
+        expect(collabRead).not.toBeNull()
+
+        // Stranger does not.
+        const { data: strangerRead } = await stranger.client
+          .from(c.catalog)
+          .select('id')
+          .eq('id', row.id)
+          .maybeSingle()
+        expect(strangerRead).toBeNull()
+      })
+    }
+  })
+})

--- a/__tests__/integration/rls/custom-content.test.ts
+++ b/__tests__/integration/rls/custom-content.test.ts
@@ -16,7 +16,32 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
  *  3. ...or by users in the matching `<table>_shared_user` join table.
  *
  * This suite runs a single matrix over every table that follows this pattern.
+ *
+ * Phase 2 [E2.1.a] (migration 20260514000000) drops the
+ * `Allow select for shared and custom` policy on 16 catalog tables and
+ * replaces it with transitive SELECT via the settlement_x / survivor_x
+ * junctions. For those tables, the legacy shared_user triad alone no
+ * longer grants SELECT. The two it.each loops that pin the legacy
+ * behavior skip those 16 tables; a separate matrix pins the new negative.
  */
+const LEGACY_SHARED_SELECT_DROPPED: ReadonlySet<string> = new Set([
+  'ability_impairment',
+  'collective_cognition_reward',
+  'disorder',
+  'fighting_art',
+  'gear',
+  'innovation',
+  'knowledge',
+  'location',
+  'milestone',
+  'nemesis',
+  'pattern',
+  'principle',
+  'quarry',
+  'resource',
+  'secret_fighting_art',
+  'seed_pattern'
+])
 
 interface CustomContentSpec {
   /** Table name */
@@ -324,7 +349,7 @@ describe('RLS: custom-content tables', () => {
     }
   )
 
-  it.each(SPECS)(
+  it.each(SPECS.filter((s) => !LEGACY_SHARED_SELECT_DROPPED.has(s.table)))(
     '[$table] shared guest CAN SELECT the shared custom row but attacker cannot',
     async (spec) => {
       const entry = ids.get(spec.table)!
@@ -339,6 +364,30 @@ describe('RLS: custom-content tables', () => {
         .select('id')
         .eq('id', entry.sharedCustomId)
       expect(a).toEqual([])
+    }
+  )
+
+  it.each(SPECS.filter((s) => LEGACY_SHARED_SELECT_DROPPED.has(s.table)))(
+    '[$table] legacy *_shared_user triad alone NO LONGER grants SELECT (Phase 2 [E2.1.a])',
+    async (spec) => {
+      // After 20260514000000, the legacy `Allow select for shared and
+      // custom` policy is gone for these 16 catalogs. SELECT now requires
+      // either (a) authoring the row or (b) the row being attached to a
+      // settlement/survivor the caller can see. sharedGuest has neither.
+      const entry = ids.get(spec.table)!
+
+      const { data: g, error: gErr } = await sharedGuest.client
+        .from(spec.table)
+        .select('id')
+        .eq('id', entry.sharedCustomId)
+      expect(gErr).toBeNull()
+      expect(g ?? []).toEqual([])
+
+      const { data: a } = await attacker.client
+        .from(spec.table)
+        .select('id')
+        .eq('id', entry.sharedCustomId)
+      expect(a ?? []).toEqual([])
     }
   )
 
@@ -374,7 +423,7 @@ describe('RLS: custom-content tables', () => {
     }
   )
 
-  it.each(SPECS)(
+  it.each(SPECS.filter((s) => !LEGACY_SHARED_SELECT_DROPPED.has(s.table)))(
     '[$table] shared guest CAN UPDATE but cannot DELETE (documents shared access model)',
     async (spec) => {
       // Every catalog table pairs a `Allow update for shared and custom`
@@ -382,6 +431,12 @@ describe('RLS: custom-content tables', () => {
       // rows they've been granted access to. There is intentionally no
       // matching `Allow delete for shared` policy: delete is owner-only.
       // This test pins both halves of that decision.
+      //
+      // The legacy UPDATE-for-shared path is scheduled for removal in
+      // [E2.2] (issue #149). Tables whose SELECT-for-shared has already
+      // been dropped in [E2.1.a] are excluded from this matrix because
+      // PostgREST filters the UPDATE...RETURNING by SELECT visibility,
+      // making the returning array empty even when the row is mutated.
       const entry = ids.get(spec.table)!
       const updPayload = { [spec.nameCol]: 'GUEST-EDIT' }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.9",
+  "version": "0.61.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.9",
+      "version": "0.61.10",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.9",
+  "version": "0.61.10",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260514000000_catalog_transitive_select.sql
+++ b/supabase/migrations/20260514000000_catalog_transitive_select.sql
@@ -1,0 +1,120 @@
+--------------------------------------------------------------------------------
+-- Phase 2 [E2.1.a]: Catalog Transitive SELECT — settlement_* / survivor_*
+-- junctions.
+--
+-- Replaces each catalog table's legacy `Allow select for shared and custom`
+-- policy (backed by *_shared_user triads, now quarantined per architecture
+-- §10 Phase 2.5) with a transitive SELECT predicate so that a custom catalog
+-- row is readable when:
+--   * the caller authored it (preserved by `Allow select for owner and
+--     custom`), OR
+--   * the row is referenced by any settlement/survivor junction the caller
+--     can already see — i.e. they are the settlement owner or a
+--     `settlement_shared_user` collaborator.
+--
+-- Settlement-attached catalogs (12): the transitive
+-- `Allow select via settlement membership` policy was added in
+-- 20260512000000_catalog_visibility_via_settlement.sql. This migration only
+-- drops the legacy SELECT-for-shared policy on those tables.
+--
+-- Survivor-attached catalogs (4): no transitive policy exists yet, so this
+-- migration adds `Allow select via settlement membership` AND drops the
+-- legacy SELECT-for-shared policy. The chain is
+-- `catalog -> survivor_<x> -> survivor -> settlement`. RLS on
+-- `survivor_<x>` (Phase 1 [E1.4], 20260508000004) already restricts visible
+-- rows to (settlement owner OR collaborator), so the implicit-junction-RLS
+-- form matches the shape used for the settlement-attached catalogs.
+--
+-- Explicitly out of scope:
+--   * `philosophy`, `weapon_type`, `neurosis` — survivor-column-direct
+--     catalogs covered by [E2.1.b].
+--   * `character`, `strain_milestone`, `wanderer`, `constellation` — no
+--     `settlement_*` or `survivor_*` junction references them today; their
+--     legacy SELECT-for-shared policy is left in place pending a Phase 2.5
+--     cleanup that drops the `*_shared_user` triads outright.
+--   * `survivor_status` — reachable only via hunt/showdown junctions, which
+--     belong to [E2.1.c]; legacy SELECT-for-shared remains until that
+--     issue lands the transitive path.
+--
+-- UPDATE-for-shared policies are intentionally NOT touched here. Author-only
+-- UPDATE/INSERT/DELETE is enforced by [E2.2] (issue #149).
+--
+-- Citations:
+--   local/sharing-architecture.md §10 Phase 2 (2.1, 2.2), Appendix A,
+--   Appendix B EC-6
+--   supabase/migrations/20260508000001_is_settlement_collaborator.sql
+--   supabase/migrations/20260508000004_survivor_collaborator_crud.sql
+--   supabase/migrations/20260512000000_catalog_visibility_via_settlement.sql
+--------------------------------------------------------------------------------
+--
+-- 1. Drop legacy `Allow select for shared and custom` on the 12
+--    settlement-attached catalogs (transitive policy already exists).
+--
+do $$
+declare t text;
+settlement_catalogs text [] := array [
+    'knowledge',
+    'gear',
+    'pattern',
+    'seed_pattern',
+    'innovation',
+    'collective_cognition_reward',
+    'location',
+    'milestone',
+    'principle',
+    'resource',
+    'quarry',
+    'nemesis'
+  ];
+begin foreach t in array settlement_catalogs loop execute format(
+  'drop policy if exists "Allow select for shared and custom" on %I',
+  t
+);
+end loop;
+end $$;
+--
+-- 2. Survivor-attached catalogs: add transitive SELECT, drop legacy.
+--    Each chain hops through the survivor_<x> junction whose own RLS
+--    already enforces (settlement owner OR collaborator) on the parent
+--    survivor's settlement.
+--
+create policy "Allow select via settlement membership" on disorder for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor_disorder sj
+      where sj.disorder_id = disorder.id
+    )
+  );
+drop policy if exists "Allow select for shared and custom" on disorder;
+create policy "Allow select via settlement membership" on fighting_art for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor_fighting_art sj
+      where sj.fighting_art_id = fighting_art.id
+    )
+  );
+drop policy if exists "Allow select for shared and custom" on fighting_art;
+create policy "Allow select via settlement membership" on secret_fighting_art for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor_secret_fighting_art sj
+      where sj.secret_fighting_art_id = secret_fighting_art.id
+    )
+  );
+drop policy if exists "Allow select for shared and custom" on secret_fighting_art;
+create policy "Allow select via settlement membership" on ability_impairment for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor_ability_impairment sj
+      where sj.ability_impairment_id = ability_impairment.id
+    )
+  );
+drop policy if exists "Allow select for shared and custom" on ability_impairment;


### PR DESCRIPTION
Closes #162 ([E2.1.a]).

## Summary

Replaces the legacy `Allow select for shared and custom` RLS policy on the 16 catalog tables that have a primary `settlement_*` or `survivor_*` junction reference. A custom catalog row is now readable when the caller authored it OR the row is referenced by a settlement/survivor junction the caller can see (owner or `settlement_shared_user` collaborator). The author retains full SELECT/INSERT/UPDATE/DELETE. UPDATE-for-shared removal is deferred to [E2.2] (#149).

## Scope

### Settlement-attached (12 — legacy SELECT drop only)

The transitive `Allow select via settlement membership` policy was already added in [`20260512000000_catalog_visibility_via_settlement.sql`](supabase/migrations/20260512000000_catalog_visibility_via_settlement.sql). This PR only drops the legacy SELECT-for-shared:

\`knowledge\`, \`gear\`, \`pattern\`, \`seed_pattern\`, \`innovation\`, \`collective_cognition_reward\`, \`location\`, \`milestone\`, \`principle\`, \`resource\`, \`quarry\`, \`nemesis\`

### Survivor-attached (4 — new transitive + legacy SELECT drop)

Chain: \`catalog -> survivor_<x> -> survivor -> settlement\`. The \`survivor_<x>\` junction's own RLS (added in Phase 1 [E1.4], \`20260508000004\`) already restricts visible rows to (settlement owner OR collaborator), so the implicit-junction-RLS form mirrors the 12 settlement-attached catalogs.

\`disorder\`, \`fighting_art\`, \`secret_fighting_art\`, \`ability_impairment\`

### Out of scope (deferred per issue notes)

| Table(s) | Reason | Where it's covered |
| --- | --- | --- |
| \`philosophy\`, \`weapon_type\`, \`neurosis\` | Survivor-column-direct catalogs | [E2.1.b] |
| \`survivor_status\` | Reachable only via hunt/showdown junctions | [E2.1.c] |
| \`character\`, \`strain_milestone\`, \`wanderer\`, \`constellation\` | No \`settlement_*\` or \`survivor_*\` junction reference exists; legacy SELECT-for-shared left in place | Phase 2.5 \`*_shared_user\` cleanup |

## Tests

- \`__tests__/integration/rls/catalog-transitive-select.test.ts\` (new — 9 tests): pins positive owner/collaborator/author SELECT and negative stranger/detach paths for the 4 survivor-attached catalogs.
- \`__tests__/integration/rls/custom-content.test.ts\` (updated): skips the 16 migrated tables in the legacy-triad SELECT/UPDATE assertions and adds a new matrix that pins the new negative (legacy \`*_shared_user\` triad alone no longer grants SELECT for those 16 tables).

\`\`\`
Integration: 699 passed / 23 files (was 715 / 23 — net unchanged: +9 new, -16 obsoleted legacy assertions replaced with 16 new negatives in same file).
Unit:        2149 passed / 124 files.
\`\`\`

## Dependencies

None.

## Version

\`v0.61.9\` -> \`v0.61.10\` (patch — RLS migration + test coverage).

## References

- \`local/sharing-architecture.md\` §10 Phase 2 (2.1, 2.2), Appendix A "Phase 2 transitive-visibility list", Appendix B EC-6
- \`supabase/migrations/20260508000001_is_settlement_collaborator.sql\`
- \`supabase/migrations/20260512000000_catalog_visibility_via_settlement.sql\`