### PR TITLE
feat(rls): catalog hard-delete guard trigger ([E2.3], closes #153)

### DIFF
--- a/__tests__/integration/rls/catalog-delete-guard.test.ts
+++ b/__tests__/integration/rls/catalog-delete-guard.test.ts
@@ -121,7 +121,7 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
   // ---------------------------------------------------------------------------
   describe('EC-5: delete blocked when a non-self settlement references the row', () => {
     it('settlement_<x> direct junction blocks (knowledge via settlement_knowledge)', async () => {
-      const { data: k } = await admin
+      const { data: k, error: kErr } = await admin
         .from('knowledge')
         .insert({
           knowledge_name: `Knowledge Blocked ${Date.now()}-${Math.random()}`,
@@ -130,17 +130,23 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         })
         .select('id')
         .single()
+      if (kErr || !k) throw new Error(`seed knowledge: ${kErr?.message}`)
 
-      await admin.from('settlement_knowledge').insert({
-        settlement_id: otherSettlementId,
-        knowledge_id: k!.id
-      })
+      const { error: attachErr } = await admin
+        .from('settlement_knowledge')
+        .insert({
+          settlement_id: otherSettlementId,
+          knowledge_id: k.id
+        })
+      if (attachErr)
+        throw new Error(`seed settlement_knowledge: ${attachErr.message}`)
 
       const { error } = await author.client
         .from('knowledge')
         .delete()
-        .eq('id', k!.id)
+        .eq('id', k.id)
       expect(error).not.toBeNull()
+      expect(error?.code).toBe('0A000')
       expect(error?.message).toMatch(/unmake what others rely upon/i)
       expect(error?.message).toContain('Delete Guard — Other Settlement')
 
@@ -148,13 +154,13 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
       const { data: still } = await admin
         .from('knowledge')
         .select('id')
-        .eq('id', k!.id)
+        .eq('id', k.id)
         .maybeSingle()
       expect(still).not.toBeNull()
     })
 
     it('survivor_<x> junction blocks (disorder via survivor_disorder on a non-self settlement)', async () => {
-      const { data: sv } = await admin
+      const { data: sv, error: svErr } = await admin
         .from('survivor')
         .insert({
           settlement_id: otherSettlementId,
@@ -163,8 +169,9 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         })
         .select('id')
         .single()
+      if (svErr || !sv) throw new Error(`seed survivor: ${svErr?.message}`)
 
-      const { data: d } = await admin
+      const { data: d, error: dErr } = await admin
         .from('disorder')
         .insert({
           disorder_name: `Disorder Blocked ${Date.now()}-${Math.random()}`,
@@ -173,22 +180,25 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         })
         .select('id')
         .single()
+      if (dErr || !d) throw new Error(`seed disorder: ${dErr?.message}`)
 
-      await admin
+      const { error: jErr } = await admin
         .from('survivor_disorder')
-        .insert({ survivor_id: sv!.id, disorder_id: d!.id })
+        .insert({ survivor_id: sv.id, disorder_id: d.id })
+      if (jErr) throw new Error(`seed survivor_disorder: ${jErr.message}`)
 
       const { error } = await author.client
         .from('disorder')
         .delete()
-        .eq('id', d!.id)
+        .eq('id', d.id)
       expect(error).not.toBeNull()
+      expect(error?.code).toBe('0A000')
       expect(error?.message).toMatch(/unmake what others rely upon/i)
       expect(error?.message).toContain('Delete Guard — Other Settlement')
     })
 
     it('survivor direct column blocks (philosophy via survivor.philosophy_id)', async () => {
-      const { data: p } = await admin
+      const { data: p, error: pErr } = await admin
         .from('philosophy')
         .insert({
           philosophy_name: `Philosophy Blocked ${Date.now()}-${Math.random()}`,
@@ -197,24 +207,27 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         })
         .select('id')
         .single()
+      if (pErr || !p) throw new Error(`seed philosophy: ${pErr?.message}`)
 
-      await admin.from('survivor').insert({
+      const { error: svErr } = await admin.from('survivor').insert({
         settlement_id: otherSettlementId,
         gender: 'FEMALE',
         survivor_name: 'Philosophy-Carrying Survivor',
-        philosophy_id: p!.id
+        philosophy_id: p.id
       })
+      if (svErr) throw new Error(`seed survivor: ${svErr.message}`)
 
       const { error } = await author.client
         .from('philosophy')
         .delete()
-        .eq('id', p!.id)
+        .eq('id', p.id)
       expect(error).not.toBeNull()
+      expect(error?.code).toBe('0A000')
       expect(error?.message).toMatch(/unmake what others rely upon/i)
     })
 
-    it('hunt_monster_trait junction blocks (trait via another owner`s hunt)', async () => {
-      const { data: t } = await admin
+    it("hunt_monster_trait junction blocks (trait via another owner's hunt)", async () => {
+      const { data: t, error: tErr } = await admin
         .from('trait')
         .insert({
           trait_name: `Trait Blocked ${Date.now()}-${Math.random()}`,
@@ -223,44 +236,50 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         })
         .select('id')
         .single()
+      if (tErr || !t) throw new Error(`seed trait: ${tErr?.message}`)
 
-      const { data: hunt } = await admin
+      const { data: hunt, error: huntErr } = await admin
         .from('hunt')
         .insert({ settlement_id: otherSettlementId, monster_level: 1 })
         .select('id')
         .single()
+      if (huntErr || !hunt) throw new Error(`seed hunt: ${huntErr?.message}`)
 
-      const { data: ad } = await admin
+      const { data: ad, error: adErr } = await admin
         .from('hunt_ai_deck')
-        .insert({ hunt_id: hunt!.id, settlement_id: otherSettlementId })
+        .insert({ hunt_id: hunt.id, settlement_id: otherSettlementId })
         .select('id')
         .single()
+      if (adErr || !ad) throw new Error(`seed hunt_ai_deck: ${adErr?.message}`)
 
-      const { data: hm } = await admin
+      const { data: hm, error: hmErr } = await admin
         .from('hunt_monster')
         .insert({
-          ai_deck_id: ad!.id,
-          hunt_id: hunt!.id,
+          ai_deck_id: ad.id,
+          hunt_id: hunt.id,
           settlement_id: otherSettlementId
         })
         .select('id')
         .single()
+      if (hmErr || !hm) throw new Error(`seed hunt_monster: ${hmErr?.message}`)
 
-      await admin
+      const { error: hmtErr } = await admin
         .from('hunt_monster_trait')
-        .insert({ hunt_monster_id: hm!.id, trait_id: t!.id })
+        .insert({ hunt_monster_id: hm.id, trait_id: t.id })
+      if (hmtErr) throw new Error(`seed hunt_monster_trait: ${hmtErr.message}`)
 
       const { error } = await author.client
         .from('trait')
         .delete()
-        .eq('id', t!.id)
+        .eq('id', t.id)
       expect(error).not.toBeNull()
+      expect(error?.code).toBe('0A000')
       expect(error?.message).toMatch(/unmake what others rely upon/i)
       expect(error?.message).toContain('Delete Guard — Other Settlement')
     })
 
     it('gear_grid selected_armor_set_id blocks (armor_set via gear_grid -> survivor)', async () => {
-      const { data: sv } = await admin
+      const { data: sv, error: svErr } = await admin
         .from('survivor')
         .insert({
           settlement_id: otherSettlementId,
@@ -269,8 +288,9 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         })
         .select('id')
         .single()
+      if (svErr || !sv) throw new Error(`seed survivor: ${svErr?.message}`)
 
-      const { data: as_ } = await admin
+      const { data: as_, error: asErr } = await admin
         .from('armor_set')
         .insert({
           armor_set_name: `Armor Blocked ${Date.now()}-${Math.random()}`,
@@ -279,18 +299,20 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         })
         .select('id')
         .single()
+      if (asErr || !as_) throw new Error(`seed armor_set: ${asErr?.message}`)
 
       const { error: ggErr } = await admin.from('gear_grid').insert({
-        survivor_id: sv!.id,
-        selected_armor_set_id: as_!.id
+        survivor_id: sv.id,
+        selected_armor_set_id: as_.id
       })
-      if (ggErr) throw new Error(`insert gear_grid: ${ggErr.message}`)
+      if (ggErr) throw new Error(`seed gear_grid: ${ggErr.message}`)
 
       const { error } = await author.client
         .from('armor_set')
         .delete()
-        .eq('id', as_!.id)
+        .eq('id', as_.id)
       expect(error).not.toBeNull()
+      expect(error?.code).toBe('0A000')
       expect(error?.message).toMatch(/unmake what others rely upon/i)
     })
 
@@ -302,7 +324,7 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
       const s3 = await seedSettlement(otherOwner.id, 'Delete Guard — Gamma')
       const s4 = await seedSettlement(otherOwner.id, 'Delete Guard — Delta')
 
-      const { data: k } = await admin
+      const { data: k, error: kErr } = await admin
         .from('knowledge')
         .insert({
           knowledge_name: `Multi Block ${Date.now()}-${Math.random()}`,
@@ -311,18 +333,22 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         })
         .select('id')
         .single()
+      if (kErr || !k) throw new Error(`seed knowledge: ${kErr?.message}`)
 
       for (const sid of [otherSettlementId, s2, s3, s4]) {
-        await admin
+        const { error: skErr } = await admin
           .from('settlement_knowledge')
-          .insert({ settlement_id: sid, knowledge_id: k!.id })
+          .insert({ settlement_id: sid, knowledge_id: k.id })
+        if (skErr)
+          throw new Error(`seed settlement_knowledge: ${skErr.message}`)
       }
 
       const { error } = await author.client
         .from('knowledge')
         .delete()
-        .eq('id', k!.id)
+        .eq('id', k.id)
       expect(error).not.toBeNull()
+      expect(error?.code).toBe('0A000')
       // Count of 4 blocking settlements.
       expect(error?.message).toMatch(/4 settlement\(s\)/)
       // Listed names are alphabetically sorted, first 3 only.
@@ -346,7 +372,7 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
     it('admin can delete a non-custom row regardless of attachments (service-role bypass)', async () => {
       // The trigger short-circuits for service_role; we just confirm that
       // a non-custom-row delete via admin succeeds even when attached.
-      const { data: k } = await admin
+      const { data: k, error: kErr } = await admin
         .from('knowledge')
         .insert({
           knowledge_name: `Seed-like ${Date.now()}-${Math.random()}`,
@@ -354,12 +380,14 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         })
         .select('id')
         .single()
+      if (kErr || !k) throw new Error(`seed knowledge: ${kErr?.message}`)
 
-      await admin
+      const { error: skErr } = await admin
         .from('settlement_knowledge')
-        .insert({ settlement_id: otherSettlementId, knowledge_id: k!.id })
+        .insert({ settlement_id: otherSettlementId, knowledge_id: k.id })
+      if (skErr) throw new Error(`seed settlement_knowledge: ${skErr.message}`)
 
-      const { error } = await admin.from('knowledge').delete().eq('id', k!.id)
+      const { error } = await admin.from('knowledge').delete().eq('id', k.id)
       expect(error).toBeNull()
     })
   })
@@ -370,7 +398,7 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
   // ---------------------------------------------------------------------------
   describe('service-role bypass', () => {
     it('admin can delete a custom row referenced by a non-self settlement', async () => {
-      const { data: k } = await admin
+      const { data: k, error: kErr } = await admin
         .from('knowledge')
         .insert({
           knowledge_name: `Admin Force Delete ${Date.now()}-${Math.random()}`,
@@ -379,18 +407,20 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         })
         .select('id')
         .single()
+      if (kErr || !k) throw new Error(`seed knowledge: ${kErr?.message}`)
 
-      await admin
+      const { error: skErr } = await admin
         .from('settlement_knowledge')
-        .insert({ settlement_id: otherSettlementId, knowledge_id: k!.id })
+        .insert({ settlement_id: otherSettlementId, knowledge_id: k.id })
+      if (skErr) throw new Error(`seed settlement_knowledge: ${skErr.message}`)
 
-      const { error } = await admin.from('knowledge').delete().eq('id', k!.id)
+      const { error } = await admin.from('knowledge').delete().eq('id', k.id)
       expect(error).toBeNull()
 
       const { data: gone } = await admin
         .from('knowledge')
         .select('id')
-        .eq('id', k!.id)
+        .eq('id', k.id)
         .maybeSingle()
       expect(gone).toBeNull()
     })
@@ -418,7 +448,7 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
     }>)(
       '[$table] author can delete a custom row (no junction to block)',
       async (spec) => {
-        const { data: row } = await admin
+        const { data: row, error: rowErr } = await admin
           .from(spec.table)
           .insert({
             [spec.nameCol]: `${spec.table} ${Date.now()}-${Math.random()}`,
@@ -428,17 +458,19 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
           })
           .select('id')
           .single()
+        if (rowErr || !row)
+          throw new Error(`seed ${spec.table}: ${rowErr?.message}`)
 
         const { error: delErr } = await author.client
           .from(spec.table)
           .delete()
-          .eq('id', row!.id)
+          .eq('id', row.id)
         expect(delErr).toBeNull()
 
         const { data: gone } = await admin
           .from(spec.table)
           .select('id')
-          .eq('id', row!.id)
+          .eq('id', row.id)
           .maybeSingle()
         expect(gone).toBeNull()
       }

--- a/__tests__/integration/rls/catalog-delete-guard.test.ts
+++ b/__tests__/integration/rls/catalog-delete-guard.test.ts
@@ -1,0 +1,447 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Catalog Hard-Delete Guard ([E2.3])
+ *
+ * Locks in the `enforce_catalog_delete_guard` BEFORE DELETE trigger added
+ * in `20260518000000_catalog_delete_guard_trigger.sql`. Rules:
+ *
+ *  * Authors may hard-delete a custom catalog row only if every settlement
+ *    that currently references it belongs to them.
+ *  * If any non-self settlement references the row, the delete is rejected
+ *    with a friendly error naming up to three blocking settlements.
+ *  * The service role (admin / fixture teardown) bypasses the guard so
+ *    test fixtures and auth.users cascade-deletes keep working.
+ *
+ * Architecture references: #122 Epic E2 Phase 2, #153 this issue,
+ * Appendix B EC-5 (author hard-deletes a referenced custom row), EC-8
+ * (author hard-deletes their own unattached / self-only row).
+ */
+describe('RLS: catalog delete guard ([E2.3])', () => {
+  let author: TestUser
+  let otherOwner: TestUser
+  let authorSettlementId: string
+  let otherSettlementId: string
+
+  beforeAll(async () => {
+    author = await createTestUser()
+    otherOwner = await createTestUser()
+
+    authorSettlementId = await seedSettlement(
+      author.id,
+      'Delete Guard — Author Settlement'
+    )
+    otherSettlementId = await seedSettlement(
+      otherOwner.id,
+      'Delete Guard — Other Settlement'
+    )
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(author.id)
+    await deleteTestUser(otherOwner.id)
+  })
+
+  // ---------------------------------------------------------------------------
+  // EC-8 — author can hard-delete an unattached / self-only custom row.
+  // ---------------------------------------------------------------------------
+  describe('EC-8: author can delete unattached or self-only rows', () => {
+    it('author deletes a brand-new unattached custom knowledge', async () => {
+      const { data: k, error: kErr } = await admin
+        .from('knowledge')
+        .insert({
+          knowledge_name: `Hollow Word ${Date.now()}-${Math.random()}`,
+          custom: true,
+          user_id: author.id
+        })
+        .select('id')
+        .single()
+      if (kErr || !k) throw new Error(`seed knowledge: ${kErr?.message}`)
+
+      const { error: delErr } = await author.client
+        .from('knowledge')
+        .delete()
+        .eq('id', k.id)
+      expect(delErr).toBeNull()
+
+      const { data: gone } = await admin
+        .from('knowledge')
+        .select('id')
+        .eq('id', k.id)
+        .maybeSingle()
+      expect(gone).toBeNull()
+    })
+
+    it('author deletes a custom knowledge attached only to their own settlement', async () => {
+      const { data: k, error: kErr } = await admin
+        .from('knowledge')
+        .insert({
+          knowledge_name: `Self-Only Knowledge ${Date.now()}-${Math.random()}`,
+          custom: true,
+          user_id: author.id
+        })
+        .select('id')
+        .single()
+      if (kErr || !k) throw new Error(`seed knowledge: ${kErr?.message}`)
+
+      const { error: attachErr } = await admin
+        .from('settlement_knowledge')
+        .insert({
+          settlement_id: authorSettlementId,
+          knowledge_id: k.id
+        })
+      if (attachErr) throw new Error(`attach knowledge: ${attachErr.message}`)
+
+      const { error: delErr } = await author.client
+        .from('knowledge')
+        .delete()
+        .eq('id', k.id)
+      expect(delErr).toBeNull()
+
+      const { data: gone } = await admin
+        .from('knowledge')
+        .select('id')
+        .eq('id', k.id)
+        .maybeSingle()
+      expect(gone).toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // EC-5 — author cannot hard-delete when a non-self settlement references
+  // the row. Same shape repeated across reference paths so the dispatch
+  // catches each branch.
+  // ---------------------------------------------------------------------------
+  describe('EC-5: delete blocked when a non-self settlement references the row', () => {
+    it('settlement_<x> direct junction blocks (knowledge via settlement_knowledge)', async () => {
+      const { data: k } = await admin
+        .from('knowledge')
+        .insert({
+          knowledge_name: `Knowledge Blocked ${Date.now()}-${Math.random()}`,
+          custom: true,
+          user_id: author.id
+        })
+        .select('id')
+        .single()
+
+      await admin.from('settlement_knowledge').insert({
+        settlement_id: otherSettlementId,
+        knowledge_id: k!.id
+      })
+
+      const { error } = await author.client
+        .from('knowledge')
+        .delete()
+        .eq('id', k!.id)
+      expect(error).not.toBeNull()
+      expect(error?.message).toMatch(/unmake what others rely upon/i)
+      expect(error?.message).toContain('Delete Guard — Other Settlement')
+
+      // Row must still exist (verified via admin to bypass RLS).
+      const { data: still } = await admin
+        .from('knowledge')
+        .select('id')
+        .eq('id', k!.id)
+        .maybeSingle()
+      expect(still).not.toBeNull()
+    })
+
+    it('survivor_<x> junction blocks (disorder via survivor_disorder on a non-self settlement)', async () => {
+      const { data: sv } = await admin
+        .from('survivor')
+        .insert({
+          settlement_id: otherSettlementId,
+          gender: 'FEMALE',
+          survivor_name: 'Other-Settlement Survivor'
+        })
+        .select('id')
+        .single()
+
+      const { data: d } = await admin
+        .from('disorder')
+        .insert({
+          disorder_name: `Disorder Blocked ${Date.now()}-${Math.random()}`,
+          custom: true,
+          user_id: author.id
+        })
+        .select('id')
+        .single()
+
+      await admin
+        .from('survivor_disorder')
+        .insert({ survivor_id: sv!.id, disorder_id: d!.id })
+
+      const { error } = await author.client
+        .from('disorder')
+        .delete()
+        .eq('id', d!.id)
+      expect(error).not.toBeNull()
+      expect(error?.message).toMatch(/unmake what others rely upon/i)
+      expect(error?.message).toContain('Delete Guard — Other Settlement')
+    })
+
+    it('survivor direct column blocks (philosophy via survivor.philosophy_id)', async () => {
+      const { data: p } = await admin
+        .from('philosophy')
+        .insert({
+          philosophy_name: `Philosophy Blocked ${Date.now()}-${Math.random()}`,
+          custom: true,
+          user_id: author.id
+        })
+        .select('id')
+        .single()
+
+      await admin.from('survivor').insert({
+        settlement_id: otherSettlementId,
+        gender: 'FEMALE',
+        survivor_name: 'Philosophy-Carrying Survivor',
+        philosophy_id: p!.id
+      })
+
+      const { error } = await author.client
+        .from('philosophy')
+        .delete()
+        .eq('id', p!.id)
+      expect(error).not.toBeNull()
+      expect(error?.message).toMatch(/unmake what others rely upon/i)
+    })
+
+    it('hunt_monster_trait junction blocks (trait via another owner`s hunt)', async () => {
+      const { data: t } = await admin
+        .from('trait')
+        .insert({
+          trait_name: `Trait Blocked ${Date.now()}-${Math.random()}`,
+          custom: true,
+          user_id: author.id
+        })
+        .select('id')
+        .single()
+
+      const { data: hunt } = await admin
+        .from('hunt')
+        .insert({ settlement_id: otherSettlementId, monster_level: 1 })
+        .select('id')
+        .single()
+
+      const { data: ad } = await admin
+        .from('hunt_ai_deck')
+        .insert({ hunt_id: hunt!.id, settlement_id: otherSettlementId })
+        .select('id')
+        .single()
+
+      const { data: hm } = await admin
+        .from('hunt_monster')
+        .insert({
+          ai_deck_id: ad!.id,
+          hunt_id: hunt!.id,
+          settlement_id: otherSettlementId
+        })
+        .select('id')
+        .single()
+
+      await admin
+        .from('hunt_monster_trait')
+        .insert({ hunt_monster_id: hm!.id, trait_id: t!.id })
+
+      const { error } = await author.client
+        .from('trait')
+        .delete()
+        .eq('id', t!.id)
+      expect(error).not.toBeNull()
+      expect(error?.message).toMatch(/unmake what others rely upon/i)
+      expect(error?.message).toContain('Delete Guard — Other Settlement')
+    })
+
+    it('gear_grid selected_armor_set_id blocks (armor_set via gear_grid -> survivor)', async () => {
+      const { data: sv } = await admin
+        .from('survivor')
+        .insert({
+          settlement_id: otherSettlementId,
+          gender: 'FEMALE',
+          survivor_name: 'Armor-Wearing Survivor'
+        })
+        .select('id')
+        .single()
+
+      const { data: as_ } = await admin
+        .from('armor_set')
+        .insert({
+          armor_set_name: `Armor Blocked ${Date.now()}-${Math.random()}`,
+          custom: true,
+          user_id: author.id
+        })
+        .select('id')
+        .single()
+
+      const { error: ggErr } = await admin.from('gear_grid').insert({
+        survivor_id: sv!.id,
+        selected_armor_set_id: as_!.id
+      })
+      if (ggErr) throw new Error(`insert gear_grid: ${ggErr.message}`)
+
+      const { error } = await author.client
+        .from('armor_set')
+        .delete()
+        .eq('id', as_!.id)
+      expect(error).not.toBeNull()
+      expect(error?.message).toMatch(/unmake what others rely upon/i)
+    })
+
+    it('counts and names up to 3 blocking settlements (sorted)', async () => {
+      // Three additional settlements for otherOwner, plus the existing
+      // one (= 4 total). The friendly message must list 3 of them and
+      // report the total count = 4.
+      const s2 = await seedSettlement(otherOwner.id, 'Delete Guard — Beta')
+      const s3 = await seedSettlement(otherOwner.id, 'Delete Guard — Gamma')
+      const s4 = await seedSettlement(otherOwner.id, 'Delete Guard — Delta')
+
+      const { data: k } = await admin
+        .from('knowledge')
+        .insert({
+          knowledge_name: `Multi Block ${Date.now()}-${Math.random()}`,
+          custom: true,
+          user_id: author.id
+        })
+        .select('id')
+        .single()
+
+      for (const sid of [otherSettlementId, s2, s3, s4]) {
+        await admin
+          .from('settlement_knowledge')
+          .insert({ settlement_id: sid, knowledge_id: k!.id })
+      }
+
+      const { error } = await author.client
+        .from('knowledge')
+        .delete()
+        .eq('id', k!.id)
+      expect(error).not.toBeNull()
+      // Count of 4 blocking settlements.
+      expect(error?.message).toMatch(/4 settlement\(s\)/)
+      // Listed names are alphabetically sorted, first 3 only.
+      expect(error?.message).toContain('Delete Guard — Beta')
+      expect(error?.message).toContain('Delete Guard — Delta')
+      expect(error?.message).toContain('Delete Guard — Gamma')
+      // The "Other Settlement" sorts AFTER "Delta" / "Gamma" alphabetically
+      // and so should NOT appear in the trimmed 3-name list.
+      expect(error?.message).not.toContain('Delete Guard — Other Settlement')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Non-custom (catalog seed) rows: the guard does not apply. The RLS
+  // policy on each catalog already blocks the delete (it doesn't match the
+  // `custom = true` owner policy), but if RLS were ever to permit it the
+  // trigger must not also block, since the guard's job is only to protect
+  // shared custom content.
+  // ---------------------------------------------------------------------------
+  describe('non-custom rows: guard does not apply', () => {
+    it('admin can delete a non-custom row regardless of attachments (service-role bypass)', async () => {
+      // The trigger short-circuits for service_role; we just confirm that
+      // a non-custom-row delete via admin succeeds even when attached.
+      const { data: k } = await admin
+        .from('knowledge')
+        .insert({
+          knowledge_name: `Seed-like ${Date.now()}-${Math.random()}`,
+          custom: false
+        })
+        .select('id')
+        .single()
+
+      await admin
+        .from('settlement_knowledge')
+        .insert({ settlement_id: otherSettlementId, knowledge_id: k!.id })
+
+      const { error } = await admin.from('knowledge').delete().eq('id', k!.id)
+      expect(error).toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Service-role / fixture-teardown bypass: admin can delete a custom row
+  // even when other owners' settlements reference it.
+  // ---------------------------------------------------------------------------
+  describe('service-role bypass', () => {
+    it('admin can delete a custom row referenced by a non-self settlement', async () => {
+      const { data: k } = await admin
+        .from('knowledge')
+        .insert({
+          knowledge_name: `Admin Force Delete ${Date.now()}-${Math.random()}`,
+          custom: true,
+          user_id: author.id
+        })
+        .select('id')
+        .single()
+
+      await admin
+        .from('settlement_knowledge')
+        .insert({ settlement_id: otherSettlementId, knowledge_id: k!.id })
+
+      const { error } = await admin.from('knowledge').delete().eq('id', k!.id)
+      expect(error).toBeNull()
+
+      const { data: gone } = await admin
+        .from('knowledge')
+        .select('id')
+        .eq('id', k!.id)
+        .maybeSingle()
+      expect(gone).toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Catalogs without settlement-attached junctions: trigger is still
+  // attached for symmetry but the dispatch's `else` branch leaves
+  // `blocking_count = 0` so authors can always delete their own custom rows.
+  // ---------------------------------------------------------------------------
+  describe('catalogs without settlement-attached references', () => {
+    it.each([
+      { table: 'character', nameCol: 'character_name' },
+      { table: 'constellation', nameCol: 'constellation_name' },
+      { table: 'strain_milestone', nameCol: 'strain_milestone_name' },
+      {
+        table: 'wanderer',
+        nameCol: 'wanderer_name',
+        extras: { gender: 'FEMALE' }
+      }
+    ] as Array<{
+      table: string
+      nameCol: string
+      extras?: Record<string, unknown>
+    }>)(
+      '[$table] author can delete a custom row (no junction to block)',
+      async (spec) => {
+        const { data: row } = await admin
+          .from(spec.table)
+          .insert({
+            [spec.nameCol]: `${spec.table} ${Date.now()}-${Math.random()}`,
+            custom: true,
+            user_id: author.id,
+            ...spec.extras
+          })
+          .select('id')
+          .single()
+
+        const { error: delErr } = await author.client
+          .from(spec.table)
+          .delete()
+          .eq('id', row!.id)
+        expect(delErr).toBeNull()
+
+        const { data: gone } = await admin
+          .from(spec.table)
+          .select('id')
+          .eq('id', row!.id)
+          .maybeSingle()
+        expect(gone).toBeNull()
+      }
+    )
+  })
+})

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -12,6 +12,7 @@ import {
   formatJoinedTimeAgo,
   getAvailableNodes,
   getCardColorStyles,
+  getCatalogDeleteGuardMessage,
   getColorStyle,
   getOverwhelmingDarknessLabel,
   saveToLocalStorage,
@@ -455,5 +456,37 @@ describe('formatJoinedTimeAgo', () => {
     expect(formatJoinedTimeAgo('2026-05-10T12:01:00.000Z', NOW)).toBe(
       'just now'
     )
+  })
+})
+
+describe('getCatalogDeleteGuardMessage', () => {
+  it('extracts the friendly message from a wrapped DAL error', () => {
+    const err = new Error(
+      'Error Removing Disorder: You cannot unmake what others rely upon (1 settlement(s): PotL 1)'
+    )
+    expect(getCatalogDeleteGuardMessage(err)).toBe(
+      'You cannot unmake what others rely upon (1 settlement(s): PotL 1)'
+    )
+  })
+
+  it('extracts the message with multiple blocking settlement names', () => {
+    const err = new Error(
+      'Error Removing Knowledge: You cannot unmake what others rely upon (4 settlement(s): Alpha, Beta, Delta)'
+    )
+    expect(getCatalogDeleteGuardMessage(err)).toBe(
+      'You cannot unmake what others rely upon (4 settlement(s): Alpha, Beta, Delta)'
+    )
+  })
+
+  it('returns null when the error is unrelated to the catalog delete guard', () => {
+    const err = new Error('Error Removing Disorder: network timeout')
+    expect(getCatalogDeleteGuardMessage(err)).toBeNull()
+  })
+
+  it('returns null for non-Error values', () => {
+    expect(getCatalogDeleteGuardMessage(null)).toBeNull()
+    expect(getCatalogDeleteGuardMessage(undefined)).toBeNull()
+    expect(getCatalogDeleteGuardMessage('string')).toBeNull()
+    expect(getCatalogDeleteGuardMessage({ message: 'boom' })).toBeNull()
   })
 })

--- a/components/custom/custom-ability-impairments-card.tsx
+++ b/components/custom/custom-ability-impairments-card.tsx
@@ -27,6 +27,7 @@ import {
   NAMELESS_OBJECT_ERROR_MESSAGE
 } from '@/lib/messages'
 import { AbilityImpairmentDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -208,8 +209,9 @@ export function CustomAbilityImpairmentsCard({
         .then(() => toast.success(ABILITY_IMPAIRMENT_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Ability/Impairment Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Ability/Impairment Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-characters-card.tsx
+++ b/components/custom/custom-characters-card.tsx
@@ -27,6 +27,7 @@ import {
   NAMELESS_OBJECT_ERROR_MESSAGE
 } from '@/lib/messages'
 import { CharacterDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -220,8 +221,9 @@ export function CustomCharactersCard({
         )
         .catch((err: unknown) => {
           setCharacters(previousCharacters)
-          console.error('Delete Character Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Character Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [characters, toast]

--- a/components/custom/custom-collective-cognition-rewards-card.tsx
+++ b/components/custom/custom-collective-cognition-rewards-card.tsx
@@ -27,6 +27,7 @@ import {
   NAMELESS_OBJECT_ERROR_MESSAGE
 } from '@/lib/messages'
 import { CollectiveCognitionRewardDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -223,8 +224,10 @@ export function CustomCollectiveCognitionRewardsCard({
         )
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Collective Cognition Reward Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard)
+            console.error('Delete Collective Cognition Reward Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-disorders-card.tsx
+++ b/components/custom/custom-disorders-card.tsx
@@ -27,6 +27,7 @@ import {
   NAMELESS_OBJECT_ERROR_MESSAGE
 } from '@/lib/messages'
 import { DisorderDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -201,8 +202,9 @@ export function CustomDisordersCard({
         .then(() => toast.success(DISORDER_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Disorder Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Disorder Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-fighting-arts-card.tsx
+++ b/components/custom/custom-fighting-arts-card.tsx
@@ -27,6 +27,7 @@ import {
   NAMELESS_OBJECT_ERROR_MESSAGE
 } from '@/lib/messages'
 import { FightingArtDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -207,8 +208,9 @@ export function CustomFightingArtsCard({
         .then(() => toast.success(FIGHTING_ART_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Fighting Art Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Fighting Art Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-gear-card.tsx
+++ b/components/custom/custom-gear-card.tsx
@@ -42,6 +42,7 @@ import {
   ResourceDetail,
   WeaponTypeDetail
 } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -342,8 +343,9 @@ export function CustomGearCard({ local }: CustomGearCardProps): ReactElement {
         })
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Gear Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Gear Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-innovations-card.tsx
+++ b/components/custom/custom-innovations-card.tsx
@@ -27,6 +27,7 @@ import {
   NAMELESS_OBJECT_ERROR_MESSAGE
 } from '@/lib/messages'
 import { InnovationDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -226,8 +227,9 @@ export function CustomInnovationsCard({
         .then(() => toast.success(INNOVATION_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Innovation Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Innovation Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-knowledge-card.tsx
+++ b/components/custom/custom-knowledge-card.tsx
@@ -28,6 +28,7 @@ import {
   NAMELESS_OBJECT_ERROR_MESSAGE
 } from '@/lib/messages'
 import { KnowledgeDetail, PhilosophyDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -266,8 +267,9 @@ export function CustomKnowledgeCard({
         .then(() => toast.success(KNOWLEDGE_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Knowledge Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Knowledge Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-locations-card.tsx
+++ b/components/custom/custom-locations-card.tsx
@@ -27,6 +27,7 @@ import {
   NAMELESS_OBJECT_ERROR_MESSAGE
 } from '@/lib/messages'
 import { LocationDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -201,8 +202,9 @@ export function CustomLocationsCard({
         .then(() => toast.success(LOCATION_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Location Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Location Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-milestones-card.tsx
+++ b/components/custom/custom-milestones-card.tsx
@@ -28,6 +28,7 @@ import {
   NAMELESS_OBJECT_ERROR_MESSAGE
 } from '@/lib/messages'
 import { MilestoneDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -233,8 +234,9 @@ export function CustomMilestonesCard({
         .then(() => toast.success(MILESTONE_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Milestone Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Milestone Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-moods-card.tsx
+++ b/components/custom/custom-moods-card.tsx
@@ -22,6 +22,7 @@ import {
   NAMELESS_OBJECT_ERROR_MESSAGE
 } from '@/lib/messages'
 import { MoodDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -199,8 +200,9 @@ export function CustomMoodsCard({ local }: CustomMoodsCardProps): ReactElement {
         .then(() => toast.success(MOOD_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Mood Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Mood Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-neuroses-card.tsx
+++ b/components/custom/custom-neuroses-card.tsx
@@ -27,6 +27,7 @@ import {
   NEUROSIS_UPDATED_MESSAGE
 } from '@/lib/messages'
 import { NeurosisDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -206,8 +207,9 @@ export function CustomNeurosesCard({
         .then(() => toast.success(NEUROSIS_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Neurosis Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Neurosis Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-patterns-card.tsx
+++ b/components/custom/custom-patterns-card.tsx
@@ -42,6 +42,7 @@ import {
   PatternDetail,
   ResourceDetail
 } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -289,8 +290,9 @@ export function CustomPatternsCard({
         .then(() => toast.success(PATTERN_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Pattern Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Pattern Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-philosophies-card.tsx
+++ b/components/custom/custom-philosophies-card.tsx
@@ -39,6 +39,7 @@ import {
   PHILOSOPHY_UPDATED_MESSAGE
 } from '@/lib/messages'
 import { KnowledgeDetail, NeurosisDetail, PhilosophyDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -311,8 +312,9 @@ export function CustomPhilosophiesCard({
         })
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Philosophy Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Philosophy Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast, onPhilosophiesChange]

--- a/components/custom/custom-principles-card.tsx
+++ b/components/custom/custom-principles-card.tsx
@@ -27,6 +27,7 @@ import {
   PRINCIPLE_UPDATED_MESSAGE
 } from '@/lib/messages'
 import { PrincipleDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -238,8 +239,9 @@ export function CustomPrinciplesCard({
         .then(() => toast.success(PRINCIPLE_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Principle Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Principle Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-resources-card.tsx
+++ b/components/custom/custom-resources-card.tsx
@@ -31,6 +31,7 @@ import {
   RESOURCE_UPDATED_MESSAGE
 } from '@/lib/messages'
 import { PatternDetail, QuarryDetail, ResourceDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -282,8 +283,9 @@ export function CustomResourcesCard({
         .then(() => toast.success(RESOURCE_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Resource Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Resource Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-secret-fighting-arts-card.tsx
+++ b/components/custom/custom-secret-fighting-arts-card.tsx
@@ -27,6 +27,7 @@ import {
   SECRET_FIGHTING_ART_UPDATED_MESSAGE
 } from '@/lib/messages'
 import { SecretFightingArtDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -208,8 +209,9 @@ export function CustomSecretFightingArtsCard({
         .then(() => toast.success(SECRET_FIGHTING_ART_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Secret Fighting Art Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Secret Fighting Art Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-seed-patterns-card.tsx
+++ b/components/custom/custom-seed-patterns-card.tsx
@@ -39,6 +39,7 @@ import {
   QuarryDetail,
   SeedPatternDetail
 } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -273,8 +274,9 @@ export function CustomSeedPatternsCard({
         .then(() => toast.success(SEED_PATTERN_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Seed Pattern Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Seed Pattern Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-strain-milestones-card.tsx
+++ b/components/custom/custom-strain-milestones-card.tsx
@@ -27,6 +27,7 @@ import {
   STRAIN_MILESTONE_UPDATED_MESSAGE
 } from '@/lib/messages'
 import { StrainMilestoneDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -222,8 +223,9 @@ export function CustomStrainMilestonesCard({
         .then(() => toast.success(STRAIN_MILESTONE_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Strain Milestone Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Strain Milestone Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-survivor-statuses-card.tsx
+++ b/components/custom/custom-survivor-statuses-card.tsx
@@ -27,6 +27,7 @@ import {
   SURVIVOR_STATUS_UPDATED_MESSAGE
 } from '@/lib/messages'
 import { SurvivorStatusDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -210,8 +211,9 @@ export function CustomSurvivorStatusesCard({
         .then(() => toast.success(SURVIVOR_STATUS_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Survivor Status Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Survivor Status Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-traits-card.tsx
+++ b/components/custom/custom-traits-card.tsx
@@ -22,6 +22,7 @@ import {
   TRAIT_UPDATED_MESSAGE
 } from '@/lib/messages'
 import { TraitDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -201,8 +202,9 @@ export function CustomTraitsCard({
         .then(() => toast.success(TRAIT_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Trait Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Trait Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/custom/custom-wanderers-card.tsx
+++ b/components/custom/custom-wanderers-card.tsx
@@ -25,6 +25,7 @@ import {
   GearDetail,
   WandererDetail
 } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -114,8 +115,9 @@ export function CustomWanderersCard({
         .then(() => toast.success(WANDERER_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setWanderers(previous)
-          console.error('Delete Wanderer Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Wanderer Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [wanderers, toast]

--- a/components/custom/custom-weapon-types-card.tsx
+++ b/components/custom/custom-weapon-types-card.tsx
@@ -27,6 +27,7 @@ import {
   WEAPON_TYPE_UPDATED_MESSAGE
 } from '@/lib/messages'
 import { WeaponTypeDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -224,8 +225,9 @@ export function CustomWeaponTypesCard({
         .then(() => toast.success(WEAPON_TYPE_REMOVED_MESSAGE()))
         .catch((err: unknown) => {
           setItems(previous)
-          console.error('Delete Weapon Type Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Weapon Type Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [items, toast]

--- a/components/monster/custom-monsters-card.tsx
+++ b/components/monster/custom-monsters-card.tsx
@@ -19,6 +19,7 @@ import { getUserCustomQuarries, removeQuarry } from '@/lib/dal/quarry'
 import { MonsterType } from '@/lib/enums'
 import { CUSTOM_MONSTER_DELETED_MESSAGE, ERROR_MESSAGE } from '@/lib/messages'
 import { NemesisDetail, QuarryDetail } from '@/lib/types'
+import { getCatalogDeleteGuardMessage } from '@/lib/utils'
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
@@ -127,8 +128,9 @@ export function CustomMonstersCard({
         .catch((err: unknown) => {
           // Rollback
           setMonsters(previousMonsters)
-          console.error('Delete Monster Error:', err)
-          toast.error(ERROR_MESSAGE())
+          const guard = getCatalogDeleteGuardMessage(err)
+          if (!guard) console.error('Delete Monster Error:', err)
+          toast.error(guard ?? ERROR_MESSAGE())
         })
     },
     [monsters, toast]

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -435,3 +435,32 @@ export function formatJoinedTimeAgo(
   const diffYears = Math.floor(diffMonths / 12)
   return diffYears === 1 ? '1 year ago' : `${diffYears} years ago`
 }
+
+/**
+ * Get Catalog Delete Guard Message
+ *
+ * Extracts the user-facing message raised by the
+ * `enforce_catalog_delete_guard` Postgres trigger when present in a
+ * caught error. DAL helpers re-throw delete failures as
+ * `new Error('Error Removing X: <postgrest message>')`, so the trigger
+ * text is preserved on `Error.message`. When the error matches, the
+ * extracted slice is suitable to pass directly to a toast.
+ *
+ * The trigger renders messages in the shape
+ * `You cannot unmake what others rely upon (N settlement(s): name1, ...)`.
+ * The nested `(s)` literal means a naive `\([^)]+\)` match terminates too
+ * early; the regex below skips past the literal `settlement(s):` before
+ * consuming the comma-separated settlement names.
+ *
+ * @param err Caught Error Value
+ * @returns Trigger Message Slice, or null when the error is unrelated
+ */
+export function getCatalogDeleteGuardMessage(err: unknown): string | null {
+  if (!(err instanceof Error)) return null
+
+  const match = err.message.match(
+    /You cannot unmake what others rely upon \(\d+ settlement\(s\): [^)]+\)/
+  )
+
+  return match ? match[0] : null
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.15",
+  "version": "0.61.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.15",
+      "version": "0.61.16",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.14",
+  "version": "0.61.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.14",
+      "version": "0.61.15",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.13",
+  "version": "0.61.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.13",
+      "version": "0.61.14",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.15",
+  "version": "0.61.16",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.13",
+  "version": "0.61.14",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.14",
+  "version": "0.61.15",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260518000000_catalog_delete_guard_trigger.sql
+++ b/supabase/migrations/20260518000000_catalog_delete_guard_trigger.sql
@@ -1,0 +1,660 @@
+--------------------------------------------------------------------------------
+-- [E2.3] BEFORE DELETE trigger guard on every catalog table.
+--
+-- Tracking: Epic E2 (#122), this phase: #153. Implements the architecture
+-- decision D2 — block hard-deletes of custom catalog rows attached to
+-- settlements the author does not own. Soft-delete is intentionally
+-- deferred to [E4.7].
+--
+-- Scope: a single SECURITY DEFINER trigger function
+-- (`enforce_catalog_delete_guard`) attached to every catalog table that
+-- has `custom` + `user_id` columns. The function uses `TG_TABLE_NAME` to
+-- dispatch to the correct settlement-reach query for each catalog.
+--
+-- Two early returns:
+--   * Service-role / admin contexts (test fixtures, auth.users cascades,
+--     admin tooling) bypass the guard so cleanup paths still work.
+--   * Non-custom rows skip the guard — catalog seed data is governed by
+--     the existing RLS policies, not by this trigger.
+--
+-- For custom rows, the dispatch builds a `union`-ed list of distinct
+-- (settlement_id, settlement_name) pairs reachable through any reference
+-- whose terminal `settlement.user_id` differs from `OLD.user_id`. If any
+-- such settlements exist, the delete is rejected with a friendly,
+-- theme-flavored message that names up to 3 blocking settlements.
+--
+-- Catalog tables WITHOUT settlement-attached references
+-- (`character`, `constellation`, `strain_milestone`, `wanderer`) still
+-- get the trigger attached for symmetry, but the dispatch has no
+-- matching `case` branch, so `blocking_count` stays 0 and the delete
+-- proceeds.
+--
+-- Citations:
+--   #122 Epic E2 — Phase 2: Catalog Transitive Visibility
+--   #153 this issue — BEFORE DELETE trigger guard
+--   #149 [E2.2] author-only UPDATE/DELETE
+--   #162 / #159 / #160 [E2.1.a-c] transitive SELECT
+--   supabase/migrations/20260512000000_catalog_visibility_via_settlement.sql
+--   supabase/migrations/20260514000000_catalog_transitive_select.sql
+--   supabase/migrations/20260515000000_catalog_transitive_via_survivor.sql
+--   supabase/migrations/20260516000000_catalog_transitive_hunt_showdown.sql
+--------------------------------------------------------------------------------
+create or replace function public.enforce_catalog_delete_guard() returns trigger language plpgsql security definer
+set search_path = '' as $$
+declare blocking_count int := 0;
+blocking_names text [] := array []::text [];
+begin -- Bypass for service-role / admin contexts. Triggers fire even when RLS
+-- is bypassed, so fixture teardown and auth.users cascade-deletes must
+-- skip the guard explicitly. The check mirrors `is_admin()` (which
+-- looks at `auth.role()`) and adds the supabase service_role role name.
+if (
+  auth.role() = 'service_role'
+  or auth.role() = 'admin'
+  or auth.role() is null
+) then return old;
+end if;
+-- Non-custom rows: catalog seed data. The RLS policies govern these;
+-- the guard does not apply.
+if not old.custom then return old;
+end if;
+case
+  tg_table_name
+  when 'ability_impairment' then with blocking as (
+    select distinct s.id,
+      s.settlement_name
+    from public.survivor_ability_impairment j
+      join public.survivor sv on sv.id = j.survivor_id
+      join public.settlement s on s.id = sv.settlement_id
+    where j.ability_impairment_id = old.id
+      and s.user_id <> old.user_id
+  )
+  select count(*),
+    (
+      array_agg(
+        settlement_name
+        order by settlement_name
+      )
+    ) [1:3] into blocking_count,
+    blocking_names
+  from blocking;
+when 'armor_set' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.gear_grid gg
+    join public.survivor sv on sv.id = gg.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where gg.selected_armor_set_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'collective_cognition_reward' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_collective_cognition_reward j
+    join public.settlement s on s.id = j.settlement_id
+  where j.collective_cognition_reward_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'disorder' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor_disorder j
+    join public.survivor sv on sv.id = j.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where j.disorder_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'fighting_art' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor_fighting_art j
+    join public.survivor sv on sv.id = j.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where j.fighting_art_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'gear' then -- Settlement-attached gear: settlement_gear, survivor_cursed_gear,
+-- and any of the 9 gear_grid pos_* slots (3x3 layout).
+with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_gear j
+    join public.settlement s on s.id = j.settlement_id
+  where j.gear_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor_cursed_gear j
+    join public.survivor sv on sv.id = j.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where j.gear_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.gear_grid gg
+    join public.survivor sv on sv.id = gg.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where (
+      gg.pos_top_left = old.id
+      or gg.pos_top_center = old.id
+      or gg.pos_top_right = old.id
+      or gg.pos_mid_left = old.id
+      or gg.pos_mid_center = old.id
+      or gg.pos_mid_right = old.id
+      or gg.pos_bottom_left = old.id
+      or gg.pos_bottom_center = old.id
+      or gg.pos_bottom_right = old.id
+    )
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'innovation' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_innovation j
+    join public.settlement s on s.id = j.settlement_id
+  where j.innovation_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'knowledge' then -- knowledge is reachable via settlement_knowledge (direct) AND via
+-- three survivor columns (knowledge_1_id, knowledge_2_id,
+-- tenet_knowledge_id), matching the SELECT predicate in
+-- 20260515000000_catalog_transitive_via_survivor.sql.
+with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_knowledge j
+    join public.settlement s on s.id = j.settlement_id
+  where j.knowledge_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor sv
+    join public.settlement s on s.id = sv.settlement_id
+  where (
+      sv.knowledge_1_id = old.id
+      or sv.knowledge_2_id = old.id
+      or sv.tenet_knowledge_id = old.id
+    )
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'location' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_location j
+    join public.settlement s on s.id = j.settlement_id
+  where j.location_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'milestone' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_milestone j
+    join public.settlement s on s.id = j.settlement_id
+  where j.milestone_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'mood' then -- mood is reachable via four hunt/showdown/quarry/nemesis junctions,
+-- matching the SELECT predicate in
+-- 20260516000000_catalog_transitive_hunt_showdown.sql.
+with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.hunt_monster_mood j
+    join public.hunt_monster m on m.id = j.hunt_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.mood_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.showdown_monster_mood j
+    join public.showdown_monster m on m.id = j.showdown_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.mood_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.quarry_level_mood j
+    join public.quarry_level ql on ql.id = j.quarry_level_id
+    join public.settlement_quarry sq on sq.quarry_id = ql.quarry_id
+    join public.settlement s on s.id = sq.settlement_id
+  where j.mood_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.nemesis_level_mood j
+    join public.nemesis_level nl on nl.id = j.nemesis_level_id
+    join public.settlement_nemesis sn on sn.nemesis_id = nl.nemesis_id
+    join public.settlement s on s.id = sn.settlement_id
+  where j.mood_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'nemesis' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_nemesis j
+    join public.settlement s on s.id = j.settlement_id
+  where j.nemesis_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'neurosis' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor sv
+    join public.settlement s on s.id = sv.settlement_id
+  where sv.neurosis_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'pattern' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_pattern j
+    join public.settlement s on s.id = j.settlement_id
+  where j.pattern_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'philosophy' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_philosophy j
+    join public.settlement s on s.id = j.settlement_id
+  where j.philosophy_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor sv
+    join public.settlement s on s.id = sv.settlement_id
+  where sv.philosophy_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'principle' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_principle j
+    join public.settlement s on s.id = j.settlement_id
+  where j.principle_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'quarry' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_quarry j
+    join public.settlement s on s.id = j.settlement_id
+  where j.quarry_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'resource' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_resource j
+    join public.settlement s on s.id = j.settlement_id
+  where j.resource_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'secret_fighting_art' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor_secret_fighting_art j
+    join public.survivor sv on sv.id = j.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where j.secret_fighting_art_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'seed_pattern' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_seed_pattern j
+    join public.settlement s on s.id = j.settlement_id
+  where j.seed_pattern_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'survivor_status' then -- survivor_status is reachable via four hunt/showdown/quarry/nemesis
+-- junctions (parallel to mood/trait).
+with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.hunt_monster_survivor_status j
+    join public.hunt_monster m on m.id = j.hunt_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.survivor_status_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.showdown_monster_survivor_status j
+    join public.showdown_monster m on m.id = j.showdown_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.survivor_status_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.quarry_level_survivor_status j
+    join public.quarry_level ql on ql.id = j.quarry_level_id
+    join public.settlement_quarry sq on sq.quarry_id = ql.quarry_id
+    join public.settlement s on s.id = sq.settlement_id
+  where j.survivor_status_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.nemesis_level_survivor_status j
+    join public.nemesis_level nl on nl.id = j.nemesis_level_id
+    join public.settlement_nemesis sn on sn.nemesis_id = nl.nemesis_id
+    join public.settlement s on s.id = sn.settlement_id
+  where j.survivor_status_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'trait' then -- trait is reachable via four hunt/showdown/quarry/nemesis junctions,
+-- matching the SELECT predicate in
+-- 20260516000000_catalog_transitive_hunt_showdown.sql.
+with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.hunt_monster_trait j
+    join public.hunt_monster m on m.id = j.hunt_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.trait_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.showdown_monster_trait j
+    join public.showdown_monster m on m.id = j.showdown_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.trait_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.quarry_level_trait j
+    join public.quarry_level ql on ql.id = j.quarry_level_id
+    join public.settlement_quarry sq on sq.quarry_id = ql.quarry_id
+    join public.settlement s on s.id = sq.settlement_id
+  where j.trait_id = old.id
+    and s.user_id <> old.user_id
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.nemesis_level_trait j
+    join public.nemesis_level nl on nl.id = j.nemesis_level_id
+    join public.settlement_nemesis sn on sn.nemesis_id = nl.nemesis_id
+    join public.settlement s on s.id = sn.settlement_id
+  where j.trait_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'weapon_type' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor sv
+    join public.settlement s on s.id = sv.settlement_id
+  where sv.weapon_type_id = old.id
+    and s.user_id <> old.user_id
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+else -- character / constellation / strain_milestone / wanderer have no
+-- settlement-attached junctions today. The trigger still fires for
+-- symmetry (so adding a future settlement junction can plug into
+-- the same dispatch), but blocking_count stays 0 and the delete
+-- proceeds.
+null;
+end case
+;
+if blocking_count > 0 then raise exception using errcode = '0A000',
+message = format(
+  'You cannot unmake what others rely upon (%s settlement(s): %s)',
+  blocking_count,
+  array_to_string(blocking_names, ', ')
+);
+end if;
+return old;
+end;
+$$;
+--
+-- Attach the trigger to every catalog table (every table with
+-- `custom` + `user_id` columns). The trigger name is the same on every
+-- table because Postgres scopes trigger names per-table.
+--
+do $$
+declare t text;
+catalog_tables text [] := array [
+  'ability_impairment',
+  'armor_set',
+  'character',
+  'collective_cognition_reward',
+  'constellation',
+  'disorder',
+  'fighting_art',
+  'gear',
+  'innovation',
+  'knowledge',
+  'location',
+  'milestone',
+  'mood',
+  'nemesis',
+  'neurosis',
+  'pattern',
+  'philosophy',
+  'principle',
+  'quarry',
+  'resource',
+  'secret_fighting_art',
+  'seed_pattern',
+  'strain_milestone',
+  'survivor_status',
+  'trait',
+  'wanderer',
+  'weapon_type'
+];
+begin foreach t in array catalog_tables loop execute format(
+  'drop trigger if exists enforce_catalog_delete_guard on public.%I;',
+  t
+);
+execute format(
+  'create trigger enforce_catalog_delete_guard before delete on public.%I for each row execute function public.enforce_catalog_delete_guard();',
+  t
+);
+end loop;
+end $$;

--- a/supabase/migrations/20260518000000_catalog_delete_guard_trigger.sql
+++ b/supabase/migrations/20260518000000_catalog_delete_guard_trigger.sql
@@ -45,12 +45,15 @@ declare blocking_count int := 0;
 blocking_names text [] := array []::text [];
 begin -- Bypass for service-role / admin contexts. Triggers fire even when RLS
 -- is bypassed, so fixture teardown and auth.users cascade-deletes must
--- skip the guard explicitly. The check mirrors `is_admin()` (which
--- looks at `auth.role()`) and adds the supabase service_role role name.
+-- skip the guard explicitly. `public.is_admin()` covers the
+-- `auth.role() = 'admin'` case (and stays in lock-step with that helper
+-- if its definition ever changes). The two explicit checks handle the
+-- Supabase service_role and the no-auth / direct-DB context (where
+-- `auth.role()` returns NULL) that `is_admin()` would not match.
 if (
   auth.role() = 'service_role'
-  or auth.role() = 'admin'
   or auth.role() is null
+  or public.is_admin()
 ) then return old;
 end if;
 -- Non-custom rows: catalog seed data. The RLS policies govern these;


### PR DESCRIPTION
## Summary

Implements **[E2.3] — BEFORE DELETE trigger guard on every catalog table** ([#153](https://github.com/ncalteen/kdm-app/issues/153)).

Adds a single `SECURITY DEFINER` trigger function, `public.enforce_catalog_delete_guard()`, attached to every catalog table that has `custom` + `user_id` columns (27 tables in total). The function dispatches on `TG_TABLE_NAME` to the correct settlement-reach query for each catalog. When any settlement *not* owned by `OLD.user_id` currently references the row, the delete is rejected with a friendly, theme-flavored Postgres exception (`errcode '0A000'`) naming up to three blocking settlements.

This closes the architecture-decision gap left by [E2.2] (#214): without a guard, authors could nuke their custom rows out from under other owners' settlements even though those rows were transitively visible to them.

Soft-delete remains intentionally deferred to **[E4.7]**.

## Behaviour

For every `custom = true` catalog row, on `BEFORE DELETE`:

| Caller context | Result |
| --- | --- |
| Service role / admin / direct DB connection | Bypassed — fixture teardown and `auth.users` cascades still work |
| Row has `custom = false` (catalog seed) | Bypassed — governed by existing RLS, not by this guard |
| All referencing settlements belong to the deleter | Allowed |
| Any referencing settlement belongs to another user | Rejected with `You cannot unmake what others rely upon (N settlement(s): A, B, C)` |

Blocking settlement names are sorted alphabetically and trimmed to the first three; the count reflects the true total.

## Reach paths covered

| Catalog | Path(s) |
| --- | --- |
| `ability_impairment` | `survivor_ability_impairment → survivor → settlement` |
| `armor_set` | `gear_grid.selected_armor_set_id → survivor → settlement` |
| `collective_cognition_reward` | `settlement_collective_cognition_reward → settlement` |
| `disorder` | `survivor_disorder → survivor → settlement` |
| `fighting_art` | `survivor_fighting_art → survivor → settlement` |
| `gear` | UNION of `settlement_gear`, `survivor_cursed_gear → survivor`, and any of the 9 `gear_grid.pos_*` slots → survivor → settlement |
| `innovation` | `settlement_innovation → settlement` |
| `knowledge` | UNION of `settlement_knowledge` and `survivor.{knowledge_1_id, knowledge_2_id, tenet_knowledge_id}` |
| `location` | `settlement_location → settlement` |
| `milestone` | `settlement_milestone → settlement` |
| `mood` | UNION of `hunt_monster_mood → hunt_monster.settlement_id`, `showdown_monster_mood → showdown_monster.settlement_id`, `quarry_level_mood → quarry_level → settlement_quarry`, `nemesis_level_mood → nemesis_level → settlement_nemesis` |
| `nemesis` | `settlement_nemesis → settlement` |
| `neurosis` | `survivor.neurosis_id → settlement` |
| `pattern` | `settlement_pattern → settlement` |
| `philosophy` | UNION of `settlement_philosophy` and `survivor.philosophy_id` |
| `principle` | `settlement_principle → settlement` |
| `quarry` | `settlement_quarry → settlement` |
| `resource` | `settlement_resource → settlement` |
| `secret_fighting_art` | `survivor_secret_fighting_art → survivor → settlement` |
| `seed_pattern` | `settlement_seed_pattern → settlement` |
| `survivor_status` | UNION of 4 paths parallel to `mood` / `trait` |
| `trait` | UNION of `hunt_monster_trait`, `showdown_monster_trait`, `quarry_level_trait`, `nemesis_level_trait` |
| `weapon_type` | `survivor.weapon_type_id → settlement` |
| `character` / `constellation` / `strain_milestone` / `wanderer` | No settlement-attached references — dispatch no-ops, delete proceeds |

A single parameterized function with `TG_TABLE_NAME` dispatch was used (matches the issue's "preferred for maintainability" guidance) rather than one tiny function per catalog.

## Tests

New integration tests at [__tests__/integration/rls/catalog-delete-guard.test.ts](__tests__/integration/rls/catalog-delete-guard.test.ts) cover the acceptance criteria from #153:

- **EC-8 (allowed)**: author deletes a brand-new unattached custom row; author deletes a custom row attached only to their own settlement.
- **EC-5 (blocked)**: across each reach-path family — `settlement_<x>` direct junction, `survivor_<x>` junction, direct `survivor` column, hunt/showdown monster junction, `gear_grid.selected_armor_set_id`.
- **Count + name slicing**: when 4 non-self settlements reference the row, the message reports `4 settlement(s)` and names only the alphabetically-first 3.
- **Service-role bypass**: admin can delete a custom row referenced by a non-self settlement.
- **No-junction catalogs**: parameterized check that `character` / `constellation` / `strain_milestone` / `wanderer` always allow the author to hard-delete their own custom rows.

Results:

- **Integration suite**: 803 tests passed (26 files) — 789 baseline + 14 new.
- **Unit suite**: 2149 tests passed (124 files).

## Dependencies

No dependency changes.

## Issues / Related

- Closes #153
- Epic: #122 ([E2] Catalog Transitive Visibility)
- Builds on: #214 ([E2.2] author-only UPDATE/DELETE), #213 ([E2.1.c]), #210 ([E2.1.b]), #207 ([E2.1.a])

## Version

`0.61.13` → `0.61.14`
