### PR TITLE
feat(settlement): surface author_username on custom rows in SettlementDetail (#158)

### DIFF
--- a/__tests__/integration/rls/get-settlement-member-usernames.test.ts
+++ b/__tests__/integration/rls/get-settlement-member-usernames.test.ts
@@ -1,0 +1,125 @@
+import {
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RPC — `get_settlement_member_usernames`
+ *
+ * SECURITY DEFINER function that returns the `(user_id, username)` map
+ * for every user connected to a settlement (the owner plus every
+ * collaborator listed in `settlement_shared_user`). Powers the "By
+ * @username" authorship chip on custom catalog rows materialized into
+ * `SettlementDetail`'s collections (E2.8 in
+ * `local/sharing-architecture.md` §7.4 / §10 Phase 2 item 2.6).
+ *
+ * This RPC exists because RLS on `user_settings` is owner-only, so a
+ * direct PostgREST embed (`settlement_knowledge → knowledge →
+ * user_settings`) would silently return `null` for every author who is
+ * not the calling user. The function joins on the caller's behalf
+ * after verifying settlement membership.
+ *
+ * Contract under test:
+ *   1. The owner sees their own row plus one row per collaborator.
+ *   2. A collaborator sees the same set of rows (they are a member).
+ *   3. An unrelated user sees an empty list — they are not a member.
+ *   4. An anonymous caller is blocked at the GRANT layer.
+ */
+describe('RPC: get_settlement_member_usernames', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let settlementId: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+
+    settlementId = await seedSettlement(
+      owner.id,
+      'Get-Member-Usernames Test Settlement'
+    )
+    await shareSettlement(settlementId, collaborator.id, owner.id)
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+  })
+
+  it('returns owner and collaborator usernames when called by the owner', async () => {
+    const { data, error } = await owner.client.rpc(
+      'get_settlement_member_usernames',
+      { target_settlement: settlementId }
+    )
+
+    expect(error).toBeNull()
+
+    const rows = (data ?? []) as Array<{
+      user_id: string
+      username: string
+    }>
+    const ids = rows.map((r) => r.user_id)
+    expect(ids).toContain(owner.id)
+    expect(ids).toContain(collaborator.id)
+    // Every row must populate username so the DAL mapping never falls
+    // back to `null` for known members.
+    for (const row of rows) expect(row.username).toBeTypeOf('string')
+  })
+
+  it('returns owner and collaborator usernames when called by a collaborator', async () => {
+    const { data, error } = await collaborator.client.rpc(
+      'get_settlement_member_usernames',
+      { target_settlement: settlementId }
+    )
+
+    expect(error).toBeNull()
+
+    const rows = (data ?? []) as Array<{
+      user_id: string
+      username: string
+    }>
+    const ids = rows.map((r) => r.user_id)
+    expect(ids).toContain(owner.id)
+    expect(ids).toContain(collaborator.id)
+  })
+
+  it('returns an empty list for an unrelated user', async () => {
+    const { data, error } = await stranger.client.rpc(
+      'get_settlement_member_usernames',
+      { target_settlement: settlementId }
+    )
+
+    expect(error).toBeNull()
+    expect(data).toEqual([])
+  })
+
+  it('blocks anonymous callers at the GRANT layer', async () => {
+    // Building an anon client locally so this test is self-contained.
+    const { createClient } = await import('@supabase/supabase-js')
+    const anon = createClient(
+      process.env.SUPABASE_URL ?? '',
+      process.env.SUPABASE_ANON_KEY ?? '',
+      { auth: { persistSession: false, autoRefreshToken: false } }
+    )
+
+    const { data, error } = await anon.rpc('get_settlement_member_usernames', {
+      target_settlement: settlementId
+    })
+
+    // The migration explicitly `revoke execute … from anon`, so PostgREST
+    // must refuse the call rather than returning empty data. Pinning the
+    // contract with a strict error assertion guards against accidentally
+    // dropping the revoke (otherwise the in-function `auth.uid()` filter
+    // would silently return [] and this test would still pass).
+    expect(data).toBeNull()
+    expect(error).not.toBeNull()
+    expect(error?.code ?? '').toMatch(/PGRST|42501/)
+  })
+})

--- a/__tests__/lib/dal/settlement-collective-cognition-reward.test.ts
+++ b/__tests__/lib/dal/settlement-collective-cognition-reward.test.ts
@@ -43,8 +43,11 @@ describe('getSettlementCollectiveCognitionRewards', () => {
       collective_cognition_reward_id: 'cr-1',
       unlocked: false,
       collective_cognition_reward: {
+        custom: false,
+        user_id: null,
         reward_name: 'Reward A',
-        collective_cognition: 3
+        collective_cognition: 3,
+        rules: null
       }
     }
     mockSupabase.from.mockReturnValue({
@@ -62,6 +65,8 @@ describe('getSettlementCollectiveCognitionRewards', () => {
         unlocked: false,
         reward_name: 'Reward A',
         collective_cognition: 3,
+        rules: null,
+        custom: false,
         author_username: null
       }
     ])

--- a/__tests__/lib/dal/settlement-collective-cognition-reward.test.ts
+++ b/__tests__/lib/dal/settlement-collective-cognition-reward.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementCollectiveCognitionRewards', () => {
@@ -57,7 +61,8 @@ describe('getSettlementCollectiveCognitionRewards', () => {
         id: 'scr-1',
         unlocked: false,
         reward_name: 'Reward A',
-        collective_cognition: 3
+        collective_cognition: 3,
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith(

--- a/__tests__/lib/dal/settlement-gear.test.ts
+++ b/__tests__/lib/dal/settlement-gear.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementGear', () => {
@@ -54,7 +58,8 @@ describe('getSettlementGear', () => {
         gear_id: 'gear-1',
         gear_name: 'Bone Dagger',
         id: 'sg-1',
-        quantity: 2
+        quantity: 2,
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_gear')

--- a/__tests__/lib/dal/settlement-innovation.test.ts
+++ b/__tests__/lib/dal/settlement-innovation.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementInnovations', () => {
@@ -55,7 +59,8 @@ describe('getSettlementInnovations', () => {
         rules: null,
         consequences: null,
         benefits: null,
-        custom: false
+        custom: false,
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_innovation')
@@ -83,7 +88,8 @@ describe('getSettlementInnovations', () => {
         rules: null,
         consequences: null,
         benefits: null,
-        custom: true
+        custom: true,
+        author_username: null
       }
     ])
   })
@@ -152,7 +158,8 @@ describe('addSettlementInnovations', () => {
         rules: null,
         consequences: null,
         benefits: null,
-        custom: false
+        custom: false,
+        author_username: null
       }
     ])
     expect(mockInsert).toHaveBeenCalledWith([

--- a/__tests__/lib/dal/settlement-knowledge.test.ts
+++ b/__tests__/lib/dal/settlement-knowledge.test.ts
@@ -41,7 +41,15 @@ describe('getSettlementKnowledges', () => {
     const rawItem = {
       id: 'sk-1',
       knowledge_id: 'k-1',
-      knowledge: { knowledge_name: 'Hovel' }
+      knowledge: {
+        custom: false,
+        user_id: null,
+        knowledge_name: 'Hovel',
+        philosophy_id: null,
+        rules: null,
+        observation_conditions: null,
+        observation_rank_up_milestone: null
+      }
     }
     mockSupabase.from.mockReturnValue({
       select: vi.fn().mockReturnValue({
@@ -56,6 +64,11 @@ describe('getSettlementKnowledges', () => {
         id: 'sk-1',
         knowledge_id: 'k-1',
         knowledge_name: 'Hovel',
+        philosophy_id: null,
+        rules: null,
+        observation_conditions: null,
+        observation_rank_up_milestone: null,
+        custom: false,
         author_username: null
       }
     ])

--- a/__tests__/lib/dal/settlement-knowledge.test.ts
+++ b/__tests__/lib/dal/settlement-knowledge.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementKnowledges', () => {
@@ -48,9 +52,78 @@ describe('getSettlementKnowledges', () => {
     const result = await getSettlementKnowledges('settlement-1')
 
     expect(result).toEqual([
-      { id: 'sk-1', knowledge_id: 'k-1', knowledge_name: 'Hovel' }
+      {
+        id: 'sk-1',
+        knowledge_id: 'k-1',
+        knowledge_name: 'Hovel',
+        author_username: null
+      }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_knowledge')
+    expect(mockSupabase.rpc).toHaveBeenCalledWith(
+      'get_settlement_member_usernames',
+      { target_settlement: 'settlement-1' }
+    )
+  })
+
+  it('returns author_username for custom rows authored by a settlement member', async () => {
+    const rawItem = {
+      id: 'sk-1',
+      knowledge_id: 'k-1',
+      knowledge: {
+        custom: true,
+        user_id: 'author-1',
+        knowledge_name: 'Whispers',
+        philosophy_id: null,
+        rules: null,
+        observation_conditions: null,
+        observation_rank_up_milestone: null
+      }
+    }
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [rawItem], error: null })
+      })
+    })
+    mockSupabase.rpc.mockResolvedValue({
+      data: [{ user_id: 'author-1', username: 'ashen.veil' }],
+      error: null
+    })
+
+    const [result] = await getSettlementKnowledges('settlement-1')
+
+    expect(result.custom).toBe(true)
+    expect(result.author_username).toBe('ashen.veil')
+  })
+
+  it('returns null author_username for custom rows whose author left the settlement', async () => {
+    const rawItem = {
+      id: 'sk-1',
+      knowledge_id: 'k-1',
+      knowledge: {
+        custom: true,
+        user_id: 'ghost-1',
+        knowledge_name: 'Echoes',
+        philosophy_id: null,
+        rules: null,
+        observation_conditions: null,
+        observation_rank_up_milestone: null
+      }
+    }
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [rawItem], error: null })
+      })
+    })
+    mockSupabase.rpc.mockResolvedValue({
+      data: [{ user_id: 'someone-else', username: 'still.here' }],
+      error: null
+    })
+
+    const [result] = await getSettlementKnowledges('settlement-1')
+
+    expect(result.custom).toBe(true)
+    expect(result.author_username).toBeNull()
   })
 
   it('returns empty array when no knowledges exist', async () => {

--- a/__tests__/lib/dal/settlement-location.test.ts
+++ b/__tests__/lib/dal/settlement-location.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementLocations', () => {
@@ -53,7 +57,8 @@ describe('getSettlementLocations', () => {
         id: 'sl-1',
         location_id: 'loc-1',
         location_name: 'Lantern Hoard',
-        unlocked: true
+        unlocked: true,
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_location')

--- a/__tests__/lib/dal/settlement-location.test.ts
+++ b/__tests__/lib/dal/settlement-location.test.ts
@@ -42,7 +42,12 @@ describe('getSettlementLocations', () => {
       id: 'sl-1',
       location_id: 'loc-1',
       unlocked: true,
-      location: { location_name: 'Lantern Hoard' }
+      location: {
+        custom: false,
+        user_id: null,
+        location_name: 'Lantern Hoard',
+        rules: null
+      }
     }
     mockSupabase.from.mockReturnValue({
       select: vi.fn().mockReturnValue({
@@ -57,7 +62,9 @@ describe('getSettlementLocations', () => {
         id: 'sl-1',
         location_id: 'loc-1',
         location_name: 'Lantern Hoard',
+        rules: null,
         unlocked: true,
+        custom: false,
         author_username: null
       }
     ])

--- a/__tests__/lib/dal/settlement-milestone.test.ts
+++ b/__tests__/lib/dal/settlement-milestone.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementMilestones', () => {
@@ -57,7 +61,8 @@ describe('getSettlementMilestones', () => {
         event_name: 'First Story',
         id: 'sm-1',
         milestone_id: 'mil-1',
-        milestone_name: 'First Survivor Death'
+        milestone_name: 'First Survivor Death',
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_milestone')

--- a/__tests__/lib/dal/settlement-milestone.test.ts
+++ b/__tests__/lib/dal/settlement-milestone.test.ts
@@ -43,8 +43,12 @@ describe('getSettlementMilestones', () => {
       id: 'sm-1',
       milestone_id: 'mil-1',
       milestone: {
+        custom: false,
+        user_id: null,
         event_name: 'First Story',
-        milestone_name: 'First Survivor Death'
+        milestone_name: 'First Survivor Death',
+        requirements: null,
+        rules: null
       }
     }
     mockSupabase.from.mockReturnValue({
@@ -62,6 +66,9 @@ describe('getSettlementMilestones', () => {
         id: 'sm-1',
         milestone_id: 'mil-1',
         milestone_name: 'First Survivor Death',
+        requirements: null,
+        rules: null,
+        custom: false,
         author_username: null
       }
     ])

--- a/__tests__/lib/dal/settlement-nemesis.test.ts
+++ b/__tests__/lib/dal/settlement-nemesis.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementNemeses', () => {
@@ -111,7 +115,8 @@ describe('getSettlementNemeses', () => {
         defeat_outcome: null,
         deployment_rules: null,
         victory_outcome: null,
-        custom: false
+        custom: false,
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_nemesis')
@@ -232,7 +237,8 @@ describe('addSettlementNemeses', () => {
         defeat_outcome: null,
         deployment_rules: null,
         victory_outcome: null,
-        custom: false
+        custom: false,
+        author_username: null
       }
     ])
   })

--- a/__tests__/lib/dal/settlement-pattern.test.ts
+++ b/__tests__/lib/dal/settlement-pattern.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementPatterns', () => {
@@ -52,7 +56,8 @@ describe('getSettlementPatterns', () => {
         id: 'sp-1',
         pattern_id: 'pat-1',
         pattern_name: 'Rawhide Headband',
-        custom: false
+        custom: false,
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_pattern')
@@ -77,7 +82,8 @@ describe('getSettlementPatterns', () => {
         id: 'sp-1',
         pattern_id: 'pat-1',
         pattern_name: 'Rawhide Headband',
-        custom: true
+        custom: true,
+        author_username: null
       }
     ])
   })
@@ -108,7 +114,8 @@ describe('getSettlementPatterns', () => {
         id: 'sp-1',
         pattern_id: 'pat-1',
         pattern_name: 'Rawhide Headband',
-        custom: false
+        custom: false,
+        author_username: null
       }
     ])
   })

--- a/__tests__/lib/dal/settlement-philosophy.test.ts
+++ b/__tests__/lib/dal/settlement-philosophy.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementPhilosophies', () => {
@@ -51,7 +55,8 @@ describe('getSettlementPhilosophies', () => {
       {
         id: 'sph-1',
         philosophy_id: 'ph-1',
-        philosophy_name: 'Survival of the Fittest'
+        philosophy_name: 'Survival of the Fittest',
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_philosophy')

--- a/__tests__/lib/dal/settlement-philosophy.test.ts
+++ b/__tests__/lib/dal/settlement-philosophy.test.ts
@@ -41,7 +41,15 @@ describe('getSettlementPhilosophies', () => {
     const rawItem = {
       id: 'sph-1',
       philosophy_id: 'ph-1',
-      philosophy: { philosophy_name: 'Survival of the Fittest' }
+      philosophy: {
+        custom: false,
+        user_id: null,
+        philosophy_name: 'Survival of the Fittest',
+        hunt_xp_milestones: null,
+        tenet_knowledge_id: null,
+        tier: null,
+        neurosis_id: null
+      }
     }
     mockSupabase.from.mockReturnValue({
       select: vi.fn().mockReturnValue({
@@ -56,6 +64,11 @@ describe('getSettlementPhilosophies', () => {
         id: 'sph-1',
         philosophy_id: 'ph-1',
         philosophy_name: 'Survival of the Fittest',
+        hunt_xp_milestones: null,
+        tenet_knowledge_id: null,
+        tier: null,
+        neurosis_id: null,
+        custom: false,
         author_username: null
       }
     ])

--- a/__tests__/lib/dal/settlement-principle.test.ts
+++ b/__tests__/lib/dal/settlement-principle.test.ts
@@ -44,9 +44,13 @@ describe('getSettlementPrinciples', () => {
       option_2_selected: true,
       principle_id: 'prin-1',
       principle: {
+        custom: false,
+        user_id: null,
         principle_name: 'New Life',
         option_1_name: 'Protect the Young',
-        option_2_name: 'Survival of the Fittest'
+        option_2_name: 'Survival of the Fittest',
+        option_1_rules: null,
+        option_2_rules: null
       }
     }
     mockSupabase.from.mockReturnValue({
@@ -61,11 +65,14 @@ describe('getSettlementPrinciples', () => {
       {
         id: 'spr-1',
         option_1_name: 'Protect the Young',
+        option_1_rules: null,
         option_1_selected: false,
         option_2_name: 'Survival of the Fittest',
+        option_2_rules: null,
         option_2_selected: true,
         principle_id: 'prin-1',
         principle_name: 'New Life',
+        custom: false,
         author_username: null
       }
     ])

--- a/__tests__/lib/dal/settlement-principle.test.ts
+++ b/__tests__/lib/dal/settlement-principle.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementPrinciples', () => {
@@ -61,7 +65,8 @@ describe('getSettlementPrinciples', () => {
         option_2_name: 'Survival of the Fittest',
         option_2_selected: true,
         principle_id: 'prin-1',
-        principle_name: 'New Life'
+        principle_name: 'New Life',
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_principle')

--- a/__tests__/lib/dal/settlement-quarry.test.ts
+++ b/__tests__/lib/dal/settlement-quarry.test.ts
@@ -46,7 +46,19 @@ describe('getSettlementQuarries', () => {
       id: 'sq-1',
       quarry_id: 'q-1',
       unlocked: true,
-      quarry: { monster_name: 'White Lion', node: 'white_lion', prologue: true }
+      quarry: {
+        custom: false,
+        user_id: null,
+        monster_name: 'White Lion',
+        node: 'white_lion',
+        prologue: true,
+        instinct: null,
+        basic_action: null,
+        blind_spot: null,
+        defeat_outcome: null,
+        deployment_rules: null,
+        victory_outcome: null
+      }
     }
     mockSupabase.from.mockReturnValue({
       select: vi.fn().mockReturnValue({
@@ -68,6 +80,13 @@ describe('getSettlementQuarries', () => {
         prologue: true,
         quarry_id: 'q-1',
         unlocked: true,
+        instinct: null,
+        basic_action: null,
+        blind_spot: null,
+        defeat_outcome: null,
+        deployment_rules: null,
+        victory_outcome: null,
+        custom: false,
         author_username: null
       }
     ])

--- a/__tests__/lib/dal/settlement-quarry.test.ts
+++ b/__tests__/lib/dal/settlement-quarry.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementQuarries', () => {
@@ -63,7 +67,8 @@ describe('getSettlementQuarries', () => {
         node: 'white_lion',
         prologue: true,
         quarry_id: 'q-1',
-        unlocked: true
+        unlocked: true,
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_quarry')

--- a/__tests__/lib/dal/settlement-resource.test.ts
+++ b/__tests__/lib/dal/settlement-resource.test.ts
@@ -43,6 +43,8 @@ describe('getSettlementResources', () => {
       resource_id: 'res-1',
       quantity: 2,
       resource: {
+        custom: false,
+        user_id: null,
         category: 'basic',
         quarry_id: 'q-1',
         resource_name: 'Bone',
@@ -69,6 +71,7 @@ describe('getSettlementResources', () => {
         resource_id: 'res-1',
         resource_name: 'Bone',
         resource_types: ['bone'],
+        custom: false,
         author_username: null
       }
     ])
@@ -81,6 +84,8 @@ describe('getSettlementResources', () => {
       resource_id: 'res-1',
       quantity: 1,
       resource: {
+        custom: false,
+        user_id: null,
         category: 'basic',
         quarry_id: null,
         resource_name: 'Scrap',

--- a/__tests__/lib/dal/settlement-resource.test.ts
+++ b/__tests__/lib/dal/settlement-resource.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementResources', () => {
@@ -64,7 +68,8 @@ describe('getSettlementResources', () => {
         quarry_node: 'white_lion',
         resource_id: 'res-1',
         resource_name: 'Bone',
-        resource_types: ['bone']
+        resource_types: ['bone'],
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_resource')

--- a/__tests__/lib/dal/settlement-seed-pattern.test.ts
+++ b/__tests__/lib/dal/settlement-seed-pattern.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,9 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members surfaced (covers tests that don't
+  // exercise author_username resolution). Individual tests override.
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getSettlementSeedPatterns', () => {
@@ -51,7 +55,8 @@ describe('getSettlementSeedPatterns', () => {
       {
         id: 'ssp-1',
         seed_pattern_id: 'sp-1',
-        seed_pattern_name: 'Skull Cap Helm'
+        seed_pattern_name: 'Skull Cap Helm',
+        author_username: null
       }
     ])
     expect(mockSupabase.from).toHaveBeenCalledWith('settlement_seed_pattern')

--- a/__tests__/lib/dal/settlement-seed-pattern.test.ts
+++ b/__tests__/lib/dal/settlement-seed-pattern.test.ts
@@ -41,7 +41,11 @@ describe('getSettlementSeedPatterns', () => {
     const rawItem = {
       id: 'ssp-1',
       seed_pattern_id: 'sp-1',
-      seed_pattern: { seed_pattern_name: 'Skull Cap Helm' }
+      seed_pattern: {
+        custom: false,
+        user_id: null,
+        seed_pattern_name: 'Skull Cap Helm'
+      }
     }
     mockSupabase.from.mockReturnValue({
       select: vi.fn().mockReturnValue({
@@ -56,6 +60,7 @@ describe('getSettlementSeedPatterns', () => {
         id: 'ssp-1',
         seed_pattern_id: 'sp-1',
         seed_pattern_name: 'Skull Cap Helm',
+        custom: false,
         author_username: null
       }
     ])

--- a/__tests__/lib/dal/settlement-shared-user.test.ts
+++ b/__tests__/lib/dal/settlement-shared-user.test.ts
@@ -17,7 +17,8 @@ const {
   getSettlementSharedUsers,
   addSettlementSharedUsers,
   removeSettlementSharedUsers,
-  getUnshareBlockers
+  getUnshareBlockers,
+  getSettlementMemberUsernames
 } = await import('@/lib/dal/settlement-shared-user')
 const { getUserId } = await import('@/lib/dal/user')
 
@@ -241,6 +242,87 @@ describe('getUnshareBlockers', () => {
 
     await expect(getUnshareBlockers('settlement-1', 'user-2')).rejects.toThrow(
       'Error Fetching Unshare Blockers: permission denied'
+    )
+  })
+})
+
+describe('getSettlementMemberUsernames', () => {
+  it('throws when settlementId is null', async () => {
+    await expect(getSettlementMemberUsernames(null)).rejects.toThrow(
+      'Required: Settlement ID'
+    )
+    expect(mockSupabase.rpc).not.toHaveBeenCalled()
+  })
+
+  it('throws when settlementId is undefined', async () => {
+    await expect(getSettlementMemberUsernames(undefined)).rejects.toThrow(
+      'Required: Settlement ID'
+    )
+    expect(mockSupabase.rpc).not.toHaveBeenCalled()
+  })
+
+  it('calls get_settlement_member_usernames and builds a user_id -> username map', async () => {
+    mockSupabase.rpc.mockResolvedValue({
+      data: [
+        { user_id: 'u-1', username: 'alpha' },
+        { user_id: 'u-2', username: 'beta' }
+      ],
+      error: null
+    })
+
+    const result = await getSettlementMemberUsernames('settlement-1')
+
+    expect(mockSupabase.rpc).toHaveBeenCalledWith(
+      'get_settlement_member_usernames',
+      { target_settlement: 'settlement-1' }
+    )
+    expect(result).toBeInstanceOf(Map)
+    expect(result.size).toBe(2)
+    expect(result.get('u-1')).toBe('alpha')
+    expect(result.get('u-2')).toBe('beta')
+  })
+
+  it('returns an empty map when the RPC returns null data', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: null, error: null })
+
+    const result = await getSettlementMemberUsernames('settlement-1')
+
+    expect(result).toBeInstanceOf(Map)
+    expect(result.size).toBe(0)
+  })
+
+  it('returns an empty map when the RPC returns an empty list', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
+
+    const result = await getSettlementMemberUsernames('settlement-1')
+
+    expect(result.size).toBe(0)
+  })
+
+  it('skips rows with null user_id or null username', async () => {
+    mockSupabase.rpc.mockResolvedValue({
+      data: [
+        { user_id: 'u-1', username: 'alpha' },
+        { user_id: null, username: 'orphan' },
+        { user_id: 'u-3', username: null }
+      ],
+      error: null
+    })
+
+    const result = await getSettlementMemberUsernames('settlement-1')
+
+    expect(result.size).toBe(1)
+    expect(result.get('u-1')).toBe('alpha')
+  })
+
+  it('throws on RPC error', async () => {
+    mockSupabase.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'permission denied' }
+    })
+
+    await expect(getSettlementMemberUsernames('settlement-1')).rejects.toThrow(
+      'Error Fetching Settlement Member Usernames: permission denied'
     )
   })
 })

--- a/__tests__/lib/dal/settlement.test.ts
+++ b/__tests__/lib/dal/settlement.test.ts
@@ -61,6 +61,9 @@ vi.mock('@/lib/dal/settlement-resource', () => ({
 vi.mock('@/lib/dal/settlement-seed-pattern', () => ({
   getSettlementSeedPatterns: vi.fn().mockResolvedValue([])
 }))
+vi.mock('@/lib/dal/settlement-shared-user', () => ({
+  getSettlementMemberUsernames: vi.fn().mockResolvedValue(new Map())
+}))
 vi.mock('@/lib/dal/settlement-timeline-year', () => ({
   getSettlementTimelineYears: vi.fn().mockResolvedValue([]),
   addSettlementTimelineYears: vi.fn()

--- a/__tests__/lib/gear-grid.test.ts
+++ b/__tests__/lib/gear-grid.test.ts
@@ -327,7 +327,8 @@ describe('computeEmbarkGearShortages', () => {
       gear_id: gearId,
       gear_name: gearName,
       quantity,
-      custom: false
+      custom: false,
+      author_username: null
     }
   }
 

--- a/components/settlement/arc/collective-cognition-rewards-card.tsx
+++ b/components/settlement/arc/collective-cognition-rewards-card.tsx
@@ -153,7 +153,10 @@ export function CollectiveCognitionRewardsCard({
           reward_name: rewardInfo.reward_name,
           rules: rewardInfo.rules ?? null,
           unlocked: false,
-          custom: rewardInfo.custom
+          custom: rewardInfo.custom,
+          // Optimistic placeholder; the realtime/refetch reconciles
+          // `author_username` from the catalog row's `user_id` (E2.8).
+          author_username: null
         }
 
       const updatedRewards = [
@@ -349,7 +352,10 @@ export function CollectiveCognitionRewardsCard({
             reward_name: newReward.reward_name,
             rules: newReward.rules ?? null,
             unlocked: false,
-            custom: true
+            custom: true,
+            // Optimistic placeholder; the realtime/refetch reconciles
+            // `author_username` from the catalog row's `user_id` (E2.8).
+            author_username: null
           }
 
         const updatedRewards = [

--- a/components/settlement/arc/knowledges-card.tsx
+++ b/components/settlement/arc/knowledges-card.tsx
@@ -147,7 +147,10 @@ export function KnowledgesCard({
         observation_conditions: knowledgeInfo.observation_conditions ?? null,
         observation_rank_up_milestone:
           knowledgeInfo.observation_rank_up_milestone ?? null,
-        custom: knowledgeInfo.custom ?? false
+        custom: knowledgeInfo.custom ?? false,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
 
       const updatedKnowledges = [
@@ -291,7 +294,10 @@ export function KnowledgesCard({
           observation_conditions: newKnowledge.observation_conditions ?? null,
           observation_rank_up_milestone:
             newKnowledge.observation_rank_up_milestone ?? null,
-          custom: newKnowledge.custom ?? true
+          custom: newKnowledge.custom ?? true,
+          // Optimistic placeholder; the realtime/refetch reconciles
+          // `author_username` from the catalog row's `user_id` (E2.8).
+          author_username: null
         }
 
         const updatedKnowledges = [

--- a/components/settlement/arc/philosophies-card.tsx
+++ b/components/settlement/arc/philosophies-card.tsx
@@ -135,7 +135,10 @@ export function PhilosophiesCard({
         philosophy_name: philosophyInfo.philosophy_name,
         tenet_knowledge_id: null,
         tier: null,
-        custom: philosophyInfo.custom ?? false
+        custom: philosophyInfo.custom ?? false,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
 
       const updatedPhilosophies = [

--- a/components/settlement/innovations/innovations-card.tsx
+++ b/components/settlement/innovations/innovations-card.tsx
@@ -143,7 +143,10 @@ export function InnovationsCard({
         rules: detail.rules ?? null,
         consequences: detail.consequences ?? null,
         benefits: detail.benefits ?? null,
-        custom: detail.custom
+        custom: detail.custom,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
       const oldInnovations = [...innovations]
 
@@ -297,7 +300,10 @@ export function InnovationsCard({
           rules: newInnovation.rules ?? null,
           consequences: newInnovation.consequences ?? null,
           benefits: newInnovation.benefits ?? null,
-          custom: true
+          custom: true,
+          // Optimistic placeholder; the realtime/refetch reconciles
+          // `author_username` from the catalog row's `user_id` (E2.8).
+          author_username: null
         }
         const oldInnovations = [...innovations]
 

--- a/components/settlement/locations/locations-card.tsx
+++ b/components/settlement/locations/locations-card.tsx
@@ -152,7 +152,10 @@ export function LocationsCard({
         location_name: locationInfo.location_name,
         rules: locationInfo.rules ?? null,
         unlocked: false,
-        custom: locationInfo.custom
+        custom: locationInfo.custom,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
 
       // Capture the updated locations list so async callbacks reference it
@@ -340,7 +343,10 @@ export function LocationsCard({
           location_name: newLocation.location_name,
           rules: newLocation.rules ?? null,
           unlocked: false,
-          custom: true
+          custom: true,
+          // Optimistic placeholder; the realtime/refetch reconciles
+          // `author_username` from the catalog row's `user_id` (E2.8).
+          author_username: null
         }
         const updatedLocations = [
           ...selectedSettlement.locations,

--- a/components/settlement/milestones/milestones-card.tsx
+++ b/components/settlement/milestones/milestones-card.tsx
@@ -135,7 +135,10 @@ export function MilestonesCard({
         milestone_name: milestoneInfo.milestone_name,
         requirements: milestoneInfo.requirements ?? null,
         rules: milestoneInfo.rules ?? null,
-        custom: milestoneInfo.custom
+        custom: milestoneInfo.custom,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
 
       // Capture the updated milestones list so async callbacks reference it
@@ -315,7 +318,10 @@ export function MilestonesCard({
           milestone_name: newMilestone.milestone_name,
           requirements: newMilestone.requirements ?? null,
           rules: newMilestone.rules ?? null,
-          custom: true
+          custom: true,
+          // Optimistic placeholder; the realtime/refetch reconciles
+          // `author_username` from the catalog row's `user_id` (E2.8).
+          author_username: null
         }
 
         const updatedMilestones = [

--- a/components/settlement/nemeses/nemeses-card.tsx
+++ b/components/settlement/nemeses/nemeses-card.tsx
@@ -165,7 +165,10 @@ export function NemesesCard({
         node: nemesisInfo.node,
         unlocked: false,
         victory_outcome: nemesisInfo.victory_outcome,
-        custom: nemesisInfo.custom
+        custom: nemesisInfo.custom,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
 
       // Capture the updated nemeses list so async callbacks reference it
@@ -239,7 +242,9 @@ export function NemesesCard({
                   location_name: ins.location_name,
                   rules: ins.rules,
                   unlocked: false,
-                  custom: ins.custom
+                  custom: ins.custom,
+                  // Realtime/refetch reconciles author_username (E2.8).
+                  author_username: null
                 }))
               }
             }

--- a/components/settlement/patterns/patterns-card.tsx
+++ b/components/settlement/patterns/patterns-card.tsx
@@ -192,7 +192,10 @@ export function PatternsCard({
         id: tempId,
         pattern_id: patternId,
         pattern_name: patternInfo.pattern_name,
-        custom: patternInfo.custom
+        custom: patternInfo.custom,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
 
       const updatedPatterns = [...selectedSettlement.patterns, optimisticRow]

--- a/components/settlement/principles/principles-card.tsx
+++ b/components/settlement/principles/principles-card.tsx
@@ -157,7 +157,10 @@ export function PrinciplesCard({
         option_2_selected: false,
         principle_id: principleId,
         principle_name: principleInfo.principle_name,
-        custom: principleInfo.custom
+        custom: principleInfo.custom,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
 
       // Capture the updated principles list so async callbacks reference it
@@ -361,7 +364,10 @@ export function PrinciplesCard({
           option_2_selected: false,
           principle_id: newPrinciple.id,
           principle_name: newPrinciple.principle_name,
-          custom: true
+          custom: true,
+          // Optimistic placeholder; the realtime/refetch reconciles
+          // `author_username` from the catalog row's `user_id` (E2.8).
+          author_username: null
         }
         const updatedPrinciples = [
           ...(selectedSettlement.principles ?? []),

--- a/components/settlement/quarries/quarries-card.tsx
+++ b/components/settlement/quarries/quarries-card.tsx
@@ -156,7 +156,10 @@ export function QuarriesCard({
         quarry_id: quarryId,
         unlocked: false,
         victory_outcome: quarryInfo.victory_outcome,
-        custom: quarryInfo.custom
+        custom: quarryInfo.custom,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
 
       // Capture the updated quarries list so async callbacks reference it
@@ -231,7 +234,9 @@ export function QuarriesCard({
                   location_name: ins.location_name,
                   rules: ins.rules,
                   unlocked: false,
-                  custom: ins.custom
+                  custom: ins.custom,
+                  // Realtime/refetch reconciles author_username (E2.8).
+                  author_username: null
                 }))
               }
             }
@@ -310,7 +315,9 @@ export function QuarriesCard({
                   collective_cognition: inserted[i].collective_cognition,
                   rules: inserted[i].rules,
                   unlocked: false,
-                  custom: inserted[i].custom
+                  custom: inserted[i].custom,
+                  // Realtime/refetch reconciles author_username (E2.8).
+                  author_username: null
                 }))
               }
             }

--- a/components/settlement/resources/resources-card.tsx
+++ b/components/settlement/resources/resources-card.tsx
@@ -160,7 +160,10 @@ export function ResourcesCard({
         resource_id: resourceId,
         resource_name: resourceInfo.resource_name,
         resource_types: resourceInfo.resource_types,
-        custom: resourceInfo.custom
+        custom: resourceInfo.custom,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
 
       // Determine whether the resource should also unlock a pattern. Only
@@ -184,7 +187,10 @@ export function ResourcesCard({
               id: tempPatternId,
               pattern_id: unlockPatternInfo.id,
               pattern_name: unlockPatternInfo.pattern_name,
-              custom: unlockPatternInfo.custom
+              custom: unlockPatternInfo.custom,
+              // Optimistic placeholder; the realtime/refetch reconciles
+              // `author_username` from the catalog row's `user_id` (E2.8).
+              author_username: null
             }
           : null
 

--- a/components/settlement/seed-patterns/seed-patterns-card.tsx
+++ b/components/settlement/seed-patterns/seed-patterns-card.tsx
@@ -180,7 +180,10 @@ export function SeedPatternsCard({
         id: tempId,
         seed_pattern_id: seedPatternId,
         seed_pattern_name: seedPatternInfo.seed_pattern_name,
-        custom: seedPatternInfo.custom
+        custom: seedPatternInfo.custom,
+        // Optimistic placeholder; the realtime/refetch reconciles
+        // `author_username` from the catalog row's `user_id` (E2.8).
+        author_username: null
       }
 
       const updatedSeedPatterns = [

--- a/hooks/use-craft-gear-persistence.tsx
+++ b/hooks/use-craft-gear-persistence.tsx
@@ -122,7 +122,10 @@ export function useCraftGearPersistence({
           gear_name: gearInfo.gear_name,
           id: tempId,
           quantity: 1,
-          custom: gearInfo.custom ?? false
+          custom: gearInfo.custom ?? false,
+          // Optimistic placeholder; the realtime/refetch reconciles
+          // `author_username` from the catalog row's `user_id` (E2.8).
+          author_username: null
         }
 
         nextGear = [...deductedGear, optimisticRow]

--- a/lib/dal/settlement-collective-cognition-reward.ts
+++ b/lib/dal/settlement-collective-cognition-reward.ts
@@ -17,7 +17,7 @@ import { SettlementDetail } from '@/lib/types'
  */
 export async function getSettlementCollectiveCognitionRewards(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['collective_cognition_rewards']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-collective-cognition-reward.ts
+++ b/lib/dal/settlement-collective-cognition-reward.ts
@@ -1,3 +1,4 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
@@ -6,6 +7,9 @@ import { SettlementDetail } from '@/lib/types'
  * Get Settlement Collective Cognition Rewards
  *
  * Retrieves the collective cognition rewards associated with a settlement.
+ * Each returned row carries `author_username` (null for built-ins; the
+ * catalog author's username for customs) — see `getSettlementKnowledges`
+ * for the canonical resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Collective Cognition Reward Data
@@ -17,12 +21,15 @@ export async function getSettlementCollectiveCognitionRewards(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_collective_cognition_reward')
-    .select(
-      'collective_cognition_reward_id, id, unlocked, collective_cognition_reward(custom, collective_cognition, reward_name, rules)'
-    )
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_collective_cognition_reward')
+      .select(
+        'collective_cognition_reward_id, id, unlocked, collective_cognition_reward(custom, user_id, collective_cognition, reward_name, rules)'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(
@@ -36,12 +43,14 @@ export async function getSettlementCollectiveCognitionRewards(
       const embeddedReward = item.collective_cognition_reward as unknown as
         | {
             custom: boolean
+            user_id: string | null
             reward_name: string
             collective_cognition: number
             rules: string | null
           }
         | {
             custom: boolean
+            user_id: string | null
             reward_name: string
             collective_cognition: number
             rules: string | null
@@ -62,7 +71,11 @@ export async function getSettlementCollectiveCognitionRewards(
           reward_name: reward.reward_name,
           collective_cognition: reward.collective_cognition,
           rules: reward.rules,
-          custom: reward.custom
+          custom: reward.custom,
+          author_username:
+            reward.custom && reward.user_id
+              ? (memberUsernames.get(reward.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-collective-cognition-reward.ts
+++ b/lib/dal/settlement-collective-cognition-reward.ts
@@ -12,10 +12,12 @@ import { SettlementDetail } from '@/lib/types'
  * for the canonical resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Collective Cognition Reward Data
  */
 export async function getSettlementCollectiveCognitionRewards(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['collective_cognition_rewards']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -28,7 +30,7 @@ export async function getSettlementCollectiveCognitionRewards(
         'collective_cognition_reward_id, id, unlocked, collective_cognition_reward(custom, user_id, collective_cognition, reward_name, rules)'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-gear.ts
+++ b/lib/dal/settlement-gear.ts
@@ -17,7 +17,7 @@ import { SettlementDetail } from '@/lib/types'
  */
 export async function getSettlementGear(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['gear']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-gear.ts
+++ b/lib/dal/settlement-gear.ts
@@ -12,10 +12,12 @@ import { SettlementDetail } from '@/lib/types'
  * canonical resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Gear Data
  */
 export async function getSettlementGear(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['gear']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -26,7 +28,7 @@ export async function getSettlementGear(
       .from('settlement_gear')
       .select('gear_id, id, quantity, gear(gear_name, custom, user_id)')
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error) throw new Error(`Error Fetching Settlement Gear: ${error.message}`)

--- a/lib/dal/settlement-gear.ts
+++ b/lib/dal/settlement-gear.ts
@@ -1,3 +1,4 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
@@ -5,7 +6,10 @@ import { SettlementDetail } from '@/lib/types'
 /**
  * Get Settlement Gear
  *
- * Retrieves the gear associated with a settlement.
+ * Retrieves the gear associated with a settlement. Each returned row
+ * carries `author_username` (null for built-ins; the catalog author's
+ * username for customs) — see `getSettlementKnowledges` for the
+ * canonical resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Gear Data
@@ -17,10 +21,13 @@ export async function getSettlementGear(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_gear')
-    .select('gear_id, id, quantity, gear(gear_name, custom)')
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_gear')
+      .select('gear_id, id, quantity, gear(gear_name, custom, user_id)')
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error) throw new Error(`Error Fetching Settlement Gear: ${error.message}`)
 
@@ -32,10 +39,12 @@ export async function getSettlementGear(
         | {
             gear_name: string
             custom: boolean
+            user_id: string | null
           }
         | {
             gear_name: string
             custom: boolean
+            user_id: string | null
           }[]
         | null
       const gear = Array.isArray(rawGear) ? (rawGear[0] ?? null) : rawGear
@@ -48,7 +57,11 @@ export async function getSettlementGear(
           gear_name: gear.gear_name,
           id: item.id,
           quantity: item.quantity,
-          custom: !!gear.custom
+          custom: !!gear.custom,
+          author_username:
+            gear.custom && gear.user_id
+              ? (memberUsernames.get(gear.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-innovation.ts
+++ b/lib/dal/settlement-innovation.ts
@@ -14,10 +14,12 @@ import { SettlementDetail } from '@/lib/types'
  * for the canonical resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Innovation Data
  */
 export async function getSettlementInnovations(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['innovations']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -30,7 +32,7 @@ export async function getSettlementInnovations(
         'id, innovation_id, innovation(custom, user_id, innovation_name, rules, consequences, benefits)'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-innovation.ts
+++ b/lib/dal/settlement-innovation.ts
@@ -1,3 +1,4 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
@@ -7,6 +8,10 @@ import { SettlementDetail } from '@/lib/types'
  *
  * Retrieves the innovations associated with a settlement. Uses a join to
  * resolve innovation names. Safely handles the Supabase join result shape.
+ *
+ * Each returned row carries `author_username` (null for built-ins; the
+ * catalog author's username for customs) — see `getSettlementKnowledges`
+ * for the canonical resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Innovation Data
@@ -18,12 +23,15 @@ export async function getSettlementInnovations(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_innovation')
-    .select(
-      'id, innovation_id, innovation(custom, innovation_name, rules, consequences, benefits)'
-    )
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_innovation')
+      .select(
+        'id, innovation_id, innovation(custom, user_id, innovation_name, rules, consequences, benefits)'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Innovations: ${error.message}`)
@@ -54,7 +62,11 @@ export async function getSettlementInnovations(
           // settlement membership (EC-6 in local/sharing-architecture.md).
           // The catalog `availableInnovations` lookup filters by user_id and
           // would otherwise return undefined for those rows.
-          custom: !!innovation.custom
+          custom: !!innovation.custom,
+          author_username:
+            innovation.custom && innovation.user_id
+              ? (memberUsernames.get(innovation.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []
@@ -79,17 +91,20 @@ export async function addSettlementInnovations(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_innovation')
-    .insert(
-      innovationIds.map((innovationId) => ({
-        innovation_id: innovationId,
-        settlement_id: settlementId
-      }))
-    )
-    .select(
-      'id, innovation_id, innovation(custom, innovation_name, rules, consequences, benefits)'
-    )
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_innovation')
+      .insert(
+        innovationIds.map((innovationId) => ({
+          innovation_id: innovationId,
+          settlement_id: settlementId
+        }))
+      )
+      .select(
+        'id, innovation_id, innovation(custom, user_id, innovation_name, rules, consequences, benefits)'
+      ),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Adding Settlement Innovations: ${error.message}`)
@@ -110,7 +125,11 @@ export async function addSettlementInnovations(
           rules: innovation.rules ?? null,
           consequences: innovation.consequences ?? null,
           benefits: innovation.benefits ?? null,
-          custom: !!innovation.custom
+          custom: !!innovation.custom,
+          author_username:
+            innovation.custom && innovation.user_id
+              ? (memberUsernames.get(innovation.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-innovation.ts
+++ b/lib/dal/settlement-innovation.ts
@@ -19,7 +19,7 @@ import { SettlementDetail } from '@/lib/types'
  */
 export async function getSettlementInnovations(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['innovations']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-knowledge.ts
+++ b/lib/dal/settlement-knowledge.ts
@@ -1,3 +1,4 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
@@ -6,6 +7,26 @@ import { SettlementDetail } from '@/lib/types'
  * Get Settlement Knowledges
  *
  * Retrieves the knowledges associated with a settlement.
+ *
+ * Each returned row carries `author_username` — `null` for built-in
+ * (non-custom) knowledges, and the catalog author's username for custom
+ * knowledges so the UI can render the "By @username" chip on custom
+ * cards (E2.8; see `local/sharing-architecture.md` §7.4 / §10 Phase 2
+ * item 2.6).
+ *
+ * **Author username resolution (canonical pattern; mirrored by sibling
+ * `settlement_*` DALs).** The catalog row's `user_id` cannot be
+ * resolved through a direct PostgREST embed of `user_settings` because
+ * RLS on `user_settings` restricts SELECT to the row owner; the JOIN
+ * is therefore performed against a `Map<user_id, username>` produced
+ * by the `get_settlement_member_usernames` SECURITY DEFINER RPC (via
+ * {@link getSettlementMemberUsernames}). The map covers every user
+ * connected to the settlement — owner plus collaborators — so any
+ * custom row attached to the settlement resolves to its author's
+ * username, while rows authored by users who are no longer connected
+ * resolve to `null`. The catalog row's `user_id` itself is readable
+ * via the existing transitive settlement-membership SELECT policy
+ * (20260512000000_catalog_visibility_via_settlement.sql).
  *
  * @param settlementId Settlement ID
  * @returns Settlement Knowledge Data
@@ -17,12 +38,15 @@ export async function getSettlementKnowledges(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_knowledge')
-    .select(
-      'id, knowledge_id, knowledge(custom, knowledge_name, philosophy_id, rules, observation_conditions, observation_rank_up_milestone)'
-    )
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_knowledge')
+      .select(
+        'id, knowledge_id, knowledge(custom, user_id, knowledge_name, philosophy_id, rules, observation_conditions, observation_rank_up_milestone)'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Knowledges: ${error.message}`)
@@ -38,6 +62,7 @@ export async function getSettlementKnowledges(
       const rawKnowledge = item.knowledge as unknown as
         | {
             custom: boolean
+            user_id: string | null
             knowledge_name: string
             philosophy_id: string | null
             rules: string | null
@@ -46,6 +71,7 @@ export async function getSettlementKnowledges(
           }
         | {
             custom: boolean
+            user_id: string | null
             knowledge_name: string
             philosophy_id: string | null
             rules: string | null
@@ -70,7 +96,11 @@ export async function getSettlementKnowledges(
           observation_conditions: knowledge.observation_conditions,
           observation_rank_up_milestone:
             knowledge.observation_rank_up_milestone,
-          custom: knowledge.custom
+          custom: knowledge.custom,
+          author_username:
+            knowledge.custom && knowledge.user_id
+              ? (memberUsernames.get(knowledge.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-knowledge.ts
+++ b/lib/dal/settlement-knowledge.ts
@@ -31,20 +31,23 @@ import { SettlementDetail } from '@/lib/types'
  *
  * **Performance** When called from {@link getSettlement} (which loads
  * every settlement-attached collection in parallel), the caller should
- * fetch the member-username map once and pass it via
- * `prefetchedMemberUsernames` so all ~13 collection DALs share one RPC
- * call. When called standalone the second argument can be omitted; the
- * DAL transparently issues its own RPC.
+ * start the member-username RPC alongside the collection queries and
+ * pass the resulting **promise** via `prefetchedMemberUsernames`. Each
+ * collection DAL awaits the same shared promise inside its own
+ * `Promise.all`, so all ~13 collection queries and the single RPC run
+ * concurrently. When called standalone the second argument can be
+ * omitted; the DAL transparently issues its own RPC.
  *
  * @param settlementId Settlement ID
- * @param prefetchedMemberUsernames Optional pre-fetched member-username
- *   map. When provided, the DAL skips its own
- *   `get_settlement_member_usernames` RPC.
+ * @param prefetchedMemberUsernames Optional in-flight (or resolved)
+ *   member-username map. When provided, the DAL skips its own
+ *   `get_settlement_member_usernames` RPC and awaits this promise
+ *   alongside its main query.
  * @returns Settlement Knowledge Data
  */
 export async function getSettlementKnowledges(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['knowledges']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-knowledge.ts
+++ b/lib/dal/settlement-knowledge.ts
@@ -27,12 +27,24 @@ import { SettlementDetail } from '@/lib/types'
  * resolve to `null`. The catalog row's `user_id` itself is readable
  * via the existing transitive settlement-membership SELECT policy
  * (20260512000000_catalog_visibility_via_settlement.sql).
+ * username for the catalog row's `user_id` (custom rows) or `null` (built-ins).
+ *
+ * **Performance** When called from {@link getSettlement} (which loads
+ * every settlement-attached collection in parallel), the caller should
+ * fetch the member-username map once and pass it via
+ * `prefetchedMemberUsernames` so all ~13 collection DALs share one RPC
+ * call. When called standalone the second argument can be omitted; the
+ * DAL transparently issues its own RPC.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched member-username
+ *   map. When provided, the DAL skips its own
+ *   `get_settlement_member_usernames` RPC.
  * @returns Settlement Knowledge Data
  */
 export async function getSettlementKnowledges(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['knowledges']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -45,7 +57,7 @@ export async function getSettlementKnowledges(
         'id, knowledge_id, knowledge(custom, user_id, knowledge_name, philosophy_id, rules, observation_conditions, observation_rank_up_milestone)'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-location.ts
+++ b/lib/dal/settlement-location.ts
@@ -12,10 +12,12 @@ import { SettlementDetail } from '@/lib/types'
  * resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Location Data
  */
 export async function getSettlementLocations(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['locations']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -28,7 +30,7 @@ export async function getSettlementLocations(
         'id, location_id, unlocked, location(custom, user_id, location_name, rules)'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-location.ts
+++ b/lib/dal/settlement-location.ts
@@ -17,7 +17,7 @@ import { SettlementDetail } from '@/lib/types'
  */
 export async function getSettlementLocations(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['locations']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-location.ts
+++ b/lib/dal/settlement-location.ts
@@ -1,3 +1,4 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
@@ -5,7 +6,10 @@ import { SettlementDetail } from '@/lib/types'
 /**
  * Get Settlement Locations
  *
- * Retrieves the locations associated with a settlement.
+ * Retrieves the locations associated with a settlement. Each returned row
+ * carries `author_username` (null for built-ins; the catalog author's
+ * username for customs) — see `getSettlementKnowledges` for the canonical
+ * resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Location Data
@@ -17,10 +21,15 @@ export async function getSettlementLocations(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_location')
-    .select('id, location_id, unlocked, location(custom, location_name, rules)')
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_location')
+      .select(
+        'id, location_id, unlocked, location(custom, user_id, location_name, rules)'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Locations: ${error.message}`)
@@ -34,6 +43,7 @@ export async function getSettlementLocations(
         Array.isArray(rawLocation) ? (rawLocation[0] ?? null) : rawLocation
       ) as {
         custom: boolean
+        user_id: string | null
         location_name: string
         rules: string | null
       } | null
@@ -47,7 +57,11 @@ export async function getSettlementLocations(
           location_name: location.location_name,
           rules: location.rules,
           unlocked: item.unlocked,
-          custom: location.custom
+          custom: location.custom,
+          author_username:
+            location.custom && location.user_id
+              ? (memberUsernames.get(location.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-milestone.ts
+++ b/lib/dal/settlement-milestone.ts
@@ -17,7 +17,7 @@ import { SettlementDetail } from '@/lib/types'
  */
 export async function getSettlementMilestones(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['milestones']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-milestone.ts
+++ b/lib/dal/settlement-milestone.ts
@@ -1,3 +1,4 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
@@ -5,7 +6,10 @@ import { SettlementDetail } from '@/lib/types'
 /**
  * Get Settlement Milestones
  *
- * Retrieves the milestones associated with a settlement.
+ * Retrieves the milestones associated with a settlement. Each returned row
+ * carries `author_username` (null for built-ins; the catalog author's
+ * username for customs) — see `getSettlementKnowledges` for the canonical
+ * resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Milestone Data
@@ -17,12 +21,15 @@ export async function getSettlementMilestones(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_milestone')
-    .select(
-      'complete, id, milestone_id, milestone(custom, event_name, milestone_name, requirements, rules)'
-    )
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_milestone')
+      .select(
+        'complete, id, milestone_id, milestone(custom, user_id, event_name, milestone_name, requirements, rules)'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Milestones: ${error.message}`)
@@ -34,6 +41,7 @@ export async function getSettlementMilestones(
       const rawMilestone = item.milestone as unknown as
         | {
             custom: boolean
+            user_id: string | null
             event_name: string
             milestone_name: string
             requirements: string | null
@@ -41,6 +49,7 @@ export async function getSettlementMilestones(
           }
         | {
             custom: boolean
+            user_id: string | null
             event_name: string
             milestone_name: string
             requirements: string | null
@@ -63,7 +72,11 @@ export async function getSettlementMilestones(
           milestone_name: milestone.milestone_name,
           requirements: milestone.requirements,
           rules: milestone.rules,
-          custom: milestone.custom
+          custom: milestone.custom,
+          author_username:
+            milestone.custom && milestone.user_id
+              ? (memberUsernames.get(milestone.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-milestone.ts
+++ b/lib/dal/settlement-milestone.ts
@@ -12,10 +12,12 @@ import { SettlementDetail } from '@/lib/types'
  * resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Milestone Data
  */
 export async function getSettlementMilestones(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['milestones']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -28,7 +30,7 @@ export async function getSettlementMilestones(
         'complete, id, milestone_id, milestone(custom, user_id, event_name, milestone_name, requirements, rules)'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-nemesis.ts
+++ b/lib/dal/settlement-nemesis.ts
@@ -26,10 +26,12 @@ type RawEmbeddedNemesis = EmbeddedNemesis | EmbeddedNemesis[] | null
  * resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Nemesis Data
  */
 export async function getSettlementNemeses(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['nemeses']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -42,7 +44,7 @@ export async function getSettlementNemeses(
         'collective_cognition_level_1, collective_cognition_level_2, collective_cognition_level_3, id, level_1_defeated, level_2_defeated, level_3_defeated, level_4_defeated, nemesis_id, unlocked, nemesis(custom, user_id, monster_name, node, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome)'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-nemesis.ts
+++ b/lib/dal/settlement-nemesis.ts
@@ -31,7 +31,7 @@ type RawEmbeddedNemesis = EmbeddedNemesis | EmbeddedNemesis[] | null
  */
 export async function getSettlementNemeses(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['nemeses']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-nemesis.ts
+++ b/lib/dal/settlement-nemesis.ts
@@ -1,8 +1,10 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail, SettlementNemesisDetail } from '@/lib/types'
 
 type EmbeddedNemesis = {
   custom: boolean
+  user_id: string | null
   monster_name: string
   node: string
   instinct: string | null
@@ -18,7 +20,10 @@ type RawEmbeddedNemesis = EmbeddedNemesis | EmbeddedNemesis[] | null
 /**
  * Get Settlement Nemeses
  *
- * Retrieves the nemeses associated with a settlement.
+ * Retrieves the nemeses associated with a settlement. Each returned row
+ * carries `author_username` (null for built-ins; the catalog author's
+ * username for customs) — see `getSettlementKnowledges` for the canonical
+ * resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Nemesis Data
@@ -30,12 +35,15 @@ export async function getSettlementNemeses(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_nemesis')
-    .select(
-      'collective_cognition_level_1, collective_cognition_level_2, collective_cognition_level_3, id, level_1_defeated, level_2_defeated, level_3_defeated, level_4_defeated, nemesis_id, unlocked, nemesis(custom, monster_name, node, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome)'
-    )
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_nemesis')
+      .select(
+        'collective_cognition_level_1, collective_cognition_level_2, collective_cognition_level_3, id, level_1_defeated, level_2_defeated, level_3_defeated, level_4_defeated, nemesis_id, unlocked, nemesis(custom, user_id, monster_name, node, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome)'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Nemeses: ${error.message}`)
@@ -95,7 +103,11 @@ export async function getSettlementNemeses(
         defeat_outcome: nemesis.defeat_outcome,
         deployment_rules: nemesis.deployment_rules,
         victory_outcome: nemesis.victory_outcome,
-        custom: nemesis.custom
+        custom: nemesis.custom,
+        author_username:
+          nemesis.custom && nemesis.user_id
+            ? (memberUsernames.get(nemesis.user_id) ?? null)
+            : null
       }
     ]
   })
@@ -120,25 +132,28 @@ export async function addSettlementNemeses(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_nemesis')
-    .insert(
-      nemesisIds.map((nemesisId) => ({
-        collective_cognition_level_1: false,
-        collective_cognition_level_2: false,
-        collective_cognition_level_3: false,
-        level_1_defeated: false,
-        level_2_defeated: false,
-        level_3_defeated: false,
-        level_4_defeated: false,
-        nemesis_id: nemesisId,
-        settlement_id: settlementId,
-        unlocked: false
-      }))
-    )
-    .select(
-      'collective_cognition_level_1, collective_cognition_level_2, collective_cognition_level_3, id, level_1_defeated, level_2_defeated, level_3_defeated, level_4_defeated, nemesis_id, unlocked, nemesis(custom, monster_name, node, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome)'
-    )
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_nemesis')
+      .insert(
+        nemesisIds.map((nemesisId) => ({
+          collective_cognition_level_1: false,
+          collective_cognition_level_2: false,
+          collective_cognition_level_3: false,
+          level_1_defeated: false,
+          level_2_defeated: false,
+          level_3_defeated: false,
+          level_4_defeated: false,
+          nemesis_id: nemesisId,
+          settlement_id: settlementId,
+          unlocked: false
+        }))
+      )
+      .select(
+        'collective_cognition_level_1, collective_cognition_level_2, collective_cognition_level_3, id, level_1_defeated, level_2_defeated, level_3_defeated, level_4_defeated, nemesis_id, unlocked, nemesis(custom, user_id, monster_name, node, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome)'
+      ),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Adding Settlement Nemeses: ${error.message}`)
@@ -193,7 +208,11 @@ export async function addSettlementNemeses(
         defeat_outcome: nemesis.defeat_outcome,
         deployment_rules: nemesis.deployment_rules,
         victory_outcome: nemesis.victory_outcome,
-        custom: nemesis.custom
+        custom: nemesis.custom,
+        author_username:
+          nemesis.custom && nemesis.user_id
+            ? (memberUsernames.get(nemesis.user_id) ?? null)
+            : null
       }
     ]
   })

--- a/lib/dal/settlement-pattern.ts
+++ b/lib/dal/settlement-pattern.ts
@@ -17,7 +17,7 @@ import { SettlementDetail } from '@/lib/types'
  */
 export async function getSettlementPatterns(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['patterns']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-pattern.ts
+++ b/lib/dal/settlement-pattern.ts
@@ -1,3 +1,4 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
@@ -5,7 +6,10 @@ import { SettlementDetail } from '@/lib/types'
 /**
  * Get Settlement Patterns
  *
- * Retrieves the patterns associated with a settlement.
+ * Retrieves the patterns associated with a settlement. Each returned row
+ * carries `author_username` (null for built-ins; the catalog author's
+ * username for customs) — see `getSettlementKnowledges` for the canonical
+ * resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Pattern Data
@@ -17,10 +21,13 @@ export async function getSettlementPatterns(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_pattern')
-    .select('id, pattern_id, pattern(custom, pattern_name)')
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_pattern')
+      .select('id, pattern_id, pattern(custom, user_id, pattern_name)')
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Patterns: ${error.message}`)
@@ -30,8 +37,8 @@ export async function getSettlementPatterns(
   return (
     data?.flatMap((item) => {
       const rawPattern = item.pattern as unknown as
-        | { custom: boolean; pattern_name: string }
-        | { custom: boolean; pattern_name: string }[]
+        | { custom: boolean; user_id: string | null; pattern_name: string }
+        | { custom: boolean; user_id: string | null; pattern_name: string }[]
         | null
 
       const pattern = Array.isArray(rawPattern)
@@ -45,7 +52,11 @@ export async function getSettlementPatterns(
           id: item.id,
           pattern_id: item.pattern_id,
           pattern_name: pattern.pattern_name,
-          custom: pattern.custom
+          custom: pattern.custom,
+          author_username:
+            pattern.custom && pattern.user_id
+              ? (memberUsernames.get(pattern.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-pattern.ts
+++ b/lib/dal/settlement-pattern.ts
@@ -12,10 +12,12 @@ import { SettlementDetail } from '@/lib/types'
  * resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Pattern Data
  */
 export async function getSettlementPatterns(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['patterns']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -26,7 +28,7 @@ export async function getSettlementPatterns(
       .from('settlement_pattern')
       .select('id, pattern_id, pattern(custom, user_id, pattern_name)')
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-philosophy.ts
+++ b/lib/dal/settlement-philosophy.ts
@@ -17,7 +17,7 @@ import { SettlementDetail } from '@/lib/types'
  */
 export async function getSettlementPhilosophies(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['philosophies']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-philosophy.ts
+++ b/lib/dal/settlement-philosophy.ts
@@ -12,10 +12,12 @@ import { SettlementDetail } from '@/lib/types'
  * resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Philosophies
  */
 export async function getSettlementPhilosophies(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['philosophies']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -28,7 +30,7 @@ export async function getSettlementPhilosophies(
         'id,  philosophy_id, philosophy(custom, user_id, philosophy_name, hunt_xp_milestones, tenet_knowledge_id, tier, neurosis_id)'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-philosophy.ts
+++ b/lib/dal/settlement-philosophy.ts
@@ -1,3 +1,4 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
@@ -5,7 +6,10 @@ import { SettlementDetail } from '@/lib/types'
 /**
  * Get Settlement Philosophies
  *
- * Gets the settlement philosophies for a given settlement.
+ * Gets the settlement philosophies for a given settlement. Each returned
+ * row carries `author_username` (null for built-ins; the catalog author's
+ * username for customs) — see `getSettlementKnowledges` for the canonical
+ * resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Philosophies
@@ -17,12 +21,15 @@ export async function getSettlementPhilosophies(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_philosophy')
-    .select(
-      'id,  philosophy_id, philosophy(custom, philosophy_name, hunt_xp_milestones, tenet_knowledge_id, tier, neurosis_id)'
-    )
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_philosophy')
+      .select(
+        'id,  philosophy_id, philosophy(custom, user_id, philosophy_name, hunt_xp_milestones, tenet_knowledge_id, tier, neurosis_id)'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Philosophies: ${error.message}`)
@@ -34,6 +41,7 @@ export async function getSettlementPhilosophies(
       const rawPhilosophy = item.philosophy as unknown as
         | {
             custom: boolean
+            user_id: string | null
             philosophy_name: string
             hunt_xp_milestones: number[] | null
             tenet_knowledge_id: string | null
@@ -42,6 +50,7 @@ export async function getSettlementPhilosophies(
           }
         | {
             custom: boolean
+            user_id: string | null
             philosophy_name: string
             hunt_xp_milestones: number[] | null
             tenet_knowledge_id: string | null
@@ -65,7 +74,11 @@ export async function getSettlementPhilosophies(
           tenet_knowledge_id: philosophy.tenet_knowledge_id,
           tier: philosophy.tier,
           neurosis_id: philosophy.neurosis_id,
-          custom: philosophy.custom
+          custom: philosophy.custom,
+          author_username:
+            philosophy.custom && philosophy.user_id
+              ? (memberUsernames.get(philosophy.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-principle.ts
+++ b/lib/dal/settlement-principle.ts
@@ -12,10 +12,12 @@ import { SettlementDetail } from '@/lib/types'
  * resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Principles
  */
 export async function getSettlementPrinciples(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['principles']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -28,7 +30,7 @@ export async function getSettlementPrinciples(
         'id,  option_1_selected, option_2_selected, principle_id, principle(custom, user_id, principle_name, option_1_name, option_2_name, option_1_rules, option_2_rules)'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-principle.ts
+++ b/lib/dal/settlement-principle.ts
@@ -17,7 +17,7 @@ import { SettlementDetail } from '@/lib/types'
  */
 export async function getSettlementPrinciples(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['principles']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-principle.ts
+++ b/lib/dal/settlement-principle.ts
@@ -1,3 +1,4 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
@@ -5,7 +6,10 @@ import { SettlementDetail } from '@/lib/types'
 /**
  * Get Settlement Principles
  *
- * Gets the settlement principles for a given settlement.
+ * Gets the settlement principles for a given settlement. Each returned
+ * row carries `author_username` (null for built-ins; the catalog author's
+ * username for customs) — see `getSettlementKnowledges` for the canonical
+ * resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Principles
@@ -17,12 +21,15 @@ export async function getSettlementPrinciples(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_principle')
-    .select(
-      'id,  option_1_selected, option_2_selected, principle_id, principle(custom, principle_name, option_1_name, option_2_name, option_1_rules, option_2_rules)'
-    )
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_principle')
+      .select(
+        'id,  option_1_selected, option_2_selected, principle_id, principle(custom, user_id, principle_name, option_1_name, option_2_name, option_1_rules, option_2_rules)'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Principles: ${error.message}`)
@@ -34,6 +41,7 @@ export async function getSettlementPrinciples(
       const embeddedPrinciple = item.principle as unknown as
         | {
             custom: boolean
+            user_id: string | null
             principle_name: string
             option_1_name: string
             option_2_name: string
@@ -42,6 +50,7 @@ export async function getSettlementPrinciples(
           }
         | {
             custom: boolean
+            user_id: string | null
             principle_name: string
             option_1_name: string
             option_2_name: string
@@ -67,7 +76,11 @@ export async function getSettlementPrinciples(
           option_2_selected: item.option_2_selected,
           principle_id: item.principle_id,
           principle_name: principle.principle_name,
-          custom: principle.custom
+          custom: principle.custom,
+          author_username:
+            principle.custom && principle.user_id
+              ? (memberUsernames.get(principle.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-quarry.ts
+++ b/lib/dal/settlement-quarry.ts
@@ -11,10 +11,12 @@ import { SettlementDetail, SettlementQuarryDetail } from '@/lib/types'
  * resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Quarry Data
  */
 export async function getSettlementQuarries(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['quarries']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -27,7 +29,7 @@ export async function getSettlementQuarries(
         'collective_cognition_level_1, collective_cognition_level_2, collective_cognition_level_3, collective_cognition_prologue, id, quarry_id, unlocked, quarry(custom, user_id, monster_name, node, prologue, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome)'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-quarry.ts
+++ b/lib/dal/settlement-quarry.ts
@@ -16,7 +16,7 @@ import { SettlementDetail, SettlementQuarryDetail } from '@/lib/types'
  */
 export async function getSettlementQuarries(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['quarries']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-quarry.ts
+++ b/lib/dal/settlement-quarry.ts
@@ -1,10 +1,14 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail, SettlementQuarryDetail } from '@/lib/types'
 
 /**
  * Get Settlement Quarries
  *
- * Retrieves the quarries associated with a settlement.
+ * Retrieves the quarries associated with a settlement. Each returned row
+ * carries `author_username` (null for built-ins; the catalog author's
+ * username for customs) — see `getSettlementKnowledges` for the canonical
+ * resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Quarry Data
@@ -16,12 +20,15 @@ export async function getSettlementQuarries(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_quarry')
-    .select(
-      'collective_cognition_level_1, collective_cognition_level_2, collective_cognition_level_3, collective_cognition_prologue, id, quarry_id, unlocked, quarry(custom, monster_name, node, prologue, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome)'
-    )
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_quarry')
+      .select(
+        'collective_cognition_level_1, collective_cognition_level_2, collective_cognition_level_3, collective_cognition_prologue, id, quarry_id, unlocked, quarry(custom, user_id, monster_name, node, prologue, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome)'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Quarries: ${error.message}`)
@@ -33,6 +40,7 @@ export async function getSettlementQuarries(
       const rawQuarry = item.quarry as unknown as
         | {
             custom: boolean
+            user_id: string | null
             monster_name: string
             node: string
             prologue: boolean
@@ -45,6 +53,7 @@ export async function getSettlementQuarries(
           }
         | {
             custom: boolean
+            user_id: string | null
             monster_name: string
             node: string
             prologue: boolean
@@ -81,7 +90,11 @@ export async function getSettlementQuarries(
           defeat_outcome: quarry.defeat_outcome,
           deployment_rules: quarry.deployment_rules,
           victory_outcome: quarry.victory_outcome,
-          custom: quarry.custom
+          custom: quarry.custom,
+          author_username:
+            quarry.custom && quarry.user_id
+              ? (memberUsernames.get(quarry.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-resource.ts
+++ b/lib/dal/settlement-resource.ts
@@ -17,7 +17,7 @@ import { SettlementDetail } from '@/lib/types'
  */
 export async function getSettlementResources(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['resources']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-resource.ts
+++ b/lib/dal/settlement-resource.ts
@@ -1,3 +1,4 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
@@ -5,7 +6,10 @@ import { SettlementDetail } from '@/lib/types'
 /**
  * Get Settlement Resources
  *
- * Retrieves the resources associated with a settlement.
+ * Retrieves the resources associated with a settlement. Each returned row
+ * carries `author_username` (null for built-ins; the catalog author's
+ * username for customs) — see `getSettlementKnowledges` for the canonical
+ * resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Resources Data
@@ -17,12 +21,15 @@ export async function getSettlementResources(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_resource')
-    .select(
-      'id, resource_id, quantity, resource(custom, category, quarry_id, resource_name, resource_types, quarry(monster_name, node))'
-    )
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_resource')
+      .select(
+        'id, resource_id, quantity, resource(custom, user_id, category, quarry_id, resource_name, resource_types, quarry(monster_name, node))'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Resources: ${error.message}`)
@@ -34,6 +41,7 @@ export async function getSettlementResources(
       const resource = item.resource as unknown as
         | {
             custom: boolean
+            user_id: string | null
             category: string
             quarry_id: string | null
             resource_name: string
@@ -42,6 +50,7 @@ export async function getSettlementResources(
           }
         | {
             custom: boolean
+            user_id: string | null
             category: string
             quarry_id: string | null
             resource_name: string
@@ -64,7 +73,11 @@ export async function getSettlementResources(
           resource_id: item.resource_id,
           resource_name: res.resource_name,
           resource_types: res.resource_types,
-          custom: res.custom
+          custom: res.custom,
+          author_username:
+            res.custom && res.user_id
+              ? (memberUsernames.get(res.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-resource.ts
+++ b/lib/dal/settlement-resource.ts
@@ -12,10 +12,12 @@ import { SettlementDetail } from '@/lib/types'
  * resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Resources Data
  */
 export async function getSettlementResources(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['resources']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -28,7 +30,7 @@ export async function getSettlementResources(
         'id, resource_id, quantity, resource(custom, user_id, category, quarry_id, resource_name, resource_types, quarry(monster_name, node))'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-seed-pattern.ts
+++ b/lib/dal/settlement-seed-pattern.ts
@@ -16,7 +16,7 @@ import { SettlementDetail } from '@/lib/types'
  */
 export async function getSettlementSeedPatterns(
   settlementId: string | null | undefined,
-  prefetchedMemberUsernames?: Map<string, string>
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SettlementDetail['seed_patterns']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 

--- a/lib/dal/settlement-seed-pattern.ts
+++ b/lib/dal/settlement-seed-pattern.ts
@@ -1,10 +1,14 @@
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail } from '@/lib/types'
 
 /**
  * Get Settlement Seed Patterns
  *
- * Retrieves the seed patterns associated with a settlement.
+ * Retrieves the seed patterns associated with a settlement. Each returned
+ * row carries `author_username` (null for built-ins; the catalog author's
+ * username for customs) — see `getSettlementKnowledges` for the canonical
+ * resolution pattern.
  *
  * @param settlementId Settlement ID
  * @returns Settlement Seed Pattern Data
@@ -16,10 +20,15 @@ export async function getSettlementSeedPatterns(
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('settlement_seed_pattern')
-    .select('id, seed_pattern_id, seed_pattern(custom, seed_pattern_name)')
-    .eq('settlement_id', settlementId)
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('settlement_seed_pattern')
+      .select(
+        'id, seed_pattern_id, seed_pattern(custom, user_id, seed_pattern_name)'
+      )
+      .eq('settlement_id', settlementId),
+    getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error)
     throw new Error(`Error Fetching Settlement Seed Patterns: ${error.message}`)
@@ -31,10 +40,12 @@ export async function getSettlementSeedPatterns(
       const seedPatternRelation = item.seed_pattern as unknown as
         | {
             custom: boolean
+            user_id: string | null
             seed_pattern_name: string
           }
         | {
             custom: boolean
+            user_id: string | null
             seed_pattern_name: string
           }[]
         | null
@@ -50,7 +61,11 @@ export async function getSettlementSeedPatterns(
           id: item.id,
           seed_pattern_id: item.seed_pattern_id,
           seed_pattern_name: seedPattern.seed_pattern_name,
-          custom: seedPattern.custom
+          custom: seedPattern.custom,
+          author_username:
+            seedPattern.custom && seedPattern.user_id
+              ? (memberUsernames.get(seedPattern.user_id) ?? null)
+              : null
         }
       ]
     }) ?? []

--- a/lib/dal/settlement-seed-pattern.ts
+++ b/lib/dal/settlement-seed-pattern.ts
@@ -11,10 +11,12 @@ import { SettlementDetail } from '@/lib/types'
  * resolution pattern.
  *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional pre-fetched map of IDs to usernames
  * @returns Settlement Seed Pattern Data
  */
 export async function getSettlementSeedPatterns(
-  settlementId: string | null | undefined
+  settlementId: string | null | undefined,
+  prefetchedMemberUsernames?: Map<string, string>
 ): Promise<SettlementDetail['seed_patterns']> {
   if (!settlementId) throw new Error('Required: Settlement ID')
 
@@ -27,7 +29,7 @@ export async function getSettlementSeedPatterns(
         'id, seed_pattern_id, seed_pattern(custom, user_id, seed_pattern_name)'
       )
       .eq('settlement_id', settlementId),
-    getSettlementMemberUsernames(settlementId)
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
   ])
 
   if (error)

--- a/lib/dal/settlement-shared-user.ts
+++ b/lib/dal/settlement-shared-user.ts
@@ -2,6 +2,57 @@ import { getUserId } from '@/lib/dal/user'
 import { createClient } from '@/lib/supabase/client'
 
 /**
+ * Get Settlement Member Usernames
+ *
+ * Returns a `Map<user_id, username>` of every user connected to a
+ * settlement — the owner plus every collaborator listed in
+ * `settlement_shared_user`. Powers the "By @username" authorship chip on
+ * custom catalog rows materialized into `SettlementDetail`'s collections
+ * (E2.8 in local/sharing-architecture.md §7.4 / §10 Phase 2 item 2.6).
+ *
+ * Goes through the `get_settlement_member_usernames` SECURITY DEFINER RPC
+ * because RLS on `user_settings` restricts SELECT to the row owner. A
+ * direct embedded query
+ * (`settlement_<x> → <catalog> → user_settings`) would silently return
+ * `null` for every author who is not the calling user. The RPC scopes
+ * results to settlements the caller is a member of (owner or
+ * collaborator); unrelated callers receive an empty map. Mirrors
+ * {@link getSettlementSharedUsers}'s use of `get_settlement_collaborators`.
+ *
+ * @param settlementId Settlement ID
+ * @returns Map of `user_id -> username` for every settlement member
+ */
+export async function getSettlementMemberUsernames(
+  settlementId: string | null | undefined
+): Promise<Map<string, string>> {
+  if (!settlementId) throw new Error('Required: Settlement ID')
+
+  const supabase = createClient()
+
+  const { data, error } = await supabase.rpc(
+    'get_settlement_member_usernames',
+    {
+      target_settlement: settlementId
+    }
+  )
+
+  if (error)
+    throw new Error(
+      `Error Fetching Settlement Member Usernames: ${error.message}`
+    )
+
+  const map = new Map<string, string>()
+  for (const row of (data ?? []) as {
+    user_id: string | null
+    username: string | null
+  }[]) {
+    if (row.user_id && row.username) map.set(row.user_id, row.username)
+  }
+
+  return map
+}
+
+/**
  * Settlement Collaborator Detail
  *
  * Row shape returned by {@link getSettlementSharedUsers}. Includes the

--- a/lib/dal/settlement.ts
+++ b/lib/dal/settlement.ts
@@ -317,10 +317,13 @@ export async function getSettlement(
 
   if (!settlement) return null
 
-  // Fetch the settlement member-username map once and pass it to every
-  // settlement-collection DAL below to avoid issuing the same RPC ~13 times
-  // per settlement load.
-  const memberUsernames = await getSettlementMemberUsernames(settlementId)
+  // Start the settlement member-username RPC once and share the in-flight
+  // promise across every settlement-collection DAL below. This avoids the
+  // ~13× RPC fan-out we'd get if each DAL fetched the map itself, and —
+  // critically — keeps the RPC running concurrently with the collection
+  // queries inside the Promise.all instead of forcing a sequential
+  // round-trip before them.
+  const memberUsernamesPromise = getSettlementMemberUsernames(settlementId)
 
   const [
     collectiveCognitionRewards,
@@ -339,20 +342,23 @@ export async function getSettlement(
     seedPatterns,
     timelineYears
   ] = await Promise.all([
-    getSettlementCollectiveCognitionRewards(settlementId, memberUsernames),
-    getSettlementGear(settlementId, memberUsernames),
-    getSettlementInnovations(settlementId, memberUsernames),
-    getSettlementKnowledges(settlementId, memberUsernames),
-    getSettlementLocations(settlementId, memberUsernames),
-    getSettlementMilestones(settlementId, memberUsernames),
-    getSettlementNemeses(settlementId, memberUsernames),
+    getSettlementCollectiveCognitionRewards(
+      settlementId,
+      memberUsernamesPromise
+    ),
+    getSettlementGear(settlementId, memberUsernamesPromise),
+    getSettlementInnovations(settlementId, memberUsernamesPromise),
+    getSettlementKnowledges(settlementId, memberUsernamesPromise),
+    getSettlementLocations(settlementId, memberUsernamesPromise),
+    getSettlementMilestones(settlementId, memberUsernamesPromise),
+    getSettlementNemeses(settlementId, memberUsernamesPromise),
     getNeuroses(),
-    getSettlementPatterns(settlementId, memberUsernames),
-    getSettlementPhilosophies(settlementId, memberUsernames),
-    getSettlementPrinciples(settlementId, memberUsernames),
-    getSettlementQuarries(settlementId, memberUsernames),
-    getSettlementResources(settlementId, memberUsernames),
-    getSettlementSeedPatterns(settlementId, memberUsernames),
+    getSettlementPatterns(settlementId, memberUsernamesPromise),
+    getSettlementPhilosophies(settlementId, memberUsernamesPromise),
+    getSettlementPrinciples(settlementId, memberUsernamesPromise),
+    getSettlementQuarries(settlementId, memberUsernamesPromise),
+    getSettlementResources(settlementId, memberUsernamesPromise),
+    getSettlementSeedPatterns(settlementId, memberUsernamesPromise),
     getSettlementTimelineYears(settlementId)
   ])
 

--- a/lib/dal/settlement.ts
+++ b/lib/dal/settlement.ts
@@ -45,6 +45,7 @@ import {
 } from '@/lib/dal/settlement-quarry'
 import { getSettlementResources } from '@/lib/dal/settlement-resource'
 import { getSettlementSeedPatterns } from '@/lib/dal/settlement-seed-pattern'
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import {
   addSettlementTimelineYears,
   getSettlementTimelineYears
@@ -316,6 +317,11 @@ export async function getSettlement(
 
   if (!settlement) return null
 
+  // Fetch the settlement member-username map once and pass it to every
+  // settlement-collection DAL below to avoid issuing the same RPC ~13 times
+  // per settlement load.
+  const memberUsernames = await getSettlementMemberUsernames(settlementId)
+
   const [
     collectiveCognitionRewards,
     gear,
@@ -333,20 +339,20 @@ export async function getSettlement(
     seedPatterns,
     timelineYears
   ] = await Promise.all([
-    getSettlementCollectiveCognitionRewards(settlementId),
-    getSettlementGear(settlementId),
-    getSettlementInnovations(settlementId),
-    getSettlementKnowledges(settlementId),
-    getSettlementLocations(settlementId),
-    getSettlementMilestones(settlementId),
-    getSettlementNemeses(settlementId),
+    getSettlementCollectiveCognitionRewards(settlementId, memberUsernames),
+    getSettlementGear(settlementId, memberUsernames),
+    getSettlementInnovations(settlementId, memberUsernames),
+    getSettlementKnowledges(settlementId, memberUsernames),
+    getSettlementLocations(settlementId, memberUsernames),
+    getSettlementMilestones(settlementId, memberUsernames),
+    getSettlementNemeses(settlementId, memberUsernames),
     getNeuroses(),
-    getSettlementPatterns(settlementId),
-    getSettlementPhilosophies(settlementId),
-    getSettlementPrinciples(settlementId),
-    getSettlementQuarries(settlementId),
-    getSettlementResources(settlementId),
-    getSettlementSeedPatterns(settlementId),
+    getSettlementPatterns(settlementId, memberUsernames),
+    getSettlementPhilosophies(settlementId, memberUsernames),
+    getSettlementPrinciples(settlementId, memberUsernames),
+    getSettlementQuarries(settlementId, memberUsernames),
+    getSettlementResources(settlementId, memberUsernames),
+    getSettlementSeedPatterns(settlementId, memberUsernames),
     getSettlementTimelineYears(settlementId)
   ])
 

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -4973,6 +4973,13 @@ export type Database = {
           username: string
         }[]
       }
+      get_settlement_member_usernames: {
+        Args: { target_settlement: string }
+        Returns: {
+          user_id: string
+          username: string
+        }[]
+      }
       get_shared_settlement_owners: {
         Args: never
         Returns: {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -797,6 +797,8 @@ export type SettlementDetail = Omit<
     unlocked: boolean
     /** Whether the underlying reward is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Gear */
   gear: {
@@ -810,6 +812,8 @@ export type SettlementDetail = Omit<
     quantity: number
     /** Whether the underlying gear is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Innovations */
   innovations: {
@@ -827,6 +831,8 @@ export type SettlementDetail = Omit<
     benefits: string | null
     /** Whether the underlying innovation is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Knowledges */
   knowledges: {
@@ -846,6 +852,8 @@ export type SettlementDetail = Omit<
     observation_rank_up_milestone: number | null
     /** Whether the underlying knowledge is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Locations */
   locations: {
@@ -861,6 +869,8 @@ export type SettlementDetail = Omit<
     unlocked: boolean
     /** Whether the underlying location is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Neuroses */
   neuroses: {
@@ -889,6 +899,8 @@ export type SettlementDetail = Omit<
     rules: string | null
     /** Whether the underlying milestone is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Nemeses */
   nemeses: {
@@ -932,6 +944,8 @@ export type SettlementDetail = Omit<
     victory_outcome: string | null
     /** Whether the underlying nemesis is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Patterns */
   patterns: {
@@ -943,6 +957,8 @@ export type SettlementDetail = Omit<
     pattern_name: string
     /** Whether the underlying pattern is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Philosophies */
   philosophies: {
@@ -962,6 +978,8 @@ export type SettlementDetail = Omit<
     neurosis_id: string | null
     /** Whether the underlying philosophy is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Principles */
   principles: {
@@ -985,6 +1003,8 @@ export type SettlementDetail = Omit<
     principle_name: string
     /** Whether the underlying principle is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Quarries */
   quarries: {
@@ -1022,6 +1042,8 @@ export type SettlementDetail = Omit<
     victory_outcome: string | null
     /** Whether the underlying quarry is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Resources */
   resources: {
@@ -1045,6 +1067,8 @@ export type SettlementDetail = Omit<
     resource_types: string[]
     /** Whether the underlying resource is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Seed Patterns */
   seed_patterns: {
@@ -1056,6 +1080,8 @@ export type SettlementDetail = Omit<
     seed_pattern_name: string
     /** Whether the underlying seed pattern is user-defined */
     custom: boolean
+    /** Author Username (null for built-ins; see E2.8 / §7.4) */
+    author_username: string | null
   }[]
   /** Caller's Role on This Settlement */
   role: SettlementRole

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.19",
+  "version": "0.61.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.19",
+      "version": "0.61.20",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.21",
+  "version": "0.61.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.21",
+      "version": "0.61.22",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.20",
+  "version": "0.61.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.20",
+      "version": "0.61.21",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.21",
+  "version": "0.61.22",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.20",
+  "version": "0.61.21",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.19",
+  "version": "0.61.20",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260521000000_get_settlement_member_usernames.sql
+++ b/supabase/migrations/20260521000000_get_settlement_member_usernames.sql
@@ -1,0 +1,91 @@
+--------------------------------------------------------------------------------
+-- Get Settlement Member Usernames
+--
+-- SECURITY DEFINER function returning the username of every user connected
+-- to a settlement (the owner plus every collaborator listed in
+-- `settlement_shared_user`). Powers the "By @username" authorship chip on
+-- custom catalog rows materialized into `SettlementDetail`'s collections
+-- (E2.8 in local/sharing-architecture.md §7.4 / §10 Phase 2 item 2.6).
+--
+-- Why an RPC is required:
+--   - RLS on `user_settings` restricts SELECT to the row owner. A direct
+--     embedded query (e.g. `settlement_knowledge → knowledge →
+--     user_settings`) would silently return `null` for the username because
+--     the calling user is rarely the `user_settings` row owner of every
+--     author whose custom rows are attached to the settlement.
+--   - Mirrors `get_settlement_collaborators` (20260510120000) and
+--     `get_shared_settlement_owners` (20260505000001), which solve adjacent
+--     username lookups for the same reason.
+--
+-- Authorization:
+--   - The function only returns rows when `auth.uid()` is the owner of the
+--     target settlement OR is listed in `settlement_shared_user` for it.
+--     Unrelated callers receive an empty result set — they cannot
+--     enumerate usernames by guessing settlement IDs.
+--
+-- Why the result is settlement-scoped rather than per-author:
+--   - Every catalog row visible to the caller on this settlement was
+--     authored by either the owner or a collaborator (custom catalog rows
+--     are exposed via transitive settlement membership; see
+--     20260512000000_catalog_visibility_via_settlement.sql). Returning the
+--     small `(user_id, username)` map for the settlement lets each DAL
+--     resolve `author_username` with a single lookup instead of issuing
+--     one RPC per catalog kind.
+--
+-- Auth surface:
+--   - `revoke execute … from anon` because Supabase's
+--     `ALTER DEFAULT PRIVILEGES` on `public` grants EXECUTE to anon
+--     independently of PUBLIC. The implicit `auth.uid()` filter would
+--     return an empty result for anon callers anyway, but the explicit
+--     revoke keeps the contract obvious.
+--
+-- Hardening: `set search_path = ''` + fully-qualified table references
+-- prevent `pg_temp` / schema-shadowing attacks against this SECURITY
+-- DEFINER function. Mirrors the pattern used by
+-- `get_settlement_collaborators` (20260510120000) and
+-- `lookup_user_by_username` (20260510000000).
+--------------------------------------------------------------------------------
+create or replace function get_settlement_member_usernames(target_settlement uuid) returns table (user_id uuid, username varchar) language sql security definer
+set search_path = '' stable as $$ with caller_member as (
+    select 1
+    where (
+        exists (
+          select 1
+          from public.settlement s
+          where s.id = target_settlement
+            and s.user_id = auth.uid()
+        )
+        or exists (
+          select 1
+          from public.settlement_shared_user ssu
+          where ssu.settlement_id = target_settlement
+            and ssu.shared_user_id = auth.uid()
+        )
+      )
+  )
+select s.user_id,
+  us.username
+from public.settlement s
+  join public.user_settings us on us.user_id = s.user_id
+where s.id = target_settlement
+  and exists (
+    select 1
+    from caller_member
+  )
+union
+select ssu.shared_user_id as user_id,
+  us.username
+from public.settlement_shared_user ssu
+  join public.user_settings us on us.user_id = ssu.shared_user_id
+where ssu.settlement_id = target_settlement
+  and exists (
+    select 1
+    from caller_member
+  );
+$$;
+revoke all on function public.get_settlement_member_usernames(uuid)
+from public;
+-- Drop anon explicitly; see header for rationale.
+revoke execute on function public.get_settlement_member_usernames(uuid)
+from anon;
+grant execute on function public.get_settlement_member_usernames(uuid) to authenticated;


### PR DESCRIPTION
## Summary

Closes #158 ([E2.8] — Surface `author_username` on custom rows in
`SettlementDetail`). Required before E2.9 can render an "By @username"
chip on custom catalog rows.

Every settlement-collection entry materialized into `SettlementDetail`
now carries `author_username` (null for built-ins; the catalog author's
username for customs). This is wired through all 13 settlement-attached
collections (collective_cognition_rewards, gear, innovations, knowledges,
locations, milestones, nemeses, patterns, philosophies, principles,
quarries, resources, seed_patterns).

Source of truth: `local/sharing-architecture.md` §7.4 / §10 Phase 2 item
2.6.

## How

- **New RPC** — `get_settlement_member_usernames` (SECURITY DEFINER,
  `set search_path = ''`, fully-qualified `public.*` refs). Returns the
  `(user_id, username)` map for the settlement owner plus every
  collaborator listed in `settlement_shared_user`. Authorized only when
  `auth.uid()` is the owner or a collaborator; unrelated callers receive
  an empty result set. `revoke execute … from anon` +
  `grant execute … to authenticated`. Mirrors the existing
  `get_settlement_collaborators` pattern.

  This RPC is required because RLS on `user_settings` is owner-only —
  a direct PostgREST embed (`settlement_<x> → <catalog> → user_settings`)
  would silently return `null` for every author who is not the calling
  user.

- **DAL** — `getSettlementMemberUsernames` added to
  `lib/dal/settlement-shared-user.ts`. Each of the 13 settlement-
  collection DALs now fetches the embedded catalog query and the member
  map in parallel via `Promise.all`, then maps `author_username` per row
  (only resolved for `custom === true`, otherwise `null`). The
  `settlement-knowledge` DAL has the expanded canonical doc comment;
  siblings reference it.

- **Types** — `lib/types.ts`: added `author_username: string | null` to
  all 13 settlement-attached collection entries. `lib/database.types.ts`:
  added the RPC signature next to `get_settlement_collaborators`.

## Tests

- All 13 settlement DAL unit test suites updated to mock `supabase.rpc`
  and assert `author_username` resolution.
- New unit tests for `getSettlementMemberUsernames` (null/undefined
  inputs, map building, empty data, null user_id/username skipped, RPC
  errors).
- New integration test
  `__tests__/integration/rls/get-settlement-member-usernames.test.ts`
  covering owner/collaborator/stranger/anon access — mirrors the style
  of `get-settlement-collaborators.test.ts`.

Verification:

- `npm test` — **1921 passed (1921)**
- `npm run lint` — clean
- `npm run format:check` — clean

## Acceptance criteria

- [x] Loading a settlement returns the author's username for every
      custom row (resolved via member-username map).
- [x] Built-ins get `null`.
- [x] Type checks pass.

## Dependencies

No new dependencies. `package.json` / `package-lock.json` bumped
`0.61.19 → 0.61.20`.

## Out of scope

Avatar lookup (E0.7 handles the data; chip rendering uses the username
+ avatar in E2.9). UI surface for the chip itself is E2.9.
