### PR TITLE
feat(realtime): add catalog tables to supabase_realtime publication ([E2.4], closes #155)

### DIFF
--- a/__tests__/integration/realtime-publication.test.ts
+++ b/__tests__/integration/realtime-publication.test.ts
@@ -4,21 +4,21 @@ import { describe, expect, it } from 'vitest'
 /**
  * Integration — Realtime Publication Membership
  *
- * Asserts that every settlement-scoped table is included in the
- * `supabase_realtime` publication. Tables in the publication broadcast
- * row-level changes to subscribed clients, which is what powers multiplayer
- * sync for shared settlements.
+ * Asserts that every settlement-scoped table AND every catalog table
+ * covered by [E2.1.a/b/c] is included in the `supabase_realtime`
+ * publication. Tables in the publication broadcast row-level changes to
+ * subscribed clients, which is what powers multiplayer sync for shared
+ * settlements and collaborator-visible custom rules text.
  *
- * If a new settlement-scoped table is added to the schema without being
- * added to the publication, this test fails with a list of missing tables —
- * a much more actionable signal than discovering the gap in production when
- * a collaborator's UI silently goes stale.
+ * If a new settlement-scoped table or a custom catalog is added to the
+ * schema without being added to the publication, this test fails with a
+ * list of missing tables — a much more actionable signal than discovering
+ * the gap in production when a collaborator's UI silently goes stale.
  *
- * Catalog tables (`survivor_status`, `armor_set`, `wanderer*`, etc.) are
- * intentionally out of scope: they are tracked under E2.4 and rely on a
- * different subscription model. `settlement_shared_user` is included here
- * (added to the publication in E1.4) so user-level subscriptions receive
- * invite / revoke events.
+ * `settlement_shared_user` is included here (added to the publication in
+ * E1.4) so user-level subscriptions receive invite / revoke events; it is
+ * intentionally absent from the per-settlement `TABLE_DOMAIN_MAP` in
+ * `hooks/use-realtime.tsx`.
  */
 describe('Realtime publication membership', () => {
   /**
@@ -82,6 +82,55 @@ describe('Realtime publication membership', () => {
     'gear_grid'
   ] as const
 
+  /**
+   * Source of truth: every catalog table whose custom rows must broadcast
+   * to settlement collaborators. Mirrors the `catalog_tables` array in
+   * `20260519000000_catalog_realtime_publication.sql`. New custom-content
+   * tables should be added here alongside their publication-membership
+   * migration.
+   */
+  const EXPECTED_CATALOG_TABLES = [
+    // Settlement-attached catalogs ([E2.1.a]).
+    'knowledge',
+    'disorder',
+    'gear',
+    'pattern',
+    'seed_pattern',
+    'innovation',
+    'fighting_art',
+    'secret_fighting_art',
+    'collective_cognition_reward',
+    'location',
+    'milestone',
+    'principle',
+    'resource',
+    'quarry',
+    'nemesis',
+    'ability_impairment',
+    // Survivor-column-direct catalogs ([E2.1.b]).
+    'neurosis',
+    'philosophy',
+    'philosophy_rank',
+    'weapon_type',
+    // Hunt / showdown / armor catalogs ([E2.1.c]).
+    'trait',
+    'mood',
+    'armor_set',
+    'armor_set_slot',
+    'quarry_level',
+    'quarry_level_trait',
+    'quarry_level_mood',
+    'nemesis_level',
+    'nemesis_level_trait',
+    'nemesis_level_mood',
+    // Catalogs without a settlement-bound junction (yet).
+    'character',
+    'strain_milestone',
+    'wanderer',
+    'constellation',
+    'survivor_status'
+  ] as const
+
   it('includes every settlement-scoped table in `supabase_realtime`', async () => {
     const { data, error } = await admin.rpc('realtime_publication_tables')
 
@@ -104,5 +153,18 @@ describe('Realtime publication membership', () => {
     const rows = (data ?? []) as { tablename: string }[]
     const matches = rows.filter((r) => r.tablename === 'settlement_shared_user')
     expect(matches).toHaveLength(1)
+  })
+
+  // [E2.4] acceptance: every catalog table covered by E2.1.a/b/c is in
+  // the publication so collaborators receive rules-text edits live.
+  it('includes every catalog table in `supabase_realtime` ([E2.4])', async () => {
+    const { data, error } = await admin.rpc('realtime_publication_tables')
+
+    expect(error).toBeNull()
+    const rows = (data ?? []) as { tablename: string }[]
+    const actual = new Set(rows.map((r) => r.tablename))
+    const missing = EXPECTED_CATALOG_TABLES.filter((t) => !actual.has(t))
+
+    expect(missing).toEqual([])
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.16",
+  "version": "0.61.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.16",
+      "version": "0.61.17",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.16",
+  "version": "0.61.17",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260519000000_catalog_realtime_publication.sql
+++ b/supabase/migrations/20260519000000_catalog_realtime_publication.sql
@@ -1,0 +1,97 @@
+--------------------------------------------------------------------------------
+-- Phase 2 [E2.4]: Add catalog tables to `supabase_realtime`.
+--
+-- The transitive-SELECT work in [E2.1.a], [E2.1.b], and [E2.1.c] made every
+-- custom catalog row reachable to settlement collaborators via the RLS
+-- predicate. Without inclusion in the `supabase_realtime` publication
+-- though, those rows still do not stream INSERT/UPDATE/DELETE events to
+-- subscribed clients, so a collaborator's rules-text view goes stale until
+-- a manual reload.
+--
+-- This migration adds every catalog table covered by the three transitive
+-- SELECT migrations (plus the catalogs that are reachable in principle but
+-- did not yet get a transitive policy — `character`, `strain_milestone`,
+-- `wanderer`, `constellation`, `survivor_status` — per the issue scope).
+-- Publication membership is strictly additive: the row is only delivered
+-- if the subscriber's RLS check passes, so adding a table whose
+-- transitive SELECT lands later does not change behavior in the interim.
+--
+-- The list below is one entry per *physical* table. The issue text
+-- (#155) lists `armor_set_slots`, `quarry_level_trait_mood`, and
+-- `nemesis_level_trait_mood` which conflate file / migration names with
+-- actual table identifiers; this migration uses the canonical singular
+-- name (`armor_set_slot`) and splits the trait/mood pairs into the two
+-- physical tables (`quarry_level_trait` + `quarry_level_mood`,
+-- `nemesis_level_trait` + `nemesis_level_mood`).
+--
+-- The publication membership is enforced one statement per table because
+-- `alter publication ... add table` does not accept a list literal and
+-- the existing convention (see `20260506000000_audit_realtime_publication.sql`)
+-- is to wrap each in an idempotent guard. The DRY form below uses a single
+-- `do $$ ... foreach ... loop` block: replays / partial application are
+-- safe because the inner `pg_publication_tables` check skips any table
+-- already in the publication.
+--
+-- Out of scope: client-side subscription wiring (E2.5). Catalogs whose
+-- legacy SELECT policy still gates visibility behind `*_shared_user` are
+-- included in the publication — the row simply will not be delivered to
+-- non-owners until [E2.5] / Appendix A Phase 2.5 cleanup.
+--
+-- Citations:
+--   local/sharing-architecture.md §5.2 Decision 6, §10 Phase 2 item 2.4
+--   supabase/migrations/20260506000000_audit_realtime_publication.sql
+--   supabase/migrations/20260514000000_catalog_transitive_select.sql
+--   supabase/migrations/20260515000000_catalog_transitive_via_survivor.sql
+--   supabase/migrations/20260516000000_catalog_transitive_hunt_showdown.sql
+--------------------------------------------------------------------------------
+do $$
+declare t text;
+catalog_tables text [] := array [
+  'knowledge',
+  'disorder',
+  'gear',
+  'pattern',
+  'seed_pattern',
+  'innovation',
+  'fighting_art',
+  'secret_fighting_art',
+  'collective_cognition_reward',
+  'location',
+  'milestone',
+  'principle',
+  'resource',
+  'quarry',
+  'nemesis',
+  'ability_impairment',
+  'neurosis',
+  'philosophy',
+  'philosophy_rank',
+  'weapon_type',
+  'trait',
+  'mood',
+  'armor_set',
+  'armor_set_slot',
+  'quarry_level',
+  'quarry_level_trait',
+  'quarry_level_mood',
+  'nemesis_level',
+  'nemesis_level_trait',
+  'nemesis_level_mood',
+  'character',
+  'strain_milestone',
+  'wanderer',
+  'constellation',
+  'survivor_status'
+];
+begin foreach t in array catalog_tables loop if not exists (
+  select 1
+  from pg_publication_tables
+  where pubname = 'supabase_realtime'
+    and tablename = t
+) then execute format(
+  'alter publication supabase_realtime add table %I',
+  t
+);
+end if;
+end loop;
+end $$;

--- a/supabase/migrations/20260519000000_catalog_realtime_publication.sql
+++ b/supabase/migrations/20260519000000_catalog_realtime_publication.sql
@@ -87,9 +87,10 @@ begin foreach t in array catalog_tables loop if not exists (
   select 1
   from pg_publication_tables
   where pubname = 'supabase_realtime'
+    and schemaname = 'public'
     and tablename = t
 ) then execute format(
-  'alter publication supabase_realtime add table %I',
+  'alter publication supabase_realtime add table public.%I',
   t
 );
 end if;


### PR DESCRIPTION
## Summary

Closes #155 — Epic E2 Phase 2 item 2.4.

The transitive-SELECT work in [E2.1.a] / [E2.1.b] / [E2.1.c] made every custom catalog row reachable to settlement collaborators via RLS. Without inclusion in the `supabase_realtime` publication though, those rows still do not stream `INSERT` / `UPDATE` / `DELETE` events to subscribed clients, so a collaborator's rules-text view goes stale until a manual reload.

This PR closes that gap.

## Changes

### Migration

`supabase/migrations/20260519000000_catalog_realtime_publication.sql` — a single idempotent `foreach` block that adds 35 catalog tables to `supabase_realtime`. The inner `pg_publication_tables` guard makes replays / partial application no-ops.

| Group | Tables |
| --- | --- |
| Settlement-attached ([E2.1.a]) | `knowledge`, `disorder`, `gear`, `pattern`, `seed_pattern`, `innovation`, `fighting_art`, `secret_fighting_art`, `collective_cognition_reward`, `location`, `milestone`, `principle`, `resource`, `quarry`, `nemesis`, `ability_impairment` |
| Survivor-column direct ([E2.1.b]) | `neurosis`, `philosophy`, `philosophy_rank`, `weapon_type` |
| Hunt / showdown / armor ([E2.1.c]) | `trait`, `mood`, `armor_set`, `armor_set_slot`, `quarry_level`, `quarry_level_trait`, `quarry_level_mood`, `nemesis_level`, `nemesis_level_trait`, `nemesis_level_mood` |
| No settlement-bound junction (yet) | `character`, `strain_milestone`, `wanderer`, `constellation`, `survivor_status` |

**Naming note.** The issue text lists `armor_set_slots`, `quarry_level_trait_mood`, and `nemesis_level_trait_mood`, which conflate file / migration names with physical table identifiers. This migration uses the canonical singular table names (`armor_set_slot`) and splits the trait/mood pairs into the two physical tables (`quarry_level_trait` + `quarry_level_mood`, `nemesis_level_trait` + `nemesis_level_mood`).

### Test

`__tests__/integration/realtime-publication.test.ts` gets a third `it()` — `includes every catalog table in supabase_realtime ([E2.4])` — backed by an `EXPECTED_CATALOG_TABLES` constant that mirrors the migration's table list. The file-level doc comment is reworded to drop the "catalog tables are intentionally out of scope" caveat.

## Acceptance

- [x] All 35 catalog tables present in `pg_publication_tables`.
- [x] The publication test passes (3/3 in [realtime-publication.test.ts](__tests__/integration/realtime-publication.test.ts)).

## Out of scope

- Client-side subscription wiring ([E2.5]). Catalogs whose legacy SELECT policy still gates visibility behind `*_shared_user` are included in the publication; the row simply will not be delivered to non-owners until [E2.5] / Appendix A Phase 2.5 cleanup.

## Tests

- **Unit**: 2153 / 2153 passed.
- **Integration**: 804 / 804 passed (was 803, +1 new).

## Dependencies

No new runtime dependencies.

## Version

`0.61.16` → `0.61.17`.

## Citations

- `local/sharing-architecture.md` §5.2 Decision 6, §10 Phase 2 item 2.4
- `supabase/migrations/20260506000000_audit_realtime_publication.sql`
- `supabase/migrations/20260509000001_settlement_shared_user_realtime.sql`
- `supabase/migrations/20260514000000_catalog_transitive_select.sql`
- `supabase/migrations/20260515000000_catalog_transitive_via_survivor.sql`
- `supabase/migrations/20260516000000_catalog_transitive_hunt_showdown.sql`
