### PR TITLE
feat(rls): drop `Allow update for shared and custom` on all catalog tables (closes #149)

### DIFF
--- a/__tests__/integration/rls/custom-content.test.ts
+++ b/__tests__/integration/rls/custom-content.test.ts
@@ -13,7 +13,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
  *
  *  1. Non-custom rows are readable by any authenticated user.
  *  2. Custom rows are readable/writable only by their owner...
- *  3. ...or by users in the matching `<table>_shared_user` join table.
+ *  3. ...or readable by users in the matching `<table>_shared_user` join
+ *     table (the legacy SELECT-for-shared path, where it still exists).
  *
  * This suite runs a single matrix over every table that follows this pattern.
  *
@@ -23,6 +24,11 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
  * junctions. For those tables, the legacy shared_user triad alone no
  * longer grants SELECT. The two it.each loops that pin the legacy
  * behavior skip those 16 tables; a separate matrix pins the new negative.
+ *
+ * Phase 2 [E2.2] (migration 20260517000000) drops the
+ * `Allow update for shared and custom` policy on every catalog table.
+ * Writes to custom catalog rows are now author-only — collaborators may
+ * SELECT but never UPDATE or DELETE.
  */
 const LEGACY_SHARED_SELECT_DROPPED: ReadonlySet<string> = new Set([
   'ability_impairment',
@@ -423,30 +429,54 @@ describe('RLS: custom-content tables', () => {
     }
   )
 
-  it.each(SPECS.filter((s) => !LEGACY_SHARED_SELECT_DROPPED.has(s.table)))(
-    '[$table] shared guest CAN UPDATE but cannot DELETE (documents shared access model)',
+  it.each(SPECS)(
+    '[$table] author (owner) CAN UPDATE their custom row',
     async (spec) => {
-      // Every catalog table pairs a `Allow update for shared and custom`
-      // policy with its shared-user join table, so shared users can mutate
-      // rows they've been granted access to. There is intentionally no
-      // matching `Allow delete for shared` policy: delete is owner-only.
-      // This test pins both halves of that decision.
+      // Pins the acceptance criterion of [E2.2] (issue #149): after the
+      // `Allow update for shared and custom` policy is dropped, the
+      // surviving `Allow update for owner and custom` policy still lets
+      // the author edit their own custom row.
+      const entry = ids.get(spec.table)!
+      const newName = `RLS-${spec.table}-author-edit`
+
+      const { data: upd, error } = await owner.client
+        .from(spec.table)
+        .update({ [spec.nameCol]: newName })
+        .eq('id', entry.ownerCustomId)
+        .select(`id, ${spec.nameCol}`)
+        .single()
+      expect(error).toBeNull()
+      expect(upd).not.toBeNull()
+      expect((upd as unknown as Record<string, string>)[spec.nameCol]).toBe(
+        newName
+      )
+    }
+  )
+
+  it.each(SPECS)(
+    '[$table] shared guest CANNOT UPDATE or DELETE the shared custom row (author-only writes, [E2.2])',
+    async (spec) => {
+      // After [E2.2] (issue #149, migration
+      // 20260517000000_catalog_drop_update_for_shared.sql) the
+      // `Allow update for shared and custom` policy is gone on every
+      // catalog table. Writes to custom catalog rows are now author-only;
+      // collaborators / shared users may SELECT (where the corresponding
+      // SELECT policy still grants it) but never UPDATE or DELETE.
       //
-      // The legacy UPDATE-for-shared path is scheduled for removal in
-      // [E2.2] (issue #149). Tables whose SELECT-for-shared has already
-      // been dropped in [E2.1.a] are excluded from this matrix because
-      // PostgREST filters the UPDATE...RETURNING by SELECT visibility,
-      // making the returning array empty even when the row is mutated.
+      // For tables in LEGACY_SHARED_SELECT_DROPPED, the shared user also
+      // cannot SELECT post-[E2.1.a], so the UPDATE/DELETE returning is
+      // doubly-empty. For the rest, the returning is empty because the
+      // UPDATE policy is gone. Either way the row must be unchanged —
+      // verified via admin to bypass RLS.
       const entry = ids.get(spec.table)!
       const updPayload = { [spec.nameCol]: 'GUEST-EDIT' }
 
-      const { data: upd, error: updErr } = await sharedGuest.client
+      const { data: upd } = await sharedGuest.client
         .from(spec.table)
         .update(updPayload)
         .eq('id', entry.sharedCustomId)
         .select('id')
-      expect(updErr).toBeNull()
-      expect(upd ?? []).toHaveLength(1)
+      expect(upd ?? []).toEqual([])
 
       const { data: del } = await sharedGuest.client
         .from(spec.table)
@@ -455,12 +485,16 @@ describe('RLS: custom-content tables', () => {
         .select('id')
       expect(del ?? []).toEqual([])
 
-      // Row must still be visible to the owner.
-      const { data: check } = await owner.client
+      // Row must still exist and be unchanged.
+      const { data: check } = await admin
         .from(spec.table)
-        .select('id')
+        .select(`id, ${spec.nameCol}`)
         .eq('id', entry.sharedCustomId)
-      expect(check ?? []).toHaveLength(1)
+        .single()
+      expect(check).not.toBeNull()
+      expect(
+        (check as unknown as Record<string, string>)[spec.nameCol]
+      ).not.toBe('GUEST-EDIT')
     }
   )
 

--- a/__tests__/integration/rls/custom-content.test.ts
+++ b/__tests__/integration/rls/custom-content.test.ts
@@ -70,6 +70,12 @@ const SPECS: CustomContentSpec[] = [
     nameCol: 'ability_impairment_name'
   },
   {
+    table: 'armor_set',
+    sharedTable: 'armor_set_shared_user',
+    fkCol: 'armor_set_id',
+    nameCol: 'armor_set_name'
+  },
+  {
     table: 'character',
     sharedTable: 'character_shared_user',
     fkCol: 'character_id',
@@ -81,6 +87,12 @@ const SPECS: CustomContentSpec[] = [
     fkCol: 'collective_cognition_reward_id',
     nameCol: 'reward_name',
     extras: { collective_cognition: 1 }
+  },
+  {
+    table: 'constellation',
+    sharedTable: 'constellation_shared_user',
+    fkCol: 'constellation_id',
+    nameCol: 'constellation_name'
   },
   {
     table: 'disorder',
@@ -471,26 +483,34 @@ describe('RLS: custom-content tables', () => {
       const entry = ids.get(spec.table)!
       const updPayload = { [spec.nameCol]: 'GUEST-EDIT' }
 
-      const { data: upd } = await sharedGuest.client
+      const { data: upd, error: updErr } = await sharedGuest.client
         .from(spec.table)
         .update(updPayload)
         .eq('id', entry.sharedCustomId)
         .select('id')
+      // RLS filters the row out of the UPDATE...RETURNING set rather than
+      // raising a permission error, so error must be null and the
+      // returning array must be empty. Asserting both pins the policy-
+      // driven 0-rows-updated behavior and prevents a silent PostgREST
+      // error from being misread as success.
+      expect(updErr).toBeNull()
       expect(upd ?? []).toEqual([])
 
-      const { data: del } = await sharedGuest.client
+      const { data: del, error: delErr } = await sharedGuest.client
         .from(spec.table)
         .delete()
         .eq('id', entry.sharedCustomId)
         .select('id')
+      expect(delErr).toBeNull()
       expect(del ?? []).toEqual([])
 
       // Row must still exist and be unchanged.
-      const { data: check } = await admin
+      const { data: check, error: checkErr } = await admin
         .from(spec.table)
         .select(`id, ${spec.nameCol}`)
         .eq('id', entry.sharedCustomId)
         .single()
+      expect(checkErr).toBeNull()
       expect(check).not.toBeNull()
       expect(
         (check as unknown as Record<string, string>)[spec.nameCol]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.12",
+  "version": "0.61.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.12",
+      "version": "0.61.13",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.12",
+  "version": "0.61.13",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260517000000_catalog_drop_update_for_shared.sql
+++ b/supabase/migrations/20260517000000_catalog_drop_update_for_shared.sql
@@ -1,11 +1,10 @@
 --------------------------------------------------------------------------------
 -- [E2.2] Drop `Allow update for shared and custom` on every catalog table.
 --
--- Source of truth: local/sharing-architecture.md §5.2 Decision 2 and §6
--- Permission Matrix. Rules text on catalog rows is author-only:
--- collaborators may SELECT custom catalog rows (via the transitive-SELECT
--- work delivered in [E2.1.a], [E2.1.b], [E2.1.c]) but they must never
--- modify them.
+-- Tracking: Epic E2 (#122), this phase: #149. Rules text on catalog rows
+-- is author-only: collaborators may SELECT custom catalog rows (via the
+-- transitive-SELECT work delivered in [E2.1.a] (#162), [E2.1.b] (#159),
+-- [E2.1.c] (#160)) but they must never modify them.
 --
 -- Author UPDATE remains untouched via the existing
 -- `Allow update for owner and custom` policy on each table.

--- a/supabase/migrations/20260517000000_catalog_drop_update_for_shared.sql
+++ b/supabase/migrations/20260517000000_catalog_drop_update_for_shared.sql
@@ -1,0 +1,56 @@
+--------------------------------------------------------------------------------
+-- [E2.2] Drop `Allow update for shared and custom` on every catalog table.
+--
+-- Source of truth: local/sharing-architecture.md §5.2 Decision 2 and §6
+-- Permission Matrix. Rules text on catalog rows is author-only:
+-- collaborators may SELECT custom catalog rows (via the transitive-SELECT
+-- work delivered in [E2.1.a], [E2.1.b], [E2.1.c]) but they must never
+-- modify them.
+--
+-- Author UPDATE remains untouched via the existing
+-- `Allow update for owner and custom` policy on each table.
+-- INSERT / DELETE remain author-only (out of scope).
+--
+-- The drops are idempotent (`drop policy if exists`) so this migration is
+-- safe to re-run and is independent of [E2.1] ordering.
+--
+-- Tables covered (every catalog table that currently has the policy):
+--   ability_impairment, armor_set, character, collective_cognition_reward,
+--   constellation, disorder, fighting_art, gear, innovation, knowledge,
+--   location, milestone, mood, nemesis, neurosis, pattern, philosophy,
+--   principle, quarry, resource, secret_fighting_art, seed_pattern,
+--   strain_milestone, survivor_status, trait, wanderer, weapon_type.
+--
+-- Not included:
+--   * gear_grid — its `Allow update for shared and custom` policy was
+--     already dropped by
+--     supabase/migrations/20260503000000_gear_grid_settlement_rls.sql when
+--     gear_grid moved to settlement-scoped RLS.
+--------------------------------------------------------------------------------
+drop policy if exists "Allow update for shared and custom" on ability_impairment;
+drop policy if exists "Allow update for shared and custom" on armor_set;
+drop policy if exists "Allow update for shared and custom" on character;
+drop policy if exists "Allow update for shared and custom" on collective_cognition_reward;
+drop policy if exists "Allow update for shared and custom" on constellation;
+drop policy if exists "Allow update for shared and custom" on disorder;
+drop policy if exists "Allow update for shared and custom" on fighting_art;
+drop policy if exists "Allow update for shared and custom" on gear;
+drop policy if exists "Allow update for shared and custom" on innovation;
+drop policy if exists "Allow update for shared and custom" on knowledge;
+drop policy if exists "Allow update for shared and custom" on location;
+drop policy if exists "Allow update for shared and custom" on milestone;
+drop policy if exists "Allow update for shared and custom" on mood;
+drop policy if exists "Allow update for shared and custom" on nemesis;
+drop policy if exists "Allow update for shared and custom" on neurosis;
+drop policy if exists "Allow update for shared and custom" on pattern;
+drop policy if exists "Allow update for shared and custom" on philosophy;
+drop policy if exists "Allow update for shared and custom" on principle;
+drop policy if exists "Allow update for shared and custom" on quarry;
+drop policy if exists "Allow update for shared and custom" on resource;
+drop policy if exists "Allow update for shared and custom" on secret_fighting_art;
+drop policy if exists "Allow update for shared and custom" on seed_pattern;
+drop policy if exists "Allow update for shared and custom" on strain_milestone;
+drop policy if exists "Allow update for shared and custom" on survivor_status;
+drop policy if exists "Allow update for shared and custom" on trait;
+drop policy if exists "Allow update for shared and custom" on wanderer;
+drop policy if exists "Allow update for shared and custom" on weapon_type;


### PR DESCRIPTION
## Summary

Implements [E2.2] of [Epic E2 — Phase 2: Catalog Transitive
Visibility](https://github.com/ncalteen/kdm-app/issues/122) (closes
#149). Rules text on custom catalog rows is now **author-only** —
collaborators may SELECT custom catalog rows (via the transitive paths
delivered in [E2.1.a/b/c]) but may never UPDATE or DELETE them.

## Migration

New migration `supabase/migrations/20260517000000_catalog_drop_update_for_shared.sql`
drops the legacy `Allow update for shared and custom` policy on every
catalog table that currently has it (idempotent `drop policy if exists`):

`ability_impairment`, `armor_set`, `character`,
`collective_cognition_reward`, `constellation`, `disorder`,
`fighting_art`, `gear`, `innovation`, `knowledge`, `location`,
`milestone`, `mood`, `nemesis`, `neurosis`, `pattern`, `philosophy`,
`principle`, `quarry`, `resource`, `secret_fighting_art`,
`seed_pattern`, `strain_milestone`, `survivor_status`, `trait`,
`wanderer`, `weapon_type`.

### Not included

- `gear_grid` — its `Allow update for shared and custom` policy was
  already dropped when it moved to settlement-scoped RLS in
  `20260503000000_gear_grid_settlement_rls.sql`.

## Scope

- **UPDATE only**. The surviving author UPDATE policy
  (`Allow update for owner and custom`) is untouched.
- INSERT / DELETE remain author-only — explicitly out of scope per the
  issue.
- No app-code changes; this is a database + tests PR.

## Testing

- Rewrote the `shared guest CAN UPDATE` matrix in
  `__tests__/integration/rls/custom-content.test.ts` to assert the
  opposite — shared guests CANNOT UPDATE or DELETE the shared custom
  row, with admin readback confirming the row is unchanged.
- Added an explicit `author (owner) CAN UPDATE their custom row` matrix
  to pin the acceptance criterion.
- Matrix coverage extended to all 27 catalog tables (the previous
  shared-UPDATE matrix excluded the 16 in `LEGACY_SHARED_SELECT_DROPPED`
  because their UPDATE...RETURNING was already empty after [E2.1.a]).
- **Full integration suite**: 773 / 773 passing across 25 files.
- **Unit suite**: 2149 / 2149 passing.

## Version

`0.61.12` → `0.61.13`.

Closes #149.
