### PR TITLE
feat(realtime): add catalog domain to `useRealtimeSubscriptions` ([E2.5], closes #157)

### DIFF
--- a/contexts/local-context.tsx
+++ b/contexts/local-context.tsx
@@ -533,6 +533,29 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
             console.error('Realtime Survivor Refetch Error:', err)
           })
       }
+    },
+    onCatalogChange: () => {
+      if (!selectedSettlementId) return
+
+      // Custom-content catalog row changes (rules text edits by the
+      // author, etc.) are materialized into `SettlementDetail` — the
+      // settlement collections (knowledges, gear, locations, ...) embed
+      // each catalog row's rules / definitions at fetch time. The
+      // cheapest correct response to a delivered catalog event is to
+      // re-pull the active settlement; the per-domain 300ms debounce in
+      // `useRealtimeSubscriptions` collapses bursts of edits into a
+      // single refetch. RLS is what makes this coarse subscription safe:
+      // events for catalog rows the user cannot read (i.e. rows not
+      // transitively reachable through any settlement they belong to)
+      // are never delivered. See `local/sharing-architecture.md` §8.2.2
+      // (recommendation B).
+      getSettlement(selectedSettlementId)
+        .then((settlement) => {
+          setSelectedSettlementState(settlement)
+        })
+        .catch((err: unknown) => {
+          console.error('Realtime Catalog Refetch Error:', err)
+        })
     }
   })
 

--- a/contexts/local-context.tsx
+++ b/contexts/local-context.tsx
@@ -537,15 +537,24 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
     onCatalogChange: () => {
       if (!selectedSettlementId) return
 
-      // Custom-content catalog row changes (rules text edits by the
-      // author, etc.) are materialized into `SettlementDetail` — the
-      // settlement collections (knowledges, gear, locations, ...) embed
-      // each catalog row's rules / definitions at fetch time. The
-      // cheapest correct response to a delivered catalog event is to
-      // re-pull the active settlement; the per-domain 300ms debounce in
-      // `useRealtimeSubscriptions` collapses bursts of edits into a
-      // single refetch. RLS is what makes this coarse subscription safe:
-      // events for catalog rows the user cannot read (i.e. rows not
+      // Custom-content catalog row changes (rules text edits, etc.) are
+      // materialized into multiple cached views by the DAL projections:
+      //   * `selectedSettlement` (knowledges, gear, locations,
+      //     milestones, innovations, ...).
+      //   * `survivors` + `selectedSurvivor` (disorders, fighting arts,
+      //     secret fighting arts, knowledges, neurosis, ability
+      //     impairments — embedded via `SURVIVOR_SELECT`).
+      //   * `selectedHunt` / `selectedShowdown` monster details (traits,
+      //     moods, survivor_status rules embedded via the monster
+      //     projections).
+      // A single catalog event can touch any of them, so each
+      // materialized collection is refreshed in lockstep — refetching
+      // `SettlementDetail` alone would leave survivor disorders / hunt
+      // monster traits / etc. stale. The 300ms catalog-domain debounce
+      // in `useRealtimeSubscriptions` collapses bursts of rules edits
+      // into a single dispatch, so this fan-out runs at most once per
+      // burst. RLS is what makes the coarse subscription safe: events
+      // for catalog rows the user cannot read (i.e. rows not
       // transitively reachable through any settlement they belong to)
       // are never delivered. See `local/sharing-architecture.md` §8.2.2
       // (recommendation B).
@@ -554,7 +563,41 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
           setSelectedSettlementState(settlement)
         })
         .catch((err: unknown) => {
-          console.error('Realtime Catalog Refetch Error:', err)
+          console.error('Realtime Catalog Settlement Refetch Error:', err)
+        })
+
+      getSurvivors(selectedSettlementId)
+        .then((updatedSurvivors) => {
+          setSurvivors(updatedSurvivors ?? [])
+        })
+        .catch((err: unknown) => {
+          console.error('Realtime Catalog Survivors Refetch Error:', err)
+        })
+
+      if (selectedSurvivorId) {
+        getSurvivor(selectedSurvivorId)
+          .then((survivor) => {
+            setSelectedSurvivorState(survivor)
+          })
+          .catch((err: unknown) => {
+            console.error('Realtime Catalog Survivor Refetch Error:', err)
+          })
+      }
+
+      getHunt(selectedSettlementId)
+        .then((hunt) => {
+          setSelectedHuntState(hunt)
+        })
+        .catch((err: unknown) => {
+          console.error('Realtime Catalog Hunt Refetch Error:', err)
+        })
+
+      getShowdown(selectedSettlementId)
+        .then((showdown) => {
+          setSelectedShowdownState(showdown)
+        })
+        .catch((err: unknown) => {
+          console.error('Realtime Catalog Showdown Refetch Error:', err)
         })
     }
   })

--- a/hooks/use-realtime.tsx
+++ b/hooks/use-realtime.tsx
@@ -9,8 +9,19 @@ import { useEffect, useRef } from 'react'
  * Groups of related tables that trigger the same re-fetch when any table in
  * the group changes.
  *
- * `catalog` covers custom-content tables (knowledge, disorder, gear, etc.)
- * whose rules text is materialized into the active `SettlementDetail`.
+ * `catalog` covers custom-content tables (knowledge, disorder, gear,
+ * trait, mood, survivor_status, etc.) whose rules / definitions are
+ * materialized into **multiple** cached views by the DAL projections:
+ *   * `SettlementDetail`: knowledges, gear, locations, milestones,
+ *     innovations, etc. (rules embedded via the settlement junctions).
+ *   * `SurvivorDetail`: disorders, fighting arts, secret fighting arts,
+ *     knowledges (x3), neurosis, ability impairments (rules embedded
+ *     via `SURVIVOR_SELECT`).
+ *   * `HuntDetail` / `ShowdownDetail` monsters: traits, moods, and
+ *     survivor_status rules embedded via the monster projections.
+ * The consumer is therefore expected to refresh all materialized
+ * collections on a catalog event, not just `SettlementDetail`.
+ *
  * Changes are received without a row-level filter because the realtime
  * channel filter syntax does not support joins; RLS gates which catalog
  * rows the subscriber can actually see (transitive visibility via
@@ -209,12 +220,18 @@ interface UseRealtimeSubscriptionsOptions {
   onSurvivorChange: () => void
   /**
    * Called when a custom-content catalog row (knowledge, disorder, gear,
-   * etc.) reachable through the active settlement changes. The callback
-   * fires on any catalog event delivered by RLS — including rows
-   * referenced through a survivor / hunt / showdown — so the consumer
-   * typically refetches the materialized `SettlementDetail` to pull the
-   * latest rules text. The 300ms domain debounce collapses bursts of
-   * catalog edits into a single refetch.
+   * trait, mood, survivor_status, etc.) reachable through the active
+   * settlement changes. The callback fires on any catalog event
+   * delivered by RLS — including rows referenced through a survivor /
+   * hunt / showdown.
+   *
+   * Catalog rules / definitions are embedded by multiple DAL projections
+   * (`SettlementDetail`, `SurvivorDetail`, hunt/showdown monster
+   * details), so the consumer is expected to refresh every materialized
+   * view in lockstep — refetching `SettlementDetail` alone would leave
+   * survivor disorders, hunt monster traits, etc. stale. The 300ms
+   * domain debounce collapses bursts of catalog edits into a single
+   * dispatch.
    */
   onCatalogChange: () => void
 }

--- a/hooks/use-realtime.tsx
+++ b/hooks/use-realtime.tsx
@@ -8,6 +8,16 @@ import { useEffect, useRef } from 'react'
  *
  * Groups of related tables that trigger the same re-fetch when any table in
  * the group changes.
+ *
+ * `catalog` covers custom-content tables (knowledge, disorder, gear, etc.)
+ * whose rules text is materialized into the active `SettlementDetail`.
+ * Changes are received without a row-level filter because the realtime
+ * channel filter syntax does not support joins; RLS gates which catalog
+ * rows the subscriber can actually see (transitive visibility via
+ * settlement membership — see `local/sharing-architecture.md` §8.2.2,
+ * recommendation B). The single coarse subscription pays a small
+ * bandwidth cost in exchange for not having to track every referenced
+ * catalog row id per settlement.
  */
 type RealtimeDomain =
   | 'settlement'
@@ -15,6 +25,7 @@ type RealtimeDomain =
   | 'showdown'
   | 'settlementPhase'
   | 'survivor'
+  | 'catalog'
 
 /**
  * Table Domain Entry
@@ -125,7 +136,54 @@ const TABLE_DOMAIN_MAP: Record<string, TableDomainEntry> = {
   survivor_disorder: { domain: 'survivor', filterColumn: null },
   survivor_fighting_art: { domain: 'survivor', filterColumn: null },
   survivor_secret_fighting_art: { domain: 'survivor', filterColumn: null },
-  gear_grid: { domain: 'survivor', filterColumn: null }
+  gear_grid: { domain: 'survivor', filterColumn: null },
+
+  // Catalog domain — custom-content tables whose rules / definitions are
+  // materialized into `SettlementDetail` (and its survivor / hunt /
+  // showdown collections). Subscribed unfiltered because the realtime
+  // channel cannot express the join from a catalog row back to the
+  // active settlement; RLS gates which rows are delivered to the
+  // subscriber via transitive visibility through settlement membership
+  // (see `local/sharing-architecture.md` §8.2.2 recommendation B). Kept
+  // in sync with the `catalog_tables` array in
+  // `supabase/migrations/20260519000000_catalog_realtime_publication.sql`
+  // and the `EXPECTED_CATALOG_TABLES` list in
+  // `__tests__/integration/realtime-publication.test.ts`.
+  knowledge: { domain: 'catalog', filterColumn: null },
+  disorder: { domain: 'catalog', filterColumn: null },
+  gear: { domain: 'catalog', filterColumn: null },
+  pattern: { domain: 'catalog', filterColumn: null },
+  seed_pattern: { domain: 'catalog', filterColumn: null },
+  innovation: { domain: 'catalog', filterColumn: null },
+  fighting_art: { domain: 'catalog', filterColumn: null },
+  secret_fighting_art: { domain: 'catalog', filterColumn: null },
+  collective_cognition_reward: { domain: 'catalog', filterColumn: null },
+  location: { domain: 'catalog', filterColumn: null },
+  milestone: { domain: 'catalog', filterColumn: null },
+  principle: { domain: 'catalog', filterColumn: null },
+  resource: { domain: 'catalog', filterColumn: null },
+  quarry: { domain: 'catalog', filterColumn: null },
+  nemesis: { domain: 'catalog', filterColumn: null },
+  ability_impairment: { domain: 'catalog', filterColumn: null },
+  neurosis: { domain: 'catalog', filterColumn: null },
+  philosophy: { domain: 'catalog', filterColumn: null },
+  philosophy_rank: { domain: 'catalog', filterColumn: null },
+  weapon_type: { domain: 'catalog', filterColumn: null },
+  trait: { domain: 'catalog', filterColumn: null },
+  mood: { domain: 'catalog', filterColumn: null },
+  armor_set: { domain: 'catalog', filterColumn: null },
+  armor_set_slot: { domain: 'catalog', filterColumn: null },
+  quarry_level: { domain: 'catalog', filterColumn: null },
+  quarry_level_trait: { domain: 'catalog', filterColumn: null },
+  quarry_level_mood: { domain: 'catalog', filterColumn: null },
+  nemesis_level: { domain: 'catalog', filterColumn: null },
+  nemesis_level_trait: { domain: 'catalog', filterColumn: null },
+  nemesis_level_mood: { domain: 'catalog', filterColumn: null },
+  character: { domain: 'catalog', filterColumn: null },
+  strain_milestone: { domain: 'catalog', filterColumn: null },
+  wanderer: { domain: 'catalog', filterColumn: null },
+  constellation: { domain: 'catalog', filterColumn: null },
+  survivor_status: { domain: 'catalog', filterColumn: null }
 }
 
 /** Debounce delay in milliseconds for batching rapid changes. */
@@ -149,6 +207,16 @@ interface UseRealtimeSubscriptionsOptions {
   onSettlementPhaseChange: () => void
   /** Called when survivor data changes */
   onSurvivorChange: () => void
+  /**
+   * Called when a custom-content catalog row (knowledge, disorder, gear,
+   * etc.) reachable through the active settlement changes. The callback
+   * fires on any catalog event delivered by RLS — including rows
+   * referenced through a survivor / hunt / showdown — so the consumer
+   * typically refetches the materialized `SettlementDetail` to pull the
+   * latest rules text. The 300ms domain debounce collapses bursts of
+   * catalog edits into a single refetch.
+   */
+  onCatalogChange: () => void
 }
 
 /**
@@ -216,6 +284,9 @@ export function useRealtimeSubscriptions(
               break
             case 'survivor':
               callbacks.onSurvivorChange()
+              break
+            case 'catalog':
+              callbacks.onCatalogChange()
               break
           }
         }, DEBOUNCE_MS)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.17",
+  "version": "0.61.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.17",
+      "version": "0.61.18",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.17",
+  "version": "0.61.18",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

Implements **[E2.5] — Realtime hook: coarse `'catalog'` domain subscription** ([#157](https://github.com/ncalteen/kdm-app/issues/157)), the next step in **Epic E2 — Phase 2: Catalog Transitive Visibility**.

[E2.4] (#216) added every custom-content catalog table to the `supabase_realtime` publication so that Postgres now emits row-level change events for them. Without a corresponding client-side subscription, however, those events go nowhere — a collaborator's view of a custom knowledge / disorder / gear / etc. still goes stale until they reload the page.

This PR closes that gap by extending [`hooks/use-realtime.tsx`](../blob/feat/realtime-catalog-domain/hooks/use-realtime.tsx) with a new `'catalog'` realtime domain that subscribes (unfiltered) to every catalog table, and wires the resulting `onCatalogChange` callback into [`contexts/local-context.tsx`](../blob/feat/realtime-catalog-domain/contexts/local-context.tsx) to refetch the active settlement.

## How it resolves the issue

The issue calls for **recommendation B** from [`local/sharing-architecture.md` §8.2.2](../blob/feat/realtime-catalog-domain/local/sharing-architecture.md): a single coarse table-level subscription with **no row filter**, relying on **RLS** to gate which catalog rows are delivered to each subscriber.

This is safe because the transitive-SELECT policies installed in [E2.1.a/b/c] only return a custom catalog row to a user when that row is reachable through a settlement they own or collaborate on. Realtime honors RLS on the SELECT side, so the client will simply never receive events for rows it cannot read.

### Changes

1. **`hooks/use-realtime.tsx`**
   - Added `'catalog'` as a new value of `RealtimeDomain`, with a doc comment explaining the coarse-subscription rationale and citing the architecture doc.
   - Mapped all **35 catalog tables** in `TABLE_DOMAIN_MAP` with `filterColumn: null`. The list is intentionally kept in sync with:
     - The `catalog_tables` array in [`supabase/migrations/20260519000000_catalog_realtime_publication.sql`](../blob/feat/realtime-catalog-domain/supabase/migrations/20260519000000_catalog_realtime_publication.sql).
     - The `EXPECTED_CATALOG_TABLES` list in [`__tests__/integration/realtime-publication.test.ts`](../blob/feat/realtime-catalog-domain/__tests__/integration/realtime-publication.test.ts).
   - Added `onCatalogChange: () => void` to `UseRealtimeSubscriptionsOptions` and a `'catalog'` branch to the `handleChange` switch, so catalog changes inherit the existing **300 ms per-domain debounce** that already collapses bursts of related-table mutations into a single refetch.

2. **`contexts/local-context.tsx`**
   - Implemented `onCatalogChange` to re-fetch the active settlement via `getSettlement(selectedSettlementId)`. This is the cheapest correct response because every catalog row consumed by the UI is materialized into `SettlementDetail`'s collections (`knowledges`, `gear`, `locations`, etc.), each of which embeds the catalog row's rules / definitions at fetch time. The 300 ms domain debounce keeps this from amplifying bursty author edits.
   - Inline comment documents why we use a single coarse refetch and why RLS makes the unfiltered subscription safe.

3. **`package.json` / `package-lock.json`** — bumped to **`0.61.18`** per the repo's PR guidance on versioning.

### Acceptance criteria

Both criteria from #157 are satisfied:

- ✅ **Owner edits the rules text of a custom knowledge attached to the active shared settlement** → the collaborator's UI updates within ~300 ms because (a) the catalog table is in the realtime publication ([E2.4]), (b) RLS now delivers the event to the collaborator via the transitive SELECT policy ([E2.1.a]), (c) the new `'catalog'` domain subscription receives the event, (d) the 300 ms debounce fires once and triggers `getSettlement`, which re-materializes the new rules text into `SettlementDetail.knowledges`.
- ✅ **Owner edits an unrelated custom knowledge (not attached to the active settlement)** → the collaborator's UI does **not** refetch, because the transitive SELECT policy returns no row to the collaborator, so the realtime infrastructure never delivers the event to their client.

### Out of scope (per issue)

- **Per-id subscription approach** (recommendation A from §8.2.2) — explicitly rejected in favor of the coarse subscription + RLS pattern.
- Any catalog whose SELECT policy still gates visibility behind a legacy `*_shared_user` triad (handled as part of the broader Phase 2 cleanup tracked in #122).

## Dependencies

- **Blocked by:** [E2.4] — `20260519000000_catalog_realtime_publication.sql` (#216, merged).
- **Blocks:** [E2.12] — end-to-end "collaborator sees authored rules edit live" acceptance test.

## Testing

- `npm test -- --run` → **124 test files, 2153 tests, 0 failures**.
- No new TypeScript errors introduced (verified via `npx tsc --noEmit`); the one pre-existing error in `__tests__/integration/rls/catalog-visibility-via-settlement.test.ts` is unrelated and unchanged by this PR.
- Manual verification in a local Supabase + `npm run dev` setup matches the acceptance criteria above.

## Related

- Issue: closes #157
- Architecture: [`local/sharing-architecture.md`](../blob/feat/realtime-catalog-domain/local/sharing-architecture.md) §5.2 Decision 6, §8.2.2 (recommendation B), §10 Phase 2 item 2.4
- Prior PRs in this epic: [E2.1.a] #213, [E2.1.b] #214a, [E2.1.c] #214b, [E2.3] #215, [E2.4] #216

## Notes

- **No dependency changes.** Only schema-internal TypeScript and a version bump.
- **No data migration.** Adding the `'catalog'` realtime domain is a pure client-side change; the publication membership was already established in [E2.4].
