### PR TITLE
feat(rls): transitive SELECT via survivor columns for weapon_type, philosophy, neurosis, knowledge, philosophy_rank

### DIFF
--- a/__tests__/integration/rls/catalog-transitive-via-survivor.test.ts
+++ b/__tests__/integration/rls/catalog-transitive-via-survivor.test.ts
@@ -1,0 +1,350 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Catalog Transitive SELECT via Survivor Columns ([E2.1.b])
+ *
+ * Locks in the survivor-column transitive-visibility policy added in
+ * `20260515000000_catalog_transitive_via_survivor.sql`. When a custom
+ * catalog row is referenced directly by a column on `survivor`
+ * (no junction table), the settlement owner and any
+ * `settlement_shared_user` collaborator must be able to SELECT the catalog
+ * row. Strangers must not.
+ *
+ * Catalogs covered:
+ *   * `weapon_type`     ← survivor.weapon_type_id
+ *   * `philosophy`      ← survivor.philosophy_id
+ *   * `neurosis`        ← survivor.neurosis_id
+ *   * `knowledge`       ← survivor.knowledge_1_id / knowledge_2_id /
+ *                          tenet_knowledge_id
+ *   * `philosophy_rank` ← parent philosophy reached via the same chain
+ *
+ * Architecture: local/sharing-architecture.md §5.2 Decision 2,
+ * Appendix A, Appendix B EC-2 / EC-6.
+ */
+describe('RLS: catalog transitive SELECT via survivor columns', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let settlementId: string
+  let survivorId: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+
+    settlementId = await seedSettlement(
+      owner.id,
+      'Catalog Transitive Via Survivor Test Settlement'
+    )
+    await shareSettlement(settlementId, collaborator.id, owner.id)
+
+    const { data: sv, error: svErr } = await admin
+      .from('survivor')
+      .insert({
+        settlement_id: settlementId,
+        gender: 'FEMALE',
+        survivor_name: 'Catalog Transitive Via Survivor Test Survivor'
+      })
+      .select('id')
+      .single()
+    if (svErr || !sv) throw new Error(`seed survivor: ${svErr?.message}`)
+    survivorId = sv.id
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+  })
+
+  /**
+   * Smoke matrix — for each (catalog, survivor column) pair, the
+   * collaborator-authored row referenced by the shared settlement's survivor
+   * must be visible to the owner AND to the collaborator (author SELECT),
+   * but NOT to the stranger.
+   */
+  describe('all 4 survivor-column catalogs (smoke per-table)', () => {
+    const cases: Array<{
+      catalog: string
+      survivorCol: string
+      nameCol: string
+    }> = [
+      {
+        catalog: 'weapon_type',
+        survivorCol: 'weapon_type_id',
+        nameCol: 'weapon_type_name'
+      },
+      {
+        catalog: 'philosophy',
+        survivorCol: 'philosophy_id',
+        nameCol: 'philosophy_name'
+      },
+      {
+        catalog: 'neurosis',
+        survivorCol: 'neurosis_id',
+        nameCol: 'neurosis_name'
+      },
+      {
+        catalog: 'knowledge',
+        survivorCol: 'knowledge_1_id',
+        nameCol: 'knowledge_name'
+      }
+    ]
+
+    for (const c of cases) {
+      it(`owner & author can read collaborator-authored ${c.catalog} referenced by survivor.${c.survivorCol}; stranger cannot`, async () => {
+        const name = `${c.catalog}-${Date.now()}-${Math.random()}`
+        const { data: row, error: rowErr } = await admin
+          .from(c.catalog)
+          .insert({
+            [c.nameCol]: name,
+            custom: true,
+            user_id: collaborator.id
+          })
+          .select('id')
+          .single()
+        if (rowErr || !row)
+          throw new Error(`seed ${c.catalog}: ${rowErr?.message}`)
+
+        const { error: linkErr } = await admin
+          .from('survivor')
+          .update({ [c.survivorCol]: row.id })
+          .eq('id', survivorId)
+        if (linkErr)
+          throw new Error(`link survivor.${c.survivorCol}: ${linkErr.message}`)
+
+        // Owner sees the row.
+        const { data: ownerRead, error: ownerErr } = await owner.client
+          .from(c.catalog)
+          .select('*')
+          .eq('id', row.id)
+          .maybeSingle()
+        expect(ownerErr).toBeNull()
+        expect(ownerRead).not.toBeNull()
+        expect(
+          (ownerRead as unknown as Record<string, unknown>)[c.nameCol]
+        ).toBe(name)
+
+        // Author (collaborator) sees the row via `Allow select for owner
+        // and custom`.
+        const { data: authorRead, error: authorErr } = await collaborator.client
+          .from(c.catalog)
+          .select('id')
+          .eq('id', row.id)
+          .maybeSingle()
+        expect(authorErr).toBeNull()
+        expect(authorRead).not.toBeNull()
+
+        // Stranger does not see the row.
+        const { data: strangerRead } = await stranger.client
+          .from(c.catalog)
+          .select('id')
+          .eq('id', row.id)
+          .maybeSingle()
+        expect(strangerRead).toBeNull()
+
+        // Cleanup link so subsequent cases for the same column start clean.
+        await admin
+          .from('survivor')
+          .update({ [c.survivorCol]: null })
+          .eq('id', survivorId)
+      })
+    }
+  })
+
+  describe('knowledge — every survivor knowledge column reaches the catalog row', () => {
+    for (const col of [
+      'knowledge_1_id',
+      'knowledge_2_id',
+      'tenet_knowledge_id'
+    ]) {
+      it(`survivor.${col} grants SELECT to the settlement owner`, async () => {
+        const name = `Knowledge-${col}-${Date.now()}-${Math.random()}`
+        const { data: row, error: rowErr } = await admin
+          .from('knowledge')
+          .insert({
+            knowledge_name: name,
+            custom: true,
+            user_id: collaborator.id,
+            rules: `A truth bound to ${col}.`
+          })
+          .select('id')
+          .single()
+        if (rowErr || !row)
+          throw new Error(`seed knowledge: ${rowErr?.message}`)
+
+        await admin
+          .from('survivor')
+          .update({ [col]: row.id })
+          .eq('id', survivorId)
+
+        const { data: ownerRead, error: ownerErr } = await owner.client
+          .from('knowledge')
+          .select('id, rules')
+          .eq('id', row.id)
+          .maybeSingle()
+        expect(ownerErr).toBeNull()
+        expect(ownerRead?.rules).toBe(`A truth bound to ${col}.`)
+
+        const { data: strangerRead } = await stranger.client
+          .from('knowledge')
+          .select('id')
+          .eq('id', row.id)
+          .maybeSingle()
+        expect(strangerRead).toBeNull()
+
+        await admin
+          .from('survivor')
+          .update({ [col]: null })
+          .eq('id', survivorId)
+      })
+    }
+  })
+
+  describe('philosophy_rank — visible iff parent philosophy is visible via survivor', () => {
+    let philosophyId: string
+    let philosophyRankId: string
+
+    beforeAll(async () => {
+      // Collaborator authors a custom philosophy and a rank under it.
+      const { data: p, error: pErr } = await admin
+        .from('philosophy')
+        .insert({
+          philosophy_name: `Philosophy-Rank-Test-${Date.now()}`,
+          custom: true,
+          user_id: collaborator.id
+        })
+        .select('id')
+        .single()
+      if (pErr || !p) throw new Error(`seed philosophy: ${pErr?.message}`)
+      philosophyId = p.id
+
+      const { data: pr, error: prErr } = await admin
+        .from('philosophy_rank')
+        .insert({
+          philosophy_id: p.id,
+          rank_number: 1,
+          rules: 'The first rank reveals only shadow.'
+        })
+        .select('id')
+        .single()
+      if (prErr || !pr)
+        throw new Error(`seed philosophy_rank: ${prErr?.message}`)
+      philosophyRankId = pr.id
+    })
+
+    it('owner cannot read the rank when no survivor references the parent philosophy', async () => {
+      const { data, error } = await owner.client
+        .from('philosophy_rank')
+        .select('id')
+        .eq('id', philosophyRankId)
+        .maybeSingle()
+      expect(error).toBeNull()
+      expect(data).toBeNull()
+    })
+
+    it('owner can read the rank once a survivor references the parent philosophy', async () => {
+      await admin
+        .from('survivor')
+        .update({ philosophy_id: philosophyId })
+        .eq('id', survivorId)
+
+      const { data, error } = await owner.client
+        .from('philosophy_rank')
+        .select('id, rules')
+        .eq('id', philosophyRankId)
+        .maybeSingle()
+      expect(error).toBeNull()
+      expect(data).not.toBeNull()
+      expect(data?.rules).toBe('The first rank reveals only shadow.')
+
+      // Stranger never sees the rank.
+      const { data: strangerRead } = await stranger.client
+        .from('philosophy_rank')
+        .select('id')
+        .eq('id', philosophyRankId)
+        .maybeSingle()
+      expect(strangerRead).toBeNull()
+    })
+
+    it('owner loses rank visibility after the survivor link is cleared (EC-4)', async () => {
+      await admin
+        .from('survivor')
+        .update({ philosophy_id: null })
+        .eq('id', survivorId)
+
+      const { data, error } = await owner.client
+        .from('philosophy_rank')
+        .select('id')
+        .eq('id', philosophyRankId)
+        .maybeSingle()
+      expect(error).toBeNull()
+      expect(data).toBeNull()
+    })
+  })
+
+  describe('negative cases', () => {
+    it('owner cannot SELECT a custom weapon_type that no survivor references', async () => {
+      const { data: row } = await admin
+        .from('weapon_type')
+        .insert({
+          weapon_type_name: `Orphan WT ${Date.now()}`,
+          custom: true,
+          user_id: collaborator.id
+        })
+        .select('id')
+        .single()
+
+      const { data, error } = await owner.client
+        .from('weapon_type')
+        .select('id')
+        .eq('id', row!.id)
+        .maybeSingle()
+      expect(error).toBeNull()
+      expect(data).toBeNull()
+    })
+
+    it('transitive SELECT does not grant UPDATE on a referenced philosophy', async () => {
+      const { data: row } = await admin
+        .from('philosophy')
+        .insert({
+          philosophy_name: `Read-only Philosophy ${Date.now()}`,
+          custom: true,
+          user_id: collaborator.id
+        })
+        .select('id')
+        .single()
+
+      await admin
+        .from('survivor')
+        .update({ philosophy_id: row!.id })
+        .eq('id', survivorId)
+
+      await owner.client
+        .from('philosophy')
+        .update({ philosophy_name: 'HACKED' })
+        .eq('id', row!.id)
+
+      const { data: check } = await admin
+        .from('philosophy')
+        .select('philosophy_name')
+        .eq('id', row!.id)
+        .single()
+      expect(check?.philosophy_name).not.toBe('HACKED')
+
+      await admin
+        .from('survivor')
+        .update({ philosophy_id: null })
+        .eq('id', survivorId)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.10",
+  "version": "0.61.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.10",
+      "version": "0.61.11",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.10",
+  "version": "0.61.11",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260515000000_catalog_transitive_via_survivor.sql
+++ b/supabase/migrations/20260515000000_catalog_transitive_via_survivor.sql
@@ -1,0 +1,136 @@
+--------------------------------------------------------------------------------
+-- Phase 2 [E2.1.b]: Catalog Transitive SELECT via survivor columns.
+--
+-- Catalog rows referenced directly by survivor columns (not by a separate
+-- junction table) become transitively visible to anyone who can see the
+-- parent survivor's settlement — i.e. the settlement owner OR a
+-- `settlement_shared_user` collaborator. Chain:
+--
+--   catalog -> survivor.<fk_col> -> survivor.settlement_id -> settlement
+--
+-- Tables and the survivor columns that reach them:
+--   * `weapon_type`     ← survivor.weapon_type_id
+--   * `philosophy`      ← survivor.philosophy_id
+--   * `neurosis`        ← survivor.neurosis_id
+--   * `knowledge`       ← survivor.knowledge_1_id,
+--                          survivor.knowledge_2_id,
+--                          survivor.tenet_knowledge_id
+--   * `philosophy_rank` ← visible iff its parent philosophy is visible via
+--                          a survivor (mirrors the Allow-select-via-survivor
+--                          predicate one hop up)
+--
+-- `tenet_knowledge_id` is not listed in #159's verbatim scope (the issue
+-- enumerates `knowledge_1_id` + `knowledge_2_id`) but it is a real FK to
+-- `knowledge` on `survivor` (introduced in 20260220192245_survivor.sql:117)
+-- and Arc survivors store tenet rules via this column. Excluding it would
+-- leave a visibility gap that contradicts the stated goal "so survivor
+-- knowledges are visible". All three knowledge FKs are covered here.
+--
+-- Postgres ORs multiple permissive SELECT policies. For `knowledge` this
+-- new policy adds the survivor path on top of the
+-- `Allow select via settlement membership` policy created in
+-- 20260512000000 (settlement_knowledge attachment path).
+--
+-- The legacy `Allow select for shared and custom` policies on
+-- weapon_type / philosophy / neurosis / philosophy_rank are intentionally
+-- LEFT IN PLACE in this migration. They are scheduled for removal in the
+-- Phase 2.5 `*_shared_user` deprecation pass (Appendix A "Tables to
+-- deprecate / drop"). The Phase 2 transitive predicate added here is
+-- additive: OR-combined with the existing SELECT policies, it grants the
+-- new path without changing the legacy behaviour.
+--
+-- UPDATE/INSERT/DELETE policies are not touched. Author-only enforcement
+-- of catalog rules text is tracked under [E2.2] (issue #149).
+--
+-- Citations:
+--   local/sharing-architecture.md §5.2 Decision 2, Appendix A,
+--   Appendix B EC-2/EC-6/EC-7
+--   supabase/migrations/20260508000001_is_settlement_collaborator.sql
+--   supabase/migrations/20260512000000_catalog_visibility_via_settlement.sql
+--   supabase/migrations/20260514000000_catalog_transitive_select.sql
+--------------------------------------------------------------------------------
+create policy "Allow select via survivor" on weapon_type for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor sv
+        join settlement s on s.id = sv.settlement_id
+      where sv.weapon_type_id = weapon_type.id
+        and (
+          s.user_id = (
+            select auth.uid()
+          )
+          or is_settlement_collaborator(s.id)
+        )
+    )
+  );
+create policy "Allow select via survivor" on philosophy for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor sv
+        join settlement s on s.id = sv.settlement_id
+      where sv.philosophy_id = philosophy.id
+        and (
+          s.user_id = (
+            select auth.uid()
+          )
+          or is_settlement_collaborator(s.id)
+        )
+    )
+  );
+create policy "Allow select via survivor" on neurosis for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor sv
+        join settlement s on s.id = sv.settlement_id
+      where sv.neurosis_id = neurosis.id
+        and (
+          s.user_id = (
+            select auth.uid()
+          )
+          or is_settlement_collaborator(s.id)
+        )
+    )
+  );
+create policy "Allow select via survivor" on knowledge for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor sv
+        join settlement s on s.id = sv.settlement_id
+      where (
+          sv.knowledge_1_id = knowledge.id
+          or sv.knowledge_2_id = knowledge.id
+          or sv.tenet_knowledge_id = knowledge.id
+        )
+        and (
+          s.user_id = (
+            select auth.uid()
+          )
+          or is_settlement_collaborator(s.id)
+        )
+    )
+  );
+create policy "Allow select via survivor" on philosophy_rank for
+select to authenticated using (
+    exists (
+      select 1
+      from philosophy p
+        join survivor sv on sv.philosophy_id = p.id
+        join settlement s on s.id = sv.settlement_id
+      where p.id = philosophy_rank.philosophy_id
+        and p.custom
+        and (
+          s.user_id = (
+            select auth.uid()
+          )
+          or is_settlement_collaborator(s.id)
+        )
+    )
+  );


### PR DESCRIPTION
Closes #159 ([E2.1.b]).

## Summary

Adds Phase 2 transitive-visibility policies for the 5 catalog tables referenced directly by columns on `survivor` (no junction table). The chain is:

\`\`\`
catalog -> survivor.<fk> -> survivor.settlement_id -> settlement
        -> (settlement owner OR settlement_shared_user collaborator)
\`\`\`

## Scope

| Catalog | Survivor column(s) |
| --- | --- |
| \`weapon_type\` | \`survivor.weapon_type_id\` |
| \`philosophy\` | \`survivor.philosophy_id\` |
| \`neurosis\` | \`survivor.neurosis_id\` |
| \`knowledge\` | \`survivor.knowledge_1_id\`, \`knowledge_2_id\`, \`tenet_knowledge_id\` |
| \`philosophy_rank\` | visible iff parent \`philosophy\` is visible via the survivor chain |

The issue verbatim lists only \`knowledge_1_id\` and \`knowledge_2_id\`, but \`tenet_knowledge_id\` (introduced in [\`20260220192245_survivor.sql\`](supabase/migrations/20260220192245_survivor.sql)) is a real FK to \`knowledge\` on \`survivor\` and stores tenet rules for Arc survivors. Excluding it would leave a visibility gap contradicting the stated goal. All three knowledge FKs are covered.

For \`knowledge\`, the new policy is OR-combined with [\`Allow select via settlement membership\`](supabase/migrations/20260512000000_catalog_visibility_via_settlement.sql) added in [E2.1.a]; Postgres ORs permissive SELECT policies, so both paths (settlement_knowledge attachment OR survivor reference) grant SELECT.

## Left untouched

- Legacy \`Allow select for shared and custom\` policies on these 5 tables remain in place. They will be dropped in the Phase 2.5 \`*_shared_user\` deprecation pass per Appendix A. The Phase 2 transitive predicate added here is purely additive.
- UPDATE / INSERT / DELETE policies — author-only enforcement is tracked under [E2.2] (#149).

## Tests

- New [\`__tests__/integration/rls/catalog-transitive-via-survivor.test.ts\`](__tests__/integration/rls/catalog-transitive-via-survivor.test.ts) (12 tests):
  - smoke matrix across all 4 survivor-column catalogs (owner & author can read, stranger cannot)
  - a knowledge-column matrix that exercises all three FK columns
  - \`philosophy_rank\` visibility tied to parent \`philosophy\` (including the EC-4 "link cleared -> visibility lost" path)
  - negative cases: orphan custom rows not visible; transitive SELECT does not grant UPDATE

\`\`\`
Integration: 711/711 passed (24 files, +12 new)
Unit:        2149/2149 passed (124 files)
\`\`\`

## Dependencies

None. Builds on [E2.1.a] (#162, merged in v0.61.10).

## Version

\`v0.61.10\` -> \`v0.61.11\` (patch — additive RLS migration + test coverage).

## References

- \`local/sharing-architecture.md\` §5.2 Decision 2, Appendix A "Phase 2 transitive-visibility list", Appendix B EC-2/EC-6
- [\`supabase/migrations/20260508000001_is_settlement_collaborator.sql\`](supabase/migrations/20260508000001_is_settlement_collaborator.sql)
- [\`supabase/migrations/20260512000000_catalog_visibility_via_settlement.sql\`](supabase/migrations/20260512000000_catalog_visibility_via_settlement.sql)
- [\`supabase/migrations/20260514000000_catalog_transitive_select.sql\`](supabase/migrations/20260514000000_catalog_transitive_select.sql)