### PR TITLE
feat(survivor,hunt,showdown): surface author_username on custom rows (#158)

### DIFF
--- a/__tests__/integration/rls/catalog-visibility-via-settlement.test.ts
+++ b/__tests__/integration/rls/catalog-visibility-via-settlement.test.ts
@@ -297,7 +297,7 @@ describe('RLS: catalog visibility via settlement membership', () => {
           .maybeSingle()
         expect(ownerErr).toBeNull()
         expect(ownerRead).not.toBeNull()
-        expect((ownerRead as Record<string, unknown>)[c.nameCol]).toBe(name)
+        expect(ownerRead![c.nameCol as never]).toBe(name)
 
         // Stranger does not.
         const { data: strangerRead } = await stranger.client

--- a/__tests__/lib/dal/hunt-monster.test.ts
+++ b/__tests__/lib/dal/hunt-monster.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,8 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members map (resolved authors will be null).
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getHuntMonsters', () => {
@@ -109,6 +112,147 @@ describe('getHuntMonsters', () => {
     await expect(getHuntMonsters('hunt-1')).rejects.toThrow(
       'Error Fetching Hunt Monsters: DB error'
     )
+  })
+
+  it('resolves author_username for custom trait/mood/survivor_status rows authored by a settlement member', async () => {
+    const rawMonster = {
+      id: 'monster-1',
+      monster_name: 'White Lion',
+      hunt_id: 'hunt-1',
+      settlement_id: 'settlement-1',
+      hunt_ai_deck: null,
+      hunt_monster_trait: [
+        {
+          trait: {
+            id: 't-1',
+            custom: true,
+            user_id: 'author-1',
+            trait_name: 'Hollow Roar',
+            rules: null
+          }
+        },
+        {
+          trait: {
+            id: 't-2',
+            custom: false,
+            user_id: null,
+            trait_name: 'Standard',
+            rules: null
+          }
+        }
+      ],
+      hunt_monster_mood: [
+        {
+          mood: {
+            id: 'm-1',
+            custom: true,
+            user_id: 'ghost-1',
+            mood_name: 'Forsaken',
+            rules: null
+          }
+        }
+      ],
+      hunt_monster_survivor_status: [
+        {
+          survivor_status: {
+            id: 's-1',
+            custom: true,
+            user_id: 'author-1',
+            survivor_status_name: 'Marked',
+            rules: null
+          }
+        }
+      ]
+    }
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [rawMonster], error: null })
+      })
+    })
+    mockSupabase.rpc.mockResolvedValue({
+      data: [{ user_id: 'author-1', username: 'ashen.veil' }],
+      error: null
+    })
+
+    const result = await getHuntMonsters('hunt-1')
+
+    expect(result!['monster-1'].traits).toEqual([
+      {
+        id: 't-1',
+        custom: true,
+        trait_name: 'Hollow Roar',
+        rules: null,
+        author_username: 'ashen.veil'
+      },
+      {
+        id: 't-2',
+        custom: false,
+        trait_name: 'Standard',
+        rules: null,
+        author_username: null
+      }
+    ])
+    // Ghost author (member left settlement) resolves to null.
+    expect(result!['monster-1'].moods[0].author_username).toBeNull()
+    expect(result!['monster-1'].survivor_statuses[0].author_username).toBe(
+      'ashen.veil'
+    )
+    expect(mockSupabase.rpc).toHaveBeenCalledWith(
+      'get_settlement_member_usernames',
+      { target_settlement: 'settlement-1' }
+    )
+  })
+
+  it('skips the member-username RPC when no monsters exist', async () => {
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [], error: null })
+      })
+    })
+
+    const result = await getHuntMonsters('hunt-1')
+
+    expect(result).toEqual({})
+    expect(mockSupabase.rpc).not.toHaveBeenCalled()
+  })
+
+  it('uses the prefetched member-username promise instead of issuing a duplicate RPC', async () => {
+    const rawMonster = {
+      id: 'monster-1',
+      monster_name: 'White Lion',
+      hunt_id: 'hunt-1',
+      settlement_id: 'settlement-1',
+      hunt_ai_deck: null,
+      hunt_monster_trait: [
+        {
+          trait: {
+            id: 't-1',
+            custom: true,
+            user_id: 'author-1',
+            trait_name: 'Hollow Roar',
+            rules: null
+          }
+        }
+      ],
+      hunt_monster_mood: [],
+      hunt_monster_survivor_status: []
+    }
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [rawMonster], error: null })
+      })
+    })
+
+    const prefetched = Promise.resolve(
+      new Map<string, string>([['author-1', 'prefetched.user']])
+    )
+
+    const result = await getHuntMonsters('hunt-1', prefetched)
+
+    expect(result!['monster-1'].traits[0].author_username).toBe(
+      'prefetched.user'
+    )
+    expect(mockSupabase.rpc).not.toHaveBeenCalled()
   })
 })
 

--- a/__tests__/lib/dal/hunt.test.ts
+++ b/__tests__/lib/dal/hunt.test.ts
@@ -20,6 +20,10 @@ vi.mock('@/lib/dal/hunt-survivor', () => ({
   getHuntSurvivors: vi.fn()
 }))
 
+vi.mock('@/lib/dal/settlement-shared-user', () => ({
+  getSettlementMemberUsernames: vi.fn().mockResolvedValue(new Map())
+}))
+
 const { getHunt, addHunt, updateHunt, removeHunt } =
   await import('@/lib/dal/hunt')
 const { getHuntHuntBoard } = await import('@/lib/dal/hunt-hunt-board')
@@ -96,7 +100,7 @@ describe('getHunt', () => {
       hunt_survivors: mockSurvivors
     })
     expect(getHuntHuntBoard).toHaveBeenCalledWith('hunt-1')
-    expect(getHuntMonsters).toHaveBeenCalledWith('hunt-1')
+    expect(getHuntMonsters).toHaveBeenCalledWith('hunt-1', expect.any(Promise))
     expect(getHuntSurvivors).toHaveBeenCalledWith('hunt-1')
   })
 

--- a/__tests__/lib/dal/showdown-monster.test.ts
+++ b/__tests__/lib/dal/showdown-monster.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -17,6 +18,8 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members map (resolved authors will be null).
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 describe('getShowdownMonsters', () => {
@@ -109,6 +112,147 @@ describe('getShowdownMonsters', () => {
     await expect(getShowdownMonsters('showdown-1')).rejects.toThrow(
       'Error Fetching Showdown Monsters: DB error'
     )
+  })
+
+  it('resolves author_username for custom trait/mood/survivor_status rows authored by a settlement member', async () => {
+    const rawMonster = {
+      id: 'monster-1',
+      monster_name: 'White Lion',
+      showdown_id: 'showdown-1',
+      settlement_id: 'settlement-1',
+      showdown_ai_deck: null,
+      showdown_monster_trait: [
+        {
+          trait: {
+            id: 't-1',
+            custom: true,
+            user_id: 'author-1',
+            trait_name: 'Hollow Roar',
+            rules: null
+          }
+        },
+        {
+          trait: {
+            id: 't-2',
+            custom: false,
+            user_id: null,
+            trait_name: 'Standard',
+            rules: null
+          }
+        }
+      ],
+      showdown_monster_mood: [
+        {
+          mood: {
+            id: 'm-1',
+            custom: true,
+            user_id: 'ghost-1',
+            mood_name: 'Forsaken',
+            rules: null
+          }
+        }
+      ],
+      showdown_monster_survivor_status: [
+        {
+          survivor_status: {
+            id: 's-1',
+            custom: true,
+            user_id: 'author-1',
+            survivor_status_name: 'Marked',
+            rules: null
+          }
+        }
+      ]
+    }
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [rawMonster], error: null })
+      })
+    })
+    mockSupabase.rpc.mockResolvedValue({
+      data: [{ user_id: 'author-1', username: 'ashen.veil' }],
+      error: null
+    })
+
+    const result = await getShowdownMonsters('showdown-1')
+
+    expect(result!['monster-1'].traits).toEqual([
+      {
+        id: 't-1',
+        custom: true,
+        trait_name: 'Hollow Roar',
+        rules: null,
+        author_username: 'ashen.veil'
+      },
+      {
+        id: 't-2',
+        custom: false,
+        trait_name: 'Standard',
+        rules: null,
+        author_username: null
+      }
+    ])
+    // Ghost author (member left settlement) resolves to null.
+    expect(result!['monster-1'].moods[0].author_username).toBeNull()
+    expect(result!['monster-1'].survivor_statuses[0].author_username).toBe(
+      'ashen.veil'
+    )
+    expect(mockSupabase.rpc).toHaveBeenCalledWith(
+      'get_settlement_member_usernames',
+      { target_settlement: 'settlement-1' }
+    )
+  })
+
+  it('skips the member-username RPC when no monsters exist', async () => {
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [], error: null })
+      })
+    })
+
+    const result = await getShowdownMonsters('showdown-1')
+
+    expect(result).toEqual({})
+    expect(mockSupabase.rpc).not.toHaveBeenCalled()
+  })
+
+  it('uses the prefetched member-username promise instead of issuing a duplicate RPC', async () => {
+    const rawMonster = {
+      id: 'monster-1',
+      monster_name: 'White Lion',
+      showdown_id: 'showdown-1',
+      settlement_id: 'settlement-1',
+      showdown_ai_deck: null,
+      showdown_monster_trait: [
+        {
+          trait: {
+            id: 't-1',
+            custom: true,
+            user_id: 'author-1',
+            trait_name: 'Hollow Roar',
+            rules: null
+          }
+        }
+      ],
+      showdown_monster_mood: [],
+      showdown_monster_survivor_status: []
+    }
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [rawMonster], error: null })
+      })
+    })
+
+    const prefetched = Promise.resolve(
+      new Map<string, string>([['author-1', 'prefetched.user']])
+    )
+
+    const result = await getShowdownMonsters('showdown-1', prefetched)
+
+    expect(result!['monster-1'].traits[0].author_username).toBe(
+      'prefetched.user'
+    )
+    expect(mockSupabase.rpc).not.toHaveBeenCalled()
   })
 })
 

--- a/__tests__/lib/dal/showdown.test.ts
+++ b/__tests__/lib/dal/showdown.test.ts
@@ -16,6 +16,10 @@ vi.mock('@/lib/dal/showdown-survivor', () => ({
   getShowdownSurvivors: vi.fn()
 }))
 
+vi.mock('@/lib/dal/settlement-shared-user', () => ({
+  getSettlementMemberUsernames: vi.fn().mockResolvedValue(new Map())
+}))
+
 const { getShowdown, addShowdown, updateShowdown, removeShowdown } =
   await import('@/lib/dal/showdown')
 const { getShowdownMonsters } = await import('@/lib/dal/showdown-monster')
@@ -82,7 +86,10 @@ describe('getShowdown', () => {
       showdown_monsters: mockMonsters,
       showdown_survivors: mockSurvivors
     })
-    expect(getShowdownMonsters).toHaveBeenCalledWith('showdown-1')
+    expect(getShowdownMonsters).toHaveBeenCalledWith(
+      'showdown-1',
+      expect.any(Promise)
+    )
     expect(getShowdownSurvivors).toHaveBeenCalledWith('showdown-1')
   })
 

--- a/__tests__/lib/dal/survivor.test.ts
+++ b/__tests__/lib/dal/survivor.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -31,6 +32,8 @@ const {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: no settlement members map (resolved authors will be null).
+  mockSupabase.rpc.mockResolvedValue({ data: [], error: null })
 })
 
 // Helper to build a minimal survivor base object
@@ -259,6 +262,133 @@ describe('getSurvivors', () => {
       fighting_arts: [],
       secret_fighting_arts: []
     })
+  })
+
+  it('resolves author_username for custom catalog rows across collections', async () => {
+    const survivorRow = {
+      ...baseSurvivor,
+      abilities_impairments: [],
+      cursed_gear: [
+        {
+          gear: {
+            id: 'g-1',
+            custom: true,
+            user_id: 'author-1',
+            gear_name: 'Hollow Blade'
+          }
+        }
+      ],
+      disorders: [
+        {
+          disorder: {
+            id: 'd-1',
+            custom: false,
+            user_id: null,
+            disorder_name: 'Standard',
+            rules: null
+          }
+        }
+      ],
+      fighting_arts: [
+        {
+          fighting_art: {
+            id: 'fa-1',
+            custom: true,
+            user_id: 'ghost-1',
+            fighting_art_name: 'Forsaken Step',
+            rules: null
+          }
+        }
+      ],
+      secret_fighting_arts: [],
+      hunt_survivor: [],
+      showdown_survivor: [],
+      knowledge_1: {
+        id: 'k-1',
+        custom: true,
+        user_id: 'author-1',
+        knowledge_name: 'Whispers',
+        rules: null,
+        observation_conditions: null,
+        observation_rank_up_milestone: null
+      },
+      knowledge_2: null,
+      neurosis: null,
+      philosophy: null,
+      tenet_knowledge: null
+    }
+
+    const mockReturns = vi
+      .fn()
+      .mockResolvedValue({ data: [survivorRow], error: null })
+    const mockOrder = vi.fn().mockReturnValue({ returns: mockReturns })
+    const mockEq = vi.fn().mockReturnValue({ order: mockOrder })
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEq })
+    mockSupabase.from.mockReturnValue({ select: mockSelect })
+
+    mockSupabase.rpc.mockResolvedValue({
+      data: [{ user_id: 'author-1', username: 'ashen.veil' }],
+      error: null
+    })
+
+    const result = await getSurvivors('set-1')
+
+    expect(result![0].cursed_gear[0].author_username).toBe('ashen.veil')
+    expect(result![0].cursed_gear[0]).not.toHaveProperty('user_id')
+    // Built-in disorder resolves to null author.
+    expect(result![0].disorders[0].author_username).toBeNull()
+    // Custom row authored by a member who left the settlement resolves to
+    // null even though `custom` is true.
+    expect(result![0].fighting_arts[0].author_username).toBeNull()
+    expect(result![0].knowledge_1?.author_username).toBe('ashen.veil')
+    expect(mockSupabase.rpc).toHaveBeenCalledWith(
+      'get_settlement_member_usernames',
+      { target_settlement: 'set-1' }
+    )
+  })
+
+  it('uses the prefetched member-username promise instead of issuing a duplicate RPC', async () => {
+    const survivorRow = {
+      ...baseSurvivor,
+      abilities_impairments: [],
+      cursed_gear: [
+        {
+          gear: {
+            id: 'g-1',
+            custom: true,
+            user_id: 'author-1',
+            gear_name: 'Hollow Blade'
+          }
+        }
+      ],
+      disorders: [],
+      fighting_arts: [],
+      secret_fighting_arts: [],
+      hunt_survivor: [],
+      showdown_survivor: [],
+      knowledge_1: null,
+      knowledge_2: null,
+      neurosis: null,
+      philosophy: null,
+      tenet_knowledge: null
+    }
+
+    const mockReturns = vi
+      .fn()
+      .mockResolvedValue({ data: [survivorRow], error: null })
+    const mockOrder = vi.fn().mockReturnValue({ returns: mockReturns })
+    const mockEq = vi.fn().mockReturnValue({ order: mockOrder })
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEq })
+    mockSupabase.from.mockReturnValue({ select: mockSelect })
+
+    const prefetched = Promise.resolve(
+      new Map<string, string>([['author-1', 'prefetched.user']])
+    )
+
+    const result = await getSurvivors('set-1', prefetched)
+
+    expect(result![0].cursed_gear[0].author_username).toBe('prefetched.user')
+    expect(mockSupabase.rpc).not.toHaveBeenCalled()
   })
 })
 

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -267,7 +267,7 @@ export function AppSidebar({
   return (
     <Sidebar
       collapsible="icon"
-      className="top-(--header-height) !h-[calc(100svh-var(--header-height))]"
+      className="top-(--header-height) h-[calc(100svh-var(--header-height))]!"
       {...props}>
       <SidebarHeader>
         <SettlementSwitcher

--- a/components/custom/custom-ability-impairments-card.tsx
+++ b/components/custom/custom-ability-impairments-card.tsx
@@ -241,7 +241,7 @@ export function CustomAbilityImpairmentsCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Abilities & Impairments</span>
@@ -271,7 +271,7 @@ export function CustomAbilityImpairmentsCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-characters-card.tsx
+++ b/components/custom/custom-characters-card.tsx
@@ -243,7 +243,7 @@ export function CustomCharactersCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Characters</span>
@@ -278,7 +278,7 @@ export function CustomCharactersCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-collective-cognition-rewards-card.tsx
+++ b/components/custom/custom-collective-cognition-rewards-card.tsx
@@ -250,7 +250,7 @@ export function CustomCollectiveCognitionRewardsCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Collective Cognition Rewards</span>
@@ -280,15 +280,13 @@ export function CustomCollectiveCognitionRewardsCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
-                  <TableHead className="w-[80px] text-center">CC</TableHead>
+                  <TableHead className="w-20 text-center">CC</TableHead>
                   <TableHead>Name</TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-disorders-card.tsx
+++ b/components/custom/custom-disorders-card.tsx
@@ -234,7 +234,7 @@ export function CustomDisordersCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Disorders</span>
@@ -264,7 +264,7 @@ export function CustomDisordersCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-fighting-arts-card.tsx
+++ b/components/custom/custom-fighting-arts-card.tsx
@@ -240,7 +240,7 @@ export function CustomFightingArtsCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Fighting Arts</span>
@@ -270,7 +270,7 @@ export function CustomFightingArtsCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-gear-card.tsx
+++ b/components/custom/custom-gear-card.tsx
@@ -384,7 +384,7 @@ export function CustomGearCard({ local }: CustomGearCardProps): ReactElement {
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Gear</span>
@@ -414,7 +414,7 @@ export function CustomGearCard({ local }: CustomGearCardProps): ReactElement {
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
@@ -423,9 +423,7 @@ export function CustomGearCard({ local }: CustomGearCardProps): ReactElement {
                   <TableHead className="hidden sm:table-cell">
                     Location
                   </TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-innovations-card.tsx
+++ b/components/custom/custom-innovations-card.tsx
@@ -259,7 +259,7 @@ export function CustomInnovationsCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Innovations</span>
@@ -289,7 +289,7 @@ export function CustomInnovationsCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-knowledge-card.tsx
+++ b/components/custom/custom-knowledge-card.tsx
@@ -299,7 +299,7 @@ export function CustomKnowledgeCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Knowledge</span>
@@ -329,7 +329,7 @@ export function CustomKnowledgeCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
@@ -337,9 +337,7 @@ export function CustomKnowledgeCard({
                   <TableHead className="hidden sm:table-cell">
                     Philosophy
                   </TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-locations-card.tsx
+++ b/components/custom/custom-locations-card.tsx
@@ -234,7 +234,7 @@ export function CustomLocationsCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Locations</span>
@@ -264,7 +264,7 @@ export function CustomLocationsCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-milestones-card.tsx
+++ b/components/custom/custom-milestones-card.tsx
@@ -266,7 +266,7 @@ export function CustomMilestonesCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Milestones</span>
@@ -296,15 +296,13 @@ export function CustomMilestonesCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
                   <TableHead>Name</TableHead>
                   <TableHead className="hidden sm:table-cell">Event</TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-moods-card.tsx
+++ b/components/custom/custom-moods-card.tsx
@@ -232,7 +232,7 @@ export function CustomMoodsCard({ local }: CustomMoodsCardProps): ReactElement {
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Moods</span>
@@ -262,14 +262,12 @@ export function CustomMoodsCard({ local }: CustomMoodsCardProps): ReactElement {
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
                   <TableHead>Name</TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-neuroses-card.tsx
+++ b/components/custom/custom-neuroses-card.tsx
@@ -239,7 +239,7 @@ export function CustomNeurosesCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Neuroses</span>
@@ -269,14 +269,12 @@ export function CustomNeurosesCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
                   <TableHead>Name</TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-patterns-card.tsx
+++ b/components/custom/custom-patterns-card.tsx
@@ -322,7 +322,7 @@ export function CustomPatternsCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Patterns</span>
@@ -352,7 +352,7 @@ export function CustomPatternsCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-philosophies-card.tsx
+++ b/components/custom/custom-philosophies-card.tsx
@@ -363,7 +363,7 @@ export function CustomPhilosophiesCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Philosophies</span>
@@ -393,7 +393,7 @@ export function CustomPhilosophiesCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-principles-card.tsx
+++ b/components/custom/custom-principles-card.tsx
@@ -271,7 +271,7 @@ export function CustomPrinciplesCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Principles</span>
@@ -301,7 +301,7 @@ export function CustomPrinciplesCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
@@ -309,9 +309,7 @@ export function CustomPrinciplesCard({
                   <TableHead className="hidden sm:table-cell">
                     Options
                   </TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-resources-card.tsx
+++ b/components/custom/custom-resources-card.tsx
@@ -315,7 +315,7 @@ export function CustomResourcesCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Resources</span>
@@ -345,7 +345,7 @@ export function CustomResourcesCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-rules-sheet.tsx
+++ b/components/custom/custom-rules-sheet.tsx
@@ -271,7 +271,7 @@ function CustomRulesSheetBody({
     <SheetContent className="flex flex-col gap-0 p-0 sm:max-w-md">
       <SheetHeader className="gap-2 border-b border-border/60 px-6 pt-6 pb-4">
         <div className="flex items-start justify-between gap-3 pr-8">
-          <SheetTitle className="text-lg font-semibold leading-tight tracking-tight break-words">
+          <SheetTitle className="text-lg font-semibold leading-tight tracking-tight wrap-break-word">
             {title}
           </SheetTitle>
           <Badge
@@ -738,7 +738,7 @@ export function GearSheetBody({
     <SheetContent className="flex flex-col gap-0 p-0 sm:max-w-md">
       <SheetHeader className="gap-2 border-b border-border/60 px-4 pt-4 pb-3 sm:px-6 sm:pt-6 sm:pb-4">
         <div className="flex items-start justify-between gap-3 pr-8">
-          <SheetTitle className="text-base sm:text-lg font-semibold leading-tight tracking-tight break-words">
+          <SheetTitle className="text-base sm:text-lg font-semibold leading-tight tracking-tight wrap-break-word">
             {detail?.gear_name ?? gearName}
           </SheetTitle>
           {custom && (

--- a/components/custom/custom-secret-fighting-arts-card.tsx
+++ b/components/custom/custom-secret-fighting-arts-card.tsx
@@ -241,7 +241,7 @@ export function CustomSecretFightingArtsCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Secret Fighting Arts</span>
@@ -271,7 +271,7 @@ export function CustomSecretFightingArtsCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-seed-patterns-card.tsx
+++ b/components/custom/custom-seed-patterns-card.tsx
@@ -306,7 +306,7 @@ export function CustomSeedPatternsCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Seed Patterns</span>
@@ -336,7 +336,7 @@ export function CustomSeedPatternsCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/custom-strain-milestones-card.tsx
+++ b/components/custom/custom-strain-milestones-card.tsx
@@ -255,7 +255,7 @@ export function CustomStrainMilestonesCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Strain Milestones</span>
@@ -285,14 +285,12 @@ export function CustomStrainMilestonesCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
                   <TableHead>Name</TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-survivor-statuses-card.tsx
+++ b/components/custom/custom-survivor-statuses-card.tsx
@@ -243,7 +243,7 @@ export function CustomSurvivorStatusesCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Survivor Statuses</span>
@@ -273,14 +273,12 @@ export function CustomSurvivorStatusesCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
                   <TableHead>Name</TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-traits-card.tsx
+++ b/components/custom/custom-traits-card.tsx
@@ -234,7 +234,7 @@ export function CustomTraitsCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Traits</span>
@@ -264,14 +264,12 @@ export function CustomTraitsCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
                   <TableHead>Name</TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-wanderers-card.tsx
+++ b/components/custom/custom-wanderers-card.tsx
@@ -163,7 +163,7 @@ export function CustomWanderersCard({
 
   // List view
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Wanderers</span>
@@ -193,20 +193,18 @@ export function CustomWanderersCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
                   <TableHead>Name</TableHead>
-                  <TableHead className="hidden sm:table-cell w-[80px] text-center">
+                  <TableHead className="hidden sm:table-cell w-20 text-center">
                     Gender
                   </TableHead>
-                  <TableHead className="hidden sm:table-cell w-[60px] text-center">
+                  <TableHead className="hidden sm:table-cell w-15 text-center">
                     Arc
                   </TableHead>
-                  <TableHead className="w-[100px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/components/custom/custom-weapon-types-card.tsx
+++ b/components/custom/custom-weapon-types-card.tsx
@@ -257,7 +257,7 @@ export function CustomWeaponTypesCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Weapon Types</span>
@@ -287,7 +287,7 @@ export function CustomWeaponTypesCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[400px] overflow-y-auto rounded-md border">
+          <div className="max-h-100 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/custom/forms/wanderer-form.tsx
+++ b/components/custom/forms/wanderer-form.tsx
@@ -463,7 +463,7 @@ export function WandererForm({
 
   if (isLoadingEdit)
     return (
-      <Card className="p-0 border-1 gap-0">
+      <Card className="p-0 border gap-0">
         <CardContent className="p-8 text-center">
           <p className="text-sm text-muted-foreground">
             Peering into the darkness...
@@ -473,7 +473,7 @@ export function WandererForm({
     )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center gap-2">
           <Button
@@ -492,7 +492,7 @@ export function WandererForm({
       <CardContent className="p-4 space-y-4 max-h-[70vh] overflow-y-auto">
         {/* Row 1: Name, Gender, Hunt XP, Arc */}
         <div className="flex flex-wrap items-end gap-3 justify-between">
-          <div className="space-y-1 w-full sm:w-auto sm:min-w-[160px]">
+          <div className="space-y-1 w-full sm:w-auto sm:min-w-40">
             <Label htmlFor="wanderer-name">Name</Label>
             <Input
               ref={nameInputRef}
@@ -503,7 +503,7 @@ export function WandererForm({
               aria-label="Wanderer name"
             />
           </div>
-          <div className="space-y-1 w-[100px]">
+          <div className="space-y-1 w-25">
             <Label htmlFor="wanderer-gender">Gender</Label>
             <Select
               value={gender}

--- a/components/generic/list-card.tsx
+++ b/components/generic/list-card.tsx
@@ -262,7 +262,7 @@ export function ListCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           {icon}
@@ -283,7 +283,7 @@ export function ListCard({
 
       {/* Item List */}
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[240px]">
+        <div className="flex flex-col h-60">
           <div className="flex-1 overflow-y-auto">
             {items.length === 0 && !isAddingNew && (
               <p className="text-sm text-muted-foreground text-center py-4">

--- a/components/generic/multi-select-dropdown.tsx
+++ b/components/generic/multi-select-dropdown.tsx
@@ -65,7 +65,7 @@ export function MultiSelectDropdown({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-full justify-between h-auto min-h-[2.5rem] px-3">
+          className="w-full justify-between h-auto min-h-10 px-3">
           <span className="truncate">{triggerLabel}</span>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>

--- a/components/hunt/create-hunt/create-hunt-card.tsx
+++ b/components/hunt/create-hunt/create-hunt-card.tsx
@@ -546,9 +546,16 @@ export function CreateHuntCard({
             overtone_cards: aiDeck.overtone_cards
           },
           id: huntMonsterId,
-          traits: level.traits,
-          moods: level.moods,
-          survivor_statuses: level.survivor_statuses,
+          // The catalog rows pulled from the selected quarry level don't
+          // carry `author_username`. Use null placeholders here; the next
+          // `getHunt` round-trip resolves the real values from the
+          // settlement member-username map (E2.8).
+          traits: level.traits.map((t) => ({ ...t, author_username: null })),
+          moods: level.moods.map((m) => ({ ...m, author_username: null })),
+          survivor_statuses: level.survivor_statuses.map((s) => ({
+            ...s,
+            author_username: null
+          })),
           ...huntMonster
         }
       }
@@ -657,7 +664,7 @@ export function CreateHuntCard({
   ])
 
   return (
-    <Card className="w-full max-w-[400px]">
+    <Card className="w-full max-w-100">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <PawPrintIcon className="h-5 w-5" />
@@ -668,7 +675,7 @@ export function CreateHuntCard({
       <CardContent className="flex flex-col gap-2 w-full">
         {/* Hunt Quarry */}
         <div className="flex items-center justify-between">
-          <Label className="text-left whitespace-nowrap min-w-[90px]">
+          <Label className="text-left whitespace-nowrap min-w-22.5">
             Quarry
           </Label>
 
@@ -697,7 +704,7 @@ export function CreateHuntCard({
 
         {/* Monster Level */}
         <div className="flex items-center justify-between">
-          <Label className="text-left whitespace-nowrap min-w-[90px]">
+          <Label className="text-left whitespace-nowrap min-w-22.5">
             Level
           </Label>
 
@@ -722,7 +729,7 @@ export function CreateHuntCard({
         {/* Monster Version */}
         {showVersionSelector && (
           <div className="flex items-center justify-between">
-            <Label className="text-left whitespace-nowrap min-w-[90px]">
+            <Label className="text-left whitespace-nowrap min-w-22.5">
               Version
             </Label>
 

--- a/components/hunt/hunt-board/hunt-board-space.tsx
+++ b/components/hunt/hunt-board/hunt-board-space.tsx
@@ -54,7 +54,7 @@ export function HuntBoardSpace({
         isStarvation && 'border-red-500 bg-red-500/10',
         className
       )}>
-      <div className="text-[10px] sm:text-xs font-medium text-center break-words px-1 sm:px-2 leading-tight">
+      <div className="text-[10px] sm:text-xs font-medium text-center wrap-break-word px-1 sm:px-2 leading-tight">
         {label ?? index}
       </div>
     </div>

--- a/components/hunt/hunt-board/hunt-board.tsx
+++ b/components/hunt/hunt-board/hunt-board.tsx
@@ -146,7 +146,7 @@ export function HuntBoard({
             {spaces.map((space) => (
               <div
                 key={space.index}
-                className="relative w-[75px] sm:w-[85px] md:w-[90px] h-[75px] sm:h-[85px] md:h-[90px] flex-shrink-0 flex items-center justify-center">
+                className="relative w-18.75 sm:w-21.25 md:w-22.5 h-18.75 sm:h-21.25 md:h-22.5 shrink-0 flex items-center justify-center">
                 <HuntBoardSpace
                   onClick={() => handleSpaceClick(space.index)}
                   className={

--- a/components/hunt/hunt-card.tsx
+++ b/components/hunt/hunt-card.tsx
@@ -100,7 +100,7 @@ export function HuntCard({
     />
   ) : (
     <div className="lg:mt-10 flex flex-wrap items-start justify-center gap-4">
-      <div className="w-full max-w-[400px] order-2 md:order-1">
+      <div className="w-full max-w-100 order-2 md:order-1">
         <CreateHuntCard
           local={local}
           selectedSettlement={selectedSettlement}
@@ -110,7 +110,7 @@ export function HuntCard({
           userSettings={userSettings}
         />
       </div>
-      <div className="w-full max-w-[400px] order-1 md:order-2">
+      <div className="w-full max-w-100 order-1 md:order-2">
         <ListCard
           local={local}
           icon={<MapPinPlusIcon className="h-4 w-4" />}

--- a/components/hunt/hunt-monster/hunt-monster-card.tsx
+++ b/components/hunt/hunt-monster/hunt-monster-card.tsx
@@ -29,14 +29,7 @@ import {
   TRAIT_REMOVED_MESSAGE,
   TRAIT_UPDATED_MESSAGE
 } from '@/lib/messages'
-import {
-  HuntDetail,
-  HuntMonsterDetail,
-  HuntStateSetter,
-  MoodDetail,
-  SurvivorStatusDetail,
-  TraitDetail
-} from '@/lib/types'
+import { HuntDetail, HuntMonsterDetail, HuntStateSetter } from '@/lib/types'
 import { CheckIcon, SkullIcon } from 'lucide-react'
 import { ReactElement, useCallback, useMemo, useState } from 'react'
 
@@ -191,7 +184,7 @@ export function HuntMonsterCard({
    * @param traits New list of selected traits
    */
   const onTraitsChange = useCallback(
-    (traits: TraitDetail[]) => {
+    (traits: HuntMonsterDetail['traits']) => {
       const prevTraits = monster?.traits ?? []
       const successMsg =
         traits.length > prevTraits.length
@@ -208,7 +201,7 @@ export function HuntMonsterCard({
    * @param moods New list of selected moods
    */
   const onMoodsChange = useCallback(
-    (moods: MoodDetail[]) => {
+    (moods: HuntMonsterDetail['moods']) => {
       const prevMoods = monster?.moods ?? []
       const successMsg =
         moods.length > prevMoods.length
@@ -225,7 +218,7 @@ export function HuntMonsterCard({
    * @param survivor_statuses New list of selected survivor statuses
    */
   const onSurvivorStatusesChange = useCallback(
-    (survivor_statuses: SurvivorStatusDetail[]) => {
+    (survivor_statuses: HuntMonsterDetail['survivor_statuses']) => {
       const prevStatuses = monster?.survivor_statuses ?? []
       const successMsg =
         survivor_statuses.length > prevStatuses.length

--- a/components/hunt/hunt-monster/hunt-monster-card.tsx
+++ b/components/hunt/hunt-monster/hunt-monster-card.tsx
@@ -242,7 +242,7 @@ export function HuntMonsterCard({
 
   return (
     <Card className="w-full border-2 rounded-xl p-0 gap-0 transition-all duration-200 hover:shadow-lg">
-      <CardHeader className="flex p-3 border-b-1 bg-red-100/50 dark:bg-red-950/30">
+      <CardHeader className="flex p-3 border-b bg-red-100/50 dark:bg-red-950/30">
         <div className="flex items-center gap-3 w-full py-0 pb-0 my-0">
           <div className="h-12 w-12 bg-red-200 dark:bg-red-800 rounded-full flex items-center justify-center">
             <SkullIcon className="h-6 w-6 text-red-700 dark:text-red-300" />

--- a/components/menu/numeric-input.tsx
+++ b/components/menu/numeric-input.tsx
@@ -196,7 +196,7 @@ export function NumericInput({
 
         <DialogFooter className="flex justify-center w-full items-center sm:justify-center">
           <Button
-            className="w-[150px]"
+            className="w-37.5"
             name="save-value"
             id="save-value-button"
             onClick={handleSave}

--- a/components/menu/select-campaign-type.tsx
+++ b/components/menu/select-campaign-type.tsx
@@ -77,7 +77,7 @@ export function SelectCampaignType({
           role="combobox"
           aria-expanded={open}
           id={id}
-          className="w-full max-w-[250px] justify-between">
+          className="w-full max-w-62.5 justify-between">
           {value
             ? campaignOptions.find((campaign) => campaign.value === value)
                 ?.label
@@ -86,7 +86,7 @@ export function SelectCampaignType({
         </Button>
       </PopoverTrigger>
 
-      <PopoverContent className="w-full max-w-[250px] p-0">
+      <PopoverContent className="w-full max-w-62.5 p-0">
         <Command>
           <CommandInput placeholder="Seek your path..." />
           <CommandList>

--- a/components/menu/select-monster-node.tsx
+++ b/components/menu/select-monster-node.tsx
@@ -139,7 +139,7 @@ export function SelectMonsterNode({
             aria-expanded={open}
             id={id}
             disabled={disabled}
-            className="w-full justify-between h-auto min-h-[2.5rem] px-3">
+            className="w-full justify-between h-auto min-h-10 px-3">
             <span className="truncate">
               {propValue.length > 0
                 ? `${propValue.length} selected`
@@ -149,7 +149,7 @@ export function SelectMonsterNode({
           </Button>
         </PopoverTrigger>
 
-        <PopoverContent className="w-[250px] p-0">
+        <PopoverContent className="w-62.5 p-0">
           <Command>
             <CommandInput placeholder="Search monsters..." />
             <CommandList>

--- a/components/menu/select-philosophy.tsx
+++ b/components/menu/select-philosophy.tsx
@@ -83,7 +83,7 @@ export function SelectPhilosophy({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-[200px] justify-between"
+          className="w-50 justify-between"
           disabled={disabled}
           onKeyDown={handleKeyDown}>
           {propValue

--- a/components/menu/select-survivor-type.tsx
+++ b/components/menu/select-survivor-type.tsx
@@ -83,7 +83,7 @@ export function SelectSurvivorType({
           aria-expanded={open}
           disabled={disabled}
           id={id}
-          className="w-full max-w-[250px] justify-between">
+          className="w-full max-w-62.5 justify-between">
           {value
             ? survivorTypeOptions.find((option) => option.value === value)
                 ?.label
@@ -92,7 +92,7 @@ export function SelectSurvivorType({
         </Button>
       </PopoverTrigger>
 
-      <PopoverContent className="w-full max-w-[200px] p-0">
+      <PopoverContent className="w-full max-w-50 p-0">
         <Command>
           <CommandInput placeholder="Search survivor type..." />
           <CommandList>

--- a/components/menu/select-wanderers.tsx
+++ b/components/menu/select-wanderers.tsx
@@ -104,7 +104,7 @@ export function SelectWanderers({
   )
 
   return (
-    <div className="flex flex-col gap-2 w-full max-w-[250px]">
+    <div className="flex flex-col gap-2 w-full max-w-62.5">
       <Popover
         open={open}
         onOpenChange={(isOpen) => !disabled && setOpen(isOpen)}>
@@ -115,7 +115,7 @@ export function SelectWanderers({
             aria-expanded={open}
             id={id}
             disabled={disabled}
-            className="w-full justify-between h-auto min-h-[2.5rem] px-3">
+            className="w-full justify-between h-auto min-h-10 px-3">
             <span className="truncate">
               {propValue.length > 0
                 ? `${propValue.length} selected`
@@ -125,7 +125,7 @@ export function SelectWanderers({
           </Button>
         </PopoverTrigger>
 
-        <PopoverContent className="w-[250px] p-0">
+        <PopoverContent className="w-62.5 p-0">
           <Command>
             <CommandInput placeholder="Search wanderers..." />
             <CommandList>

--- a/components/menu/select-weapon-type.tsx
+++ b/components/menu/select-weapon-type.tsx
@@ -159,7 +159,7 @@ export function SelectWeaponType({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="justify-between text-sm min-w-[180px]"
+          className="justify-between text-sm min-w-45"
           disabled={disabled}>
           {value && weaponTypes[value]
             ? weaponTypes[value].weapon_type_name

--- a/components/monster/custom-monsters-card.tsx
+++ b/components/monster/custom-monsters-card.tsx
@@ -189,7 +189,7 @@ export function CustomMonstersCard({
 
   // Show monster list
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Monsters</span>
@@ -222,7 +222,7 @@ export function CustomMonstersCard({
             </div>
           </div>
         ) : (
-          <div className="max-h-[600px] overflow-y-auto rounded-md border">
+          <div className="max-h-150 overflow-y-auto rounded-md border">
             <Table>
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>

--- a/components/monster/monster-form.tsx
+++ b/components/monster/monster-form.tsx
@@ -611,7 +611,7 @@ export function MonsterForm({
     (mode === 'create' && Object.keys(levels).length === 0)
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span className="flex items-center gap-2">
@@ -1118,7 +1118,7 @@ export function MonsterForm({
               <div key={levelNum} className="border rounded-lg">
                 <button
                   type="button"
-                  className="w-full flex items-center justify-between p-3 hover:bg-accent/50 rounded-t-lg h-[44px]"
+                  className="w-full flex items-center justify-between p-3 hover:bg-accent/50 rounded-t-lg h-11"
                   onClick={() => toggleLevel(levelNum)}>
                   <span className="text-sm font-medium">
                     Level {levelNum}{' '}
@@ -1254,7 +1254,7 @@ export function MonsterForm({
                                         <NumericInput
                                           label="Life"
                                           value={sub.life ?? 0}
-                                          className="max-w-[75px]"
+                                          className="max-w-18.75"
                                           min={0}
                                           onChange={(v) =>
                                             updateSubMonster(levelNum, subIdx, {

--- a/components/monster/traits-moods/traits-moods.tsx
+++ b/components/monster/traits-moods/traits-moods.tsx
@@ -37,12 +37,23 @@ import { ReactElement, useEffect, useState } from 'react'
 interface TraitsMoodsProps {
   /** Monster data */
   monster: HuntMonsterDetail | ShowdownMonsterDetail
-  /** Called when the traits list should change */
-  onTraitsChange: (traits: TraitDetail[]) => void
-  /** Called when the moods list should change */
-  onMoodsChange: (moods: MoodDetail[]) => void
-  /** Called when the survivor statuses list should change */
-  onSurvivorStatusesChange: (statuses: SurvivorStatusDetail[]) => void
+  /**
+   * Called when the traits list should change. Each entry carries
+   * `author_username` so the monster detail's typed shape is preserved.
+   * The picker augments fresh catalog rows with `author_username: null`;
+   * the realtime refetch backfills the real value.
+   */
+  onTraitsChange: (
+    traits: (TraitDetail & { author_username: string | null })[]
+  ) => void
+  /** Called when the moods list should change. See `onTraitsChange`. */
+  onMoodsChange: (
+    moods: (MoodDetail & { author_username: string | null })[]
+  ) => void
+  /** Called when the survivor statuses list should change. See `onTraitsChange`. */
+  onSurvivorStatusesChange: (
+    statuses: (SurvivorStatusDetail & { author_username: string | null })[]
+  ) => void
 }
 
 /**
@@ -141,7 +152,10 @@ export function TraitsMoods({
                         key={trait.id}
                         value={trait.trait_name}
                         onSelect={() => {
-                          onTraitsChange([...monster.traits, trait])
+                          onTraitsChange([
+                            ...monster.traits,
+                            { ...trait, author_username: null }
+                          ])
                           setOpenTraitPicker(false)
                         }}>
                         {trait.trait_name}
@@ -218,7 +232,10 @@ export function TraitsMoods({
                         key={mood.id}
                         value={mood.mood_name}
                         onSelect={() => {
-                          onMoodsChange([...monster.moods, mood])
+                          onMoodsChange([
+                            ...monster.moods,
+                            { ...mood, author_username: null }
+                          ])
                           setOpenMoodPicker(false)
                         }}>
                         {mood.mood_name}
@@ -297,7 +314,7 @@ export function TraitsMoods({
                         onSelect={() => {
                           onSurvivorStatusesChange([
                             ...monster.survivor_statuses,
-                            status
+                            { ...status, author_username: null }
                           ])
                           setOpenStatusPicker(false)
                         }}>

--- a/components/monster/traits-moods/traits-moods.tsx
+++ b/components/monster/traits-moods/traits-moods.tsx
@@ -178,7 +178,7 @@ export function TraitsMoods({
         {monster.traits.map((trait) => (
           <div key={trait.id} className="flex items-center gap-2">
             <CustomRulesText
-              className="flex-grow"
+              className="grow"
               custom={trait.custom}
               label={trait.trait_name}
               title={trait.trait_name}
@@ -258,7 +258,7 @@ export function TraitsMoods({
         {monster.moods.map((mood) => (
           <div key={mood.id} className="flex items-center gap-2">
             <CustomRulesText
-              className="flex-grow"
+              className="grow"
               custom={mood.custom}
               label={mood.mood_name}
               title={mood.mood_name}
@@ -338,7 +338,7 @@ export function TraitsMoods({
         {monster.survivor_statuses.map((status) => (
           <div key={status.id} className="flex items-center gap-2">
             <CustomRulesText
-              className="flex-grow"
+              className="grow"
               custom={status.custom}
               label={status.survivor_status_name}
               title={status.survivor_status_name}

--- a/components/settlement-phase/settlement-phase-board/settlement-phase-board-space.tsx
+++ b/components/settlement-phase/settlement-phase-board/settlement-phase-board-space.tsx
@@ -49,7 +49,7 @@ export function SettlementPhaseBoardSpace({
         isOver && 'border-primary bg-primary/10',
         className
       )}>
-      <div className="text-[10px] sm:text-xs font-medium text-center break-words px-1 sm:px-2 leading-tight">
+      <div className="text-[10px] sm:text-xs font-medium text-center wrap-break-word px-1 sm:px-2 leading-tight">
         {label ?? index}
       </div>
       <div className="mt-auto flex flex-col items-center">{children}</div>

--- a/components/settlement-phase/settlement-phase-board/settlement-phase-board.tsx
+++ b/components/settlement-phase/settlement-phase-board/settlement-phase-board.tsx
@@ -67,7 +67,7 @@ export function SettlementPhaseBoard({
             {settlementPhaseSteps.map((space) => (
               <div
                 key={space.index}
-                className="relative w-[75px] sm:w-[85px] md:w-[90px] h-[75px] sm:h-[85px] md:h-[90px] flex-shrink-0 flex items-center justify-center">
+                className="relative w-18.75 sm:w-21.25 md:w-22.5 h-18.75 sm:h-21.25 md:h-22.5 shrink-0 flex items-center justify-center">
                 <SettlementPhaseBoardSpace
                   index={space.index}
                   label={space.step}

--- a/components/settlement/arc/collective-cognition-rewards-card.tsx
+++ b/components/settlement/arc/collective-cognition-rewards-card.tsx
@@ -426,7 +426,7 @@ export function CollectiveCognitionRewardsCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <BrainIcon className="h-4 w-4" />
@@ -510,7 +510,7 @@ export function CollectiveCognitionRewardsCard({
 
       {/* Rewards List */}
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[400px]">
+        <div className="flex flex-col h-100">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.collective_cognition_rewards ||
               selectedSettlement.collective_cognition_rewards.length === 0) &&

--- a/components/settlement/arc/collective-cognition-victories-card.tsx
+++ b/components/settlement/arc/collective-cognition-victories-card.tsx
@@ -194,7 +194,7 @@ export function CollectiveCognitionVictoriesCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <TrophyIcon className="h-4 w-4" /> Settlement Victories

--- a/components/settlement/arc/knowledge-item.tsx
+++ b/components/settlement/arc/knowledge-item.tsx
@@ -53,7 +53,7 @@ export const KnowledgeItem = memo(function KnowledgeItem({
       {/* Knowledge Name */}
       {knowledge.custom ? (
         <CustomKnowledgeRulesText
-          className="ml-1 flex-grow"
+          className="ml-1 grow"
           custom={knowledge.custom}
           knowledgeName={knowledge.knowledge_name}
           rules={knowledge.rules}
@@ -64,7 +64,7 @@ export const KnowledgeItem = memo(function KnowledgeItem({
         />
       ) : (
         <CustomRulesText
-          className="ml-1 flex-grow"
+          className="ml-1 grow"
           custom={customDetail?.custom ?? knowledge.custom}
           description={customDetail?.description}
           label={knowledge.knowledge_name}

--- a/components/settlement/arc/knowledges-card.tsx
+++ b/components/settlement/arc/knowledges-card.tsx
@@ -363,7 +363,7 @@ export function KnowledgesCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <GraduationCapIcon className="h-4 w-4" />
@@ -443,7 +443,7 @@ export function KnowledgesCard({
 
       {/* Knowledges List */}
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[200px]">
+        <div className="flex flex-col h-50">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.knowledges ||
               selectedSettlement.knowledges.length === 0) &&

--- a/components/settlement/arc/philosophies-card.tsx
+++ b/components/settlement/arc/philosophies-card.tsx
@@ -230,7 +230,7 @@ export function PhilosophiesCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <BrainCogIcon className="h-4 w-4" />
@@ -290,7 +290,7 @@ export function PhilosophiesCard({
 
       {/* Philosophies List */}
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[200px]">
+        <div className="flex flex-col h-50">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.philosophies ||
               selectedSettlement.philosophies.length === 0) &&

--- a/components/settlement/arc/philosophy-item.tsx
+++ b/components/settlement/arc/philosophy-item.tsx
@@ -53,7 +53,7 @@ export const PhilosophyItem = memo(function PhilosophyItem({
       {/* Philosophy Name */}
       {philosophy.custom ? (
         <CustomPhilosophyRulesText
-          className="ml-1 flex-grow"
+          className="ml-1 grow"
           custom={philosophy.custom}
           philosophyId={philosophy.philosophy_id}
           philosophyName={philosophy.philosophy_name}
@@ -63,7 +63,7 @@ export const PhilosophyItem = memo(function PhilosophyItem({
         />
       ) : (
         <CustomRulesText
-          className="ml-1 flex-grow"
+          className="ml-1 grow"
           custom={customDetail?.custom ?? philosophy.custom}
           description={customDetail?.description}
           label={philosophy.philosophy_name}

--- a/components/settlement/create-settlement-card.tsx
+++ b/components/settlement/create-settlement-card.tsx
@@ -194,7 +194,7 @@ export function CreateSettlementCard({
       })}
       className="space-y-6">
       <Form {...form}>
-        <Card className="max-w-[500px] mt-14 mx-auto">
+        <Card className="max-w-125 mt-14 mx-auto">
           <CardHeader className="px-6 pt-2 pb-0">
             <CardTitle className="flex items-center gap-2 text-base">
               <LanternMark className="h-5 w-5 text-amber-400/90" />
@@ -223,7 +223,7 @@ export function CreateSettlementCard({
                         onChange={(e) =>
                           form.setValue(field.name, e.target.value)
                         }
-                        className="w-full max-w-[250px]"
+                        className="w-full max-w-62.5"
                       />
                     </FormControl>
                   </div>
@@ -325,7 +325,7 @@ export function CreateSettlementCard({
         </Card>
 
         {/* Monster Node Selection */}
-        <Card className="max-w-[500px] mx-auto pt-0">
+        <Card className="max-w-125 mx-auto pt-0">
           <CardContent className="flex flex-col gap-6 w-full pt-6">
             {/* Quarry Nodes Row */}
             <div className="grid grid-cols-4 gap-2">
@@ -522,7 +522,7 @@ export function CreateSettlementCard({
         </Card>
       </Form>
 
-      <div className="flex items-center justify-center gap-2 max-w-[500px] mx-auto">
+      <div className="flex items-center justify-center gap-2 max-w-125 mx-auto">
         <Button
           type="button"
           variant="outline"

--- a/components/settlement/gear/gear-card.tsx
+++ b/components/settlement/gear/gear-card.tsx
@@ -296,7 +296,7 @@ export function GearCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <WrenchIcon className="h-4 w-4" />
@@ -344,7 +344,7 @@ export function GearCard({
       </CardHeader>
 
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[240px]">
+        <div className="flex flex-col h-60">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.gear ||
               selectedSettlement.gear.length === 0) &&

--- a/components/settlement/innovations/innovations-card.tsx
+++ b/components/settlement/innovations/innovations-card.tsx
@@ -358,7 +358,7 @@ export function InnovationsCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <LightbulbIcon className="h-4 w-4" />
@@ -441,7 +441,7 @@ export function InnovationsCard({
       </CardHeader>
 
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[400px]">
+        <div className="flex flex-col h-100">
           <div className="flex-1 overflow-y-auto">
             {sortedInnovations.map(({ item, originalIndex }) => {
               const detail = availableInnovations[item.innovation_id]
@@ -468,7 +468,7 @@ export function InnovationsCard({
                   key={`${item.id}-${originalIndex}`}
                   className="flex items-center gap-2">
                   <CustomRulesText
-                    className="ml-1 flex-grow pl-2"
+                    className="ml-1 grow pl-2"
                     custom={item.custom}
                     label={item.innovation_name}
                     sections={sections}

--- a/components/settlement/locations/locations-card.tsx
+++ b/components/settlement/locations/locations-card.tsx
@@ -404,7 +404,7 @@ export function LocationsCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <HouseIcon className="h-4 w-4" />
@@ -475,7 +475,7 @@ export function LocationsCard({
 
       {/* Locations List */}
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[400px]">
+        <div className="flex flex-col h-100">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.locations ||
               selectedSettlement.locations.length === 0) &&

--- a/components/settlement/milestones/milestones-card.tsx
+++ b/components/settlement/milestones/milestones-card.tsx
@@ -385,7 +385,7 @@ export function MilestonesCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <BadgeCheckIcon className="h-4 w-4" />
@@ -453,7 +453,7 @@ export function MilestonesCard({
 
       {/* Milestones List */}
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[200px]">
+        <div className="flex flex-col h-50">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.milestones ||
               selectedSettlement.milestones.length === 0) &&

--- a/components/settlement/nemeses/nemeses-card.tsx
+++ b/components/settlement/nemeses/nemeses-card.tsx
@@ -494,7 +494,7 @@ export function NemesesCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <SkullIcon className="h-4 w-4" />
@@ -539,7 +539,7 @@ export function NemesesCard({
 
       {/* Nemeses List */}
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[240px]">
+        <div className="flex flex-col h-60">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.nemeses ||
               selectedSettlement.nemeses.length === 0) &&

--- a/components/settlement/notes/notes-card.tsx
+++ b/components/settlement/notes/notes-card.tsx
@@ -92,7 +92,7 @@ export function NotesCard({
 
   return (
     <Card className="p-0 pb-1 border-0 h-full flex flex-col">
-      <CardHeader className="px-2 py-0 flex-shrink-0">
+      <CardHeader className="px-2 py-0 shrink-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <StickyNoteIcon className="h-4 w-4" /> Notes
         </CardTitle>
@@ -113,7 +113,7 @@ export function NotesCard({
             className="w-full flex-1 resize-none"
             style={{ minHeight: '200px' }}
           />
-          <div className="flex justify-end pt-1 flex-shrink-0">
+          <div className="flex justify-end pt-1 shrink-0">
             <Button
               type="button"
               size="sm"

--- a/components/settlement/patterns/patterns-card.tsx
+++ b/components/settlement/patterns/patterns-card.tsx
@@ -353,7 +353,7 @@ export function PatternsCard({
   }, [pendingCraftPattern, selectedSettlement?.innovations])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <ScissorsLineDashedIcon className="h-4 w-4" />
@@ -401,7 +401,7 @@ export function PatternsCard({
       </CardHeader>
 
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[200px]">
+        <div className="flex flex-col h-50">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.patterns ||
               selectedSettlement.patterns.length === 0) &&

--- a/components/settlement/principles/principles-card.tsx
+++ b/components/settlement/principles/principles-card.tsx
@@ -431,7 +431,7 @@ export function PrinciplesCard({
   }, [])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <StampIcon className="h-4 w-4" />
@@ -499,7 +499,7 @@ export function PrinciplesCard({
 
       {/* Principles List */}
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[200px]">
+        <div className="flex flex-col h-50">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.principles ||
               selectedSettlement.principles.length === 0) &&

--- a/components/settlement/quarries/quarries-card.tsx
+++ b/components/settlement/quarries/quarries-card.tsx
@@ -480,7 +480,7 @@ export function QuarriesCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <SwordIcon className="h-4 w-4" />
@@ -525,7 +525,7 @@ export function QuarriesCard({
 
       {/* Quarries List */}
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[240px]">
+        <div className="flex flex-col h-60">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.quarries ||
               selectedSettlement.quarries.length === 0) &&

--- a/components/settlement/resources/resource-overview-card.tsx
+++ b/components/settlement/resources/resource-overview-card.tsx
@@ -49,7 +49,7 @@ export function ResourceOverviewCard({
   }, [selectedSettlement?.resources])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-1">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <BeefIcon className="h-4 w-4" />

--- a/components/settlement/resources/resources-card.tsx
+++ b/components/settlement/resources/resources-card.tsx
@@ -378,7 +378,7 @@ export function ResourcesCard({
   )
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <BeefIcon className="h-4 w-4" />
@@ -426,7 +426,7 @@ export function ResourcesCard({
       </CardHeader>
 
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[240px]">
+        <div className="flex flex-col h-60">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.resources ||
               selectedSettlement.resources.length === 0) &&

--- a/components/settlement/seed-patterns/seed-patterns-card.tsx
+++ b/components/settlement/seed-patterns/seed-patterns-card.tsx
@@ -332,7 +332,7 @@ export function SeedPatternsCard({
   void search
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-2 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center gap-1 h-8">
           <BeanIcon className="h-4 w-4" />
@@ -380,7 +380,7 @@ export function SeedPatternsCard({
       </CardHeader>
 
       <CardContent className="p-1 pb-0">
-        <div className="flex flex-col h-[200px]">
+        <div className="flex flex-col h-50">
           <div className="flex-1 overflow-y-auto">
             {(!selectedSettlement?.seed_patterns ||
               selectedSettlement.seed_patterns.length === 0) &&

--- a/components/settlement/squires/squire-progression-cards.tsx
+++ b/components/settlement/squires/squire-progression-cards.tsx
@@ -32,7 +32,7 @@ const SquireProgressionCard = ({
   squire
 }: SquireProgressionCardProps): ReactElement => {
   return (
-    <Card className="p-0 border-1 gap-2">
+    <Card className="p-0 border gap-2">
       <CardHeader className="px-2 pt-1 pb-0">
         <CardTitle className="text-sm flex flex-row items-center gap-1 h-8">
           {squire.name}
@@ -51,7 +51,7 @@ const SquireProgressionCard = ({
                 <TableCell className="text-left font-bold">
                   {stat.name}
                 </TableCell>
-                <TableCell className="text-left py-2 whitespace-normal break-words">
+                <TableCell className="text-left py-2 whitespace-normal wrap-break-word">
                   {stat.value}
                 </TableCell>
               </TableRow>

--- a/components/settlement/survivors/columns.tsx
+++ b/components/settlement/survivors/columns.tsx
@@ -173,7 +173,7 @@ export const createColumns = ({
         </div>
       ),
       meta: {
-        className: 'hidden md:table-cell md:w-[100px] text-center'
+        className: 'hidden md:table-cell md:w-25 text-center'
       }
     },
     {
@@ -196,7 +196,7 @@ export const createColumns = ({
         </div>
       ),
       meta: {
-        className: 'w-[80px] md:w-[100px] text-center'
+        className: 'w-20 md:w-25 text-center'
       }
     },
     {
@@ -245,7 +245,7 @@ export const createColumns = ({
           </div>
         ),
       meta: {
-        className: 'w-[60px] md:w-[100px] text-center'
+        className: 'w-15 md:w-25 text-center'
       }
     },
     {
@@ -271,7 +271,7 @@ export const createColumns = ({
           </div>
         ),
       meta: {
-        className: 'w-[60px] md:w-[100px] text-center'
+        className: 'w-15 md:w-25 text-center'
       }
     }
   ]

--- a/components/settlement/survivors/data-table.tsx
+++ b/components/settlement/survivors/data-table.tsx
@@ -96,7 +96,7 @@ export function SurvivorDataTable<TData, TValue>({
   )
 
   return (
-    <div className="flex flex-col gap-2 flex-shrink-0">
+    <div className="flex flex-col gap-2 shrink-0">
       <div className="flex items-center pb-2 gap-2">
         <Input
           placeholder="Filter survivors..."
@@ -122,7 +122,7 @@ export function SurvivorDataTable<TData, TValue>({
         )}
       </div>
 
-      <div className="overflow-auto h-[300px] w-full rounded-md border">
+      <div className="overflow-auto h-75 w-full rounded-md border">
         <table className="min-w-full">
           <thead className="sticky top-0 bg-accent">
             {table.getHeaderGroups().map((headerGroup) => (

--- a/components/settlement/survivors/family-tree/family-tree-view.tsx
+++ b/components/settlement/survivors/family-tree/family-tree-view.tsx
@@ -394,7 +394,7 @@ export function FamilyTreeView({
             </TooltipTrigger>
             <TooltipContent>Zoom out</TooltipContent>
           </Tooltip>
-          <div className="px-2 text-xs tabular-nums text-muted-foreground min-w-[3rem] text-center">
+          <div className="px-2 text-xs tabular-nums text-muted-foreground min-w-12 text-center">
             {Math.round(scale * 100)}%
           </div>
           <Tooltip>
@@ -438,7 +438,7 @@ export function FamilyTreeView({
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerUp}
         className={cn(
-          'relative w-full overflow-hidden rounded-md border bg-gradient-to-br from-background via-background/95 to-background/85 select-none',
+          'relative w-full overflow-hidden rounded-md border bg-linear-to-br from-background via-background/95 to-background/85 select-none',
           isPanning ? 'cursor-grabbing' : 'cursor-grab'
         )}
         style={{

--- a/components/showdown/create-showdown/create-showdown-card.tsx
+++ b/components/showdown/create-showdown/create-showdown-card.tsx
@@ -541,9 +541,16 @@ export function CreateShowdownCard({
         showdownMonsters[showdownMonsterId] = {
           id: showdownMonsterId,
           ...showdownMonster,
-          traits: level.traits,
-          moods: level.moods,
-          survivor_statuses: level.survivor_statuses,
+          // The catalog rows pulled from the selected quarry level don't
+          // carry `author_username`. Use null placeholders here; the next
+          // `getShowdown` round-trip resolves the real values from the
+          // settlement member-username map (E2.8).
+          traits: level.traits.map((t) => ({ ...t, author_username: null })),
+          moods: level.moods.map((m) => ({ ...m, author_username: null })),
+          survivor_statuses: level.survivor_statuses.map((s) => ({
+            ...s,
+            author_username: null
+          })),
           ai_deck: {
             id: aiDeck.id,
             basic_cards: aiDeck.basic_cards,

--- a/components/showdown/create-showdown/create-showdown-card.tsx
+++ b/components/showdown/create-showdown/create-showdown-card.tsx
@@ -724,7 +724,7 @@ export function CreateShowdownCard({
   ])
 
   return (
-    <Card className="w-full max-w-[400px]">
+    <Card className="w-full max-w-100">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <SkullIcon className="h-5 w-5" />
@@ -735,7 +735,7 @@ export function CreateShowdownCard({
       <CardContent className="flex flex-col gap-2 w-full">
         {/* Monster Selection */}
         <div className="flex items-center justify-between">
-          <Label className="text-left whitespace-nowrap min-w-[90px]">
+          <Label className="text-left whitespace-nowrap min-w-22.5">
             Monster
           </Label>
           {availableMonsters.length > 0 ? (
@@ -765,7 +765,7 @@ export function CreateShowdownCard({
 
         {/* Monster Level */}
         <div className="flex items-center justify-between">
-          <Label className="text-left whitespace-nowrap min-w-[90px]">
+          <Label className="text-left whitespace-nowrap min-w-22.5">
             Level
           </Label>
           <Select
@@ -788,7 +788,7 @@ export function CreateShowdownCard({
         {/* Monster Version */}
         {showVersionSelector && (
           <div className="flex items-center justify-between">
-            <Label className="text-left whitespace-nowrap min-w-[90px]">
+            <Label className="text-left whitespace-nowrap min-w-22.5">
               Version
             </Label>
             <Select
@@ -832,7 +832,7 @@ export function CreateShowdownCard({
 
         {/* Starting Turn */}
         <div className="flex items-center justify-between">
-          <Label className="text-left whitespace-nowrap min-w-[90px]">
+          <Label className="text-left whitespace-nowrap min-w-22.5">
             First Turn
           </Label>
           <Select

--- a/components/showdown/showdown-monster/showdown-monster-card.tsx
+++ b/components/showdown/showdown-monster/showdown-monster-card.tsx
@@ -30,12 +30,9 @@ import {
   TRAIT_UPDATED_MESSAGE
 } from '@/lib/messages'
 import {
-  MoodDetail,
   ShowdownDetail,
   ShowdownMonsterDetail,
-  ShowdownStateSetter,
-  SurvivorStatusDetail,
-  TraitDetail
+  ShowdownStateSetter
 } from '@/lib/types'
 import { CheckIcon, SkullIcon } from 'lucide-react'
 import { ReactElement, useCallback, useMemo, useState } from 'react'
@@ -172,7 +169,7 @@ export function ShowdownMonsterCard({
   )
 
   const onTraitsChange = useCallback(
-    (traits: TraitDetail[]) => {
+    (traits: ShowdownMonsterDetail['traits']) => {
       const prevTraits = monster?.traits ?? []
       const successMsg =
         traits.length > prevTraits.length
@@ -184,7 +181,7 @@ export function ShowdownMonsterCard({
   )
 
   const onMoodsChange = useCallback(
-    (moods: MoodDetail[]) => {
+    (moods: ShowdownMonsterDetail['moods']) => {
       const prevMoods = monster?.moods ?? []
       const successMsg =
         moods.length > prevMoods.length
@@ -196,7 +193,7 @@ export function ShowdownMonsterCard({
   )
 
   const onSurvivorStatusesChange = useCallback(
-    (survivor_statuses: SurvivorStatusDetail[]) => {
+    (survivor_statuses: ShowdownMonsterDetail['survivor_statuses']) => {
       const prevStatuses = monster?.survivor_statuses ?? []
       const successMsg =
         survivor_statuses.length > prevStatuses.length

--- a/components/showdown/showdown-monster/showdown-monster-card.tsx
+++ b/components/showdown/showdown-monster/showdown-monster-card.tsx
@@ -214,7 +214,7 @@ export function ShowdownMonsterCard({
 
   return (
     <Card className="w-full border-2 rounded-xl p-0 gap-0 transition-all duration-200 hover:shadow-lg">
-      <CardHeader className="flex p-3 border-b-1 bg-red-100/50 dark:bg-red-950/30">
+      <CardHeader className="flex p-3 border-b bg-red-100/50 dark:bg-red-950/30">
         <div className="flex items-center gap-3 w-full py-0 pb-0 my-0">
           <div className="h-12 w-12 bg-red-200 dark:bg-red-800 rounded-full flex items-center justify-center">
             <SkullIcon className="h-6 w-6 text-red-700 dark:text-red-300" />
@@ -252,7 +252,7 @@ export function ShowdownMonsterCard({
       </CardHeader>
       <CardContent className="p-2 py-0 mt-0">
         <div className="flex flex-col lg:flex-row lg:gap-2">
-          <div className="flex flex-col flex-1 max-w-[400px]">
+          <div className="flex flex-col flex-1 max-w-100">
             <ShowdownMonsterBaseStats
               monster={monster}
               saveMonsterData={saveMonsterData}

--- a/components/showdown/showdown-turn/showdown-turn-card.tsx
+++ b/components/showdown/showdown-turn/showdown-turn-card.tsx
@@ -298,7 +298,7 @@ export function TurnCard({
   const isScout = selectedSurvivorRecord?.scout ?? false
 
   return (
-    <Card className="h-full min-w-[300px] border-2 rounded-xl pt-0 pb-2 gap-2 transition-all duration-200 hover:shadow-lg">
+    <Card className="h-full min-w-75 border-2 rounded-xl pt-0 pb-2 gap-2 transition-all duration-200 hover:shadow-lg">
       <CardHeader className="flex items-center gap-3 p-3 rounded-t-lg">
         <Avatar className="h-12 w-12 border-2 items-center justify-center">
           <AvatarFallback className="font-bold text-lg text-white bg-slate-500">
@@ -333,7 +333,7 @@ export function TurnCard({
                   <Toggle
                     size="sm"
                     variant="outline"
-                    className="data-[state=on]:bg-transparent data-[state=on]:*:[svg]:outline-green-500 data-[state=on]:*:[svg]:stroke-green-500 w-[120px]"
+                    className="data-[state=on]:bg-transparent data-[state=on]:*:[svg]:outline-green-500 data-[state=on]:*:[svg]:stroke-green-500 w-30"
                     pressed={selectedSurvivorRecord?.movement_used ?? false}
                     onPressedChange={(pressed) =>
                       selectedSurvivorRecord
@@ -350,7 +350,7 @@ export function TurnCard({
                   <Toggle
                     size="sm"
                     variant="outline"
-                    className="data-[state=on]:bg-transparent data-[state=on]:*:[svg]:outline-green-500 data-[state=on]:*:[svg]:stroke-green-500 w-[120px]"
+                    className="data-[state=on]:bg-transparent data-[state=on]:*:[svg]:outline-green-500 data-[state=on]:*:[svg]:stroke-green-500 w-30"
                     pressed={selectedSurvivorRecord?.activation_used ?? false}
                     onPressedChange={(pressed) =>
                       selectedSurvivorRecord
@@ -394,7 +394,7 @@ export function TurnCard({
                   <Toggle
                     size="sm"
                     variant="outline"
-                    className="data-[state=on]:bg-transparent data-[state=on]:*:[svg]:outline-green-500 data-[state=on]:*:[svg]:stroke-green-500 w-[120px]"
+                    className="data-[state=on]:bg-transparent data-[state=on]:*:[svg]:outline-green-500 data-[state=on]:*:[svg]:stroke-green-500 w-30"
                     pressed={currentMonster?.ai_card_drawn ?? false}
                     onPressedChange={(pressed) =>
                       updateMonsterAiCardDrawn(!!pressed)

--- a/components/survivor/abilities-and-impairments/abilities-and-impairments-card.tsx
+++ b/components/survivor/abilities-and-impairments/abilities-and-impairments-card.tsx
@@ -390,7 +390,7 @@ export function AbilitiesAndImpairmentsCard({
                 key={`${item.id}-${index}`}
                 className="flex items-center gap-2">
                 <CustomRulesText
-                  className="ml-1 flex-grow"
+                  className="ml-1 grow"
                   custom={item.custom}
                   label={item.ability_impairment_name}
                   title={item.ability_impairment_name}

--- a/components/survivor/bleeding/bleeding-card.tsx
+++ b/components/survivor/bleeding/bleeding-card.tsx
@@ -6,12 +6,12 @@ import { Label } from '@/components/ui/label'
 import { LocalStateType } from '@/contexts/local-context'
 import { useOptimisticMutation } from '@/hooks/use-optimistic-mutation'
 import { updateShowdownSurvivor } from '@/lib/dal/showdown-survivor'
+import { SURVIVOR_ATTRIBUTE_TOKEN_UPDATED_MESSAGE } from '@/lib/messages'
 import {
   ShowdownDetail,
   ShowdownStateSetter,
   SurvivorDetail
 } from '@/lib/types'
-import { SURVIVOR_ATTRIBUTE_TOKEN_UPDATED_MESSAGE } from '@/lib/messages'
 import { ReactElement } from 'react'
 
 /**

--- a/components/survivor/combat/arms-card.tsx
+++ b/components/survivor/combat/arms-card.tsx
@@ -129,7 +129,7 @@ export function ArmsCard({
               onChange={(value) =>
                 handleUpdate('arm_armor', value, setArmArmor, armArmor)
               }
-              className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 !bg-transparent border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 bg-transparent! border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
             />
           </div>
 

--- a/components/survivor/combat/body-card.tsx
+++ b/components/survivor/combat/body-card.tsx
@@ -127,7 +127,7 @@ export function BodyCard({
               onChange={(value) =>
                 handleUpdate('body_armor', value, setBodyArmor, bodyArmor)
               }
-              className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 !bg-transparent border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 bg-transparent! border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
             />
           </div>
 

--- a/components/survivor/combat/head-card.tsx
+++ b/components/survivor/combat/head-card.tsx
@@ -125,7 +125,7 @@ export function HeadCard({
               onChange={(value) =>
                 handleUpdate('head_armor', value, setHeadArmor, headArmor)
               }
-              className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 !bg-transparent border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 bg-transparent! border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
             />
           </div>
 

--- a/components/survivor/combat/legs-card.tsx
+++ b/components/survivor/combat/legs-card.tsx
@@ -125,7 +125,7 @@ export function LegsCard({
               onChange={(value) =>
                 handleUpdate('leg_armor', value, setLegArmor, legArmor)
               }
-              className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 !bg-transparent border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 bg-transparent! border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
             />
           </div>
 

--- a/components/survivor/combat/waist-card.tsx
+++ b/components/survivor/combat/waist-card.tsx
@@ -137,7 +137,7 @@ export function WaistCard({
               onChange={(value) =>
                 handleUpdate('waist_armor', value, setWaistArmor, waistArmor)
               }
-              className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 !bg-transparent border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 bg-transparent! border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
             />
           </div>
 

--- a/components/survivor/courage-understanding/courage-understanding-card.tsx
+++ b/components/survivor/courage-understanding/courage-understanding-card.tsx
@@ -159,7 +159,7 @@ export function CourageUnderstandingCard({
                     <Checkbox
                       key={j}
                       disabled
-                      className="!bg-white border border-gray-300 h-3 w-3"
+                      className="bg-white! border border-gray-300 h-3 w-3"
                     />
                   ))}
                   {i === 0 ? (
@@ -210,7 +210,7 @@ export function CourageUnderstandingCard({
                     <Checkbox
                       key={j}
                       disabled
-                      className="!bg-white border border-gray-300 h-3 w-3"
+                      className="bg-white! border border-gray-300 h-3 w-3"
                     />
                   ))}
                   {i === 0 ? (

--- a/components/survivor/create-survivor-form.tsx
+++ b/components/survivor/create-survivor-form.tsx
@@ -336,7 +336,7 @@ export function CreateSurvivorForm({
           render={({ field }) => (
             <FormItem>
               <div className="flex items-center justify-between gap-2">
-                <FormLabel className="text-left whitespace-nowrap min-w-[120px]">
+                <FormLabel className="text-left whitespace-nowrap min-w-30">
                   Parent 1
                 </FormLabel>
                 <div className="w-[75%]">
@@ -368,7 +368,7 @@ export function CreateSurvivorForm({
           render={({ field }) => (
             <FormItem>
               <div className="flex items-center justify-between gap-2">
-                <FormLabel className="text-left whitespace-nowrap min-w-[120px]">
+                <FormLabel className="text-left whitespace-nowrap min-w-30">
                   Parent 2
                 </FormLabel>
                 <div className="w-[75%]">
@@ -408,7 +408,7 @@ export function CreateSurvivorForm({
       })}
       className="py-3 space-y-6">
       <Form {...form}>
-        <Card className="max-w-[500px] mx-auto">
+        <Card className="max-w-125 mx-auto">
           <CardContent className="w-full space-y-2">
             {Object.keys(availableWanderers).length > 0 ? (
               <Tabs
@@ -428,7 +428,7 @@ export function CreateSurvivorForm({
                     render={({ field }) => (
                       <FormItem>
                         <div className="flex items-center justify-between">
-                          <FormLabel className="text-left whitespace-nowrap min-w-[120px]">
+                          <FormLabel className="text-left whitespace-nowrap min-w-30">
                             Name
                           </FormLabel>
                           <FormControl>
@@ -453,7 +453,7 @@ export function CreateSurvivorForm({
                     render={({ field }) => (
                       <FormItem>
                         <div className="flex items-center justify-between">
-                          <FormLabel className="text-left whitespace-nowrap min-w-[120px]">
+                          <FormLabel className="text-left whitespace-nowrap min-w-30">
                             Gender
                           </FormLabel>
                           <ToggleGroup
@@ -494,7 +494,7 @@ export function CreateSurvivorForm({
 
                 <TabsContent value="wanderer" className="space-y-2 mt-4">
                   <div className="flex items-center justify-between">
-                    <Label className="text-left whitespace-nowrap min-w-[120px]">
+                    <Label className="text-left whitespace-nowrap min-w-30">
                       Wanderer
                     </Label>
                     <SelectWanderer
@@ -526,7 +526,7 @@ export function CreateSurvivorForm({
                   render={({ field }) => (
                     <FormItem>
                       <div className="flex items-center justify-between">
-                        <FormLabel className="text-left whitespace-nowrap min-w-[120px]">
+                        <FormLabel className="text-left whitespace-nowrap min-w-30">
                           Name
                         </FormLabel>
                         <FormControl>
@@ -551,7 +551,7 @@ export function CreateSurvivorForm({
                   render={({ field }) => (
                     <FormItem>
                       <div className="flex items-center justify-between">
-                        <FormLabel className="text-left whitespace-nowrap min-w-[120px]">
+                        <FormLabel className="text-left whitespace-nowrap min-w-30">
                           Gender
                         </FormLabel>
                         <ToggleGroup

--- a/components/survivor/cursed-gear/cursed-gear-card.tsx
+++ b/components/survivor/cursed-gear/cursed-gear-card.tsx
@@ -37,7 +37,7 @@ import { PlusIcon } from 'lucide-react'
 import { ReactElement, useCallback, useMemo, useState } from 'react'
 
 /** Cursed gear item shape matching SurvivorDetail['cursed_gear'][0] */
-type CursedGearRow = { id: string; gear_name: string }
+type CursedGearRow = SurvivorDetail['cursed_gear'][number]
 
 /**
  * Cursed Gear Card Properties
@@ -134,7 +134,11 @@ export function CursedGearCard({
 
       const optimisticItem: CursedGearRow = {
         id: gearId,
-        gear_name: gearDetail.gear_name
+        gear_name: gearDetail.gear_name,
+        // Optimistic placeholders for the catalog flags. The realtime
+        // refetch backfills the true values from the catalog row.
+        custom: gearDetail.custom ?? false,
+        author_username: gearDetail.author_username ?? null
       }
       const oldCursedGear = [...cursedGear]
       const updatedCursedGear = [...cursedGear, optimisticItem]

--- a/components/survivor/cursed-gear/cursed-gear-item.tsx
+++ b/components/survivor/cursed-gear/cursed-gear-item.tsx
@@ -38,7 +38,7 @@ export const CursedGearItem = memo(function CursedGearItem({
   return (
     <div className="flex items-center gap-2 pl-2">
       <CustomGearRulesTrigger
-        className="ml-1 flex-grow truncate"
+        className="ml-1 grow truncate"
         custom={custom}
         gearId={gearId}
         gearName={gearName}

--- a/components/survivor/disorders/disorders-card.tsx
+++ b/components/survivor/disorders/disorders-card.tsx
@@ -342,7 +342,7 @@ export function DisordersCard({
               key={`${item.id}-${index}`}
               className="flex items-center gap-2">
               <CustomRulesText
-                className="ml-1 flex-grow"
+                className="ml-1 grow"
                 custom={item.custom}
                 label={item.disorder_name}
                 title={item.disorder_name}

--- a/components/survivor/fighting-arts/fighting-arts-card.tsx
+++ b/components/survivor/fighting-arts/fighting-arts-card.tsx
@@ -96,11 +96,11 @@ export function FightingArtsCard({
   }>({})
   const [availableSecretFightingArts, setAvailableSecretFightingArts] =
     useState<{ [key: string]: SecretFightingArtDetail }>({})
-  const [fightingArts, setFightingArts] = useState<FightingArtDetail[]>(
-    selectedSurvivor?.fighting_arts ?? []
-  )
+  const [fightingArts, setFightingArts] = useState<
+    SurvivorDetail['fighting_arts']
+  >(selectedSurvivor?.fighting_arts ?? [])
   const [secretFightingArts, setSecretFightingArts] = useState<
-    SecretFightingArtDetail[]
+    SurvivorDetail['secret_fighting_arts']
   >(selectedSurvivor?.secret_fighting_arts ?? [])
   const [addOpen, setAddOpen] = useState<boolean>(false)
   const [search, setSearch] = useState('')
@@ -195,11 +195,15 @@ export function FightingArtsCard({
       const detail = availableFightingArts[fightingArtId]
       if (!detail) return
 
-      const optimisticItem: FightingArtDetail = {
+      const optimisticItem: SurvivorDetail['fighting_arts'][number] = {
         id: fightingArtId,
         fighting_art_name: detail.fighting_art_name,
         custom: detail.custom,
-        rules: detail.rules ?? null
+        rules: detail.rules ?? null,
+        // The realtime refetch will backfill `author_username` from the
+        // settlement member-username map. Custom rows authored by the
+        // current user will resolve to their username after the round-trip.
+        author_username: null
       }
       const oldArts = [...fightingArts]
 
@@ -250,11 +254,13 @@ export function FightingArtsCard({
       const detail = availableSecretFightingArts[secretFightingArtId]
       if (!detail) return
 
-      const optimisticItem: SecretFightingArtDetail = {
+      const optimisticItem: SurvivorDetail['secret_fighting_arts'][number] = {
         id: secretFightingArtId,
         secret_fighting_art_name: detail.secret_fighting_art_name,
         custom: detail.custom,
-        rules: detail.rules ?? null
+        rules: detail.rules ?? null,
+        // See note in `handleAddRegular`.
+        author_username: null
       }
       const oldArts = [...secretFightingArts]
 
@@ -481,11 +487,13 @@ export function FightingArtsCard({
         toast.success(FIGHTING_ART_CREATED_MESSAGE())
 
         // Add to survivor immediately
-        const optimisticItem: FightingArtDetail = {
+        const optimisticItem: SurvivorDetail['fighting_arts'][number] = {
           id: newArt.id,
           fighting_art_name: newArt.fighting_art_name,
           custom: newArt.custom,
-          rules: newArt.rules ?? null
+          rules: newArt.rules ?? null,
+          // See note in `handleAddRegular`.
+          author_username: null
         }
         const oldArts = [...fightingArts]
 
@@ -559,11 +567,13 @@ export function FightingArtsCard({
         toast.success(SECRET_FIGHTING_ART_CREATED_MESSAGE())
 
         // Add to survivor immediately
-        const optimisticItem: SecretFightingArtDetail = {
+        const optimisticItem: SurvivorDetail['secret_fighting_arts'][number] = {
           id: newArt.id,
           secret_fighting_art_name: newArt.secret_fighting_art_name,
           custom: newArt.custom,
-          rules: newArt.rules ?? null
+          rules: newArt.rules ?? null,
+          // See note in `handleAddRegular`.
+          author_username: null
         }
         const oldArts = [...secretFightingArts]
 

--- a/components/survivor/fighting-arts/fighting-arts-card.tsx
+++ b/components/survivor/fighting-arts/fighting-arts-card.tsx
@@ -794,11 +794,11 @@ export function FightingArtsCard({
         <div className="flex flex-col">
           {fightingArts.map((art, index) => (
             <div key={`regular-${art.id}`} className="flex items-center gap-2">
-              <Badge variant="default" className="w-[60px] text-center">
+              <Badge variant="default" className="w-15 text-center">
                 Fighting
               </Badge>
               <CustomRulesText
-                className="flex-grow"
+                className="grow"
                 custom={art.custom}
                 label={art.fighting_art_name}
                 title={art.fighting_art_name}
@@ -818,11 +818,11 @@ export function FightingArtsCard({
 
           {secretFightingArts.map((art, index) => (
             <div key={`secret-${art.id}`} className="flex items-center gap-2">
-              <Badge variant="secondary" className="w-[60px] text-center">
+              <Badge variant="secondary" className="w-15 text-center">
                 Secret
               </Badge>
               <CustomRulesText
-                className="flex-grow"
+                className="grow"
                 custom={art.custom}
                 label={art.secret_fighting_art_name}
                 title={art.secret_fighting_art_name}

--- a/components/survivor/gear-grid/gear-grid-card.tsx
+++ b/components/survivor/gear-grid/gear-grid-card.tsx
@@ -468,7 +468,7 @@ export function GearGridCard({
   }, [persistSlotChange, viewingSlot])
 
   return (
-    <Card className="p-0 border-1 gap-0">
+    <Card className="p-0 border gap-0">
       <CardHeader className="px-4 pt-2 pb-0">
         <CardTitle className="text-md flex flex-row items-center justify-between gap-2">
           {/*
@@ -622,7 +622,7 @@ export function GearGridCard({
         <SheetContent className="flex flex-col gap-0 p-0 sm:max-w-md">
           <SheetHeader className="gap-2 border-b border-border/60 px-6 pt-6 pb-4">
             <div className="flex items-start justify-between gap-3 pr-8">
-              <SheetTitle className="text-lg font-semibold leading-tight tracking-tight break-words">
+              <SheetTitle className="text-lg font-semibold leading-tight tracking-tight wrap-break-word">
                 {activeBonus?.name ?? ''}
               </SheetTitle>
               {activeBonus?.isFallback && (

--- a/components/survivor/gear-grid/gear-grid-picker-dialog.tsx
+++ b/components/survivor/gear-grid/gear-grid-picker-dialog.tsx
@@ -122,7 +122,7 @@ export function GearGridPickerDialog({
     <div className="rounded-md border">
       <Command>
         <CommandInput placeholder="Search gear..." />
-        <CommandList className="max-h-[40vh] sm:max-h-[320px]">
+        <CommandList className="max-h-[40vh] sm:max-h-80">
           <CommandEmpty>No gear in settlement storage.</CommandEmpty>
           <CommandGroup>
             {sortedCandidates.map((candidate) => {
@@ -227,7 +227,7 @@ export function GearGridPickerDialog({
               Cap the preview cell so it doesn't take more than ~30% of the
               drawer height on small screens, leaving room for the list.
             */}
-            <div className="mx-auto w-full max-w-[200px]">{previewPane}</div>
+            <div className="mx-auto w-full max-w-50">{previewPane}</div>
           </div>
 
           <DrawerFooter className="flex flex-row justify-end gap-2">

--- a/components/survivor/hunt-xp/hunt-xp-card.tsx
+++ b/components/survivor/hunt-xp/hunt-xp-card.tsx
@@ -201,7 +201,7 @@ export function HuntXPCard({
                 <Label className="font-bold text-left text-sm self-start lg:self-center">
                   Hunt XP
                 </Label>
-                <div className="grid grid-cols-[repeat(16,minmax(0,1fr))] place-items-center gap-0.5 w-full lg:flex lg:w-auto lg:items-center lg:gap-1">
+                <div className="grid grid-cols-16 place-items-center gap-0.5 w-full lg:flex lg:w-auto lg:items-center lg:gap-1">
                   {Array.from({ length: 16 }, (_, i) => {
                     const checked = (huntXP ?? 0) > i
 
@@ -245,7 +245,7 @@ export function HuntXPCard({
                 <Checkbox
                   key={j}
                   disabled
-                  className="!bg-white border border-gray-300 h-3 w-3"
+                  className="bg-white! border border-gray-300 h-3 w-3"
                 />
               ))}
               <span className="text-xs text-muted-foreground">

--- a/components/survivor/knowledge/knowledge-card.tsx
+++ b/components/survivor/knowledge/knowledge-card.tsx
@@ -865,10 +865,10 @@ export function KnowledgeCard({
       <CardContent className="p-0 flex flex-col">
         {/* Knowledge 1 */}
         <div className="flex flex-col lg:flex-row lg:items-start gap-2">
-          <div className="flex-grow flex flex-col gap-1">
+          <div className="grow flex flex-col gap-1">
             <div className="flex flex-col gap-1">
               <div className="flex flex-row items-center gap-1">
-                <div className="flex-grow">
+                <div className="grow">
                   <KnowledgeSelect
                     knowledges={selectedSettlement?.knowledges ?? []}
                     value={knowledge1?.id}
@@ -987,10 +987,10 @@ export function KnowledgeCard({
 
         {/* Knowledge 2 */}
         <div className="flex flex-col lg:flex-row lg:items-start gap-2">
-          <div className="flex-grow flex flex-col gap-1">
+          <div className="grow flex flex-col gap-1">
             <div className="flex flex-col gap-1">
               <div className="flex flex-row items-center gap-1">
-                <div className="flex-grow">
+                <div className="grow">
                   <KnowledgeSelect
                     knowledges={selectedSettlement?.knowledges ?? []}
                     value={knowledge2?.id}

--- a/components/survivor/knowledge/knowledge-card.tsx
+++ b/components/survivor/knowledge/knowledge-card.tsx
@@ -373,11 +373,13 @@ export function KnowledgeCard({
                 ? {
                     id: knowledgeId,
                     knowledge_name: knowledgeDetail.knowledge_name,
+                    custom: knowledgeDetail.custom,
                     rules: knowledgeDetail.rules,
                     observation_conditions:
                       knowledgeDetail.observation_conditions,
                     observation_rank_up_milestone:
-                      knowledgeDetail.observation_rank_up_milestone
+                      knowledgeDetail.observation_rank_up_milestone,
+                    author_username: knowledgeDetail.author_username
                   }
                 : null,
               knowledge_1_observation_rank: 0,
@@ -626,11 +628,13 @@ export function KnowledgeCard({
                 ? {
                     id: knowledgeId,
                     knowledge_name: knowledgeDetail.knowledge_name,
+                    custom: knowledgeDetail.custom,
                     rules: knowledgeDetail.rules,
                     observation_conditions:
                       knowledgeDetail.observation_conditions,
                     observation_rank_up_milestone:
-                      knowledgeDetail.observation_rank_up_milestone
+                      knowledgeDetail.observation_rank_up_milestone,
+                    author_username: knowledgeDetail.author_username
                   }
                 : null,
               knowledge_2_observation_rank: 0,

--- a/components/survivor/parent-selection/parent-selection-drawer.tsx
+++ b/components/survivor/parent-selection/parent-selection-drawer.tsx
@@ -192,7 +192,7 @@ export function ParentSelectionDrawer({
         </DrawerHeader>
 
         <div className="px-4 pb-4 h-[60vh] flex gap-4">
-          <div className="flex flex-wrap gap-2 overflow-y-auto min-w-[200px]">
+          <div className="flex flex-wrap gap-2 overflow-y-auto min-w-50">
             {survivors.map((survivor) => (
               <SurvivorSelectionCard
                 key={survivor.id}
@@ -207,7 +207,7 @@ export function ParentSelectionDrawer({
           </div>
 
           {!isMobile && (
-            <div className="w-[450px]">
+            <div className="w-112.5">
               <SurvivorDetailsPanel
                 local={local}
                 survivor={hoveredSurvivor ?? lastHoveredSurvivor}

--- a/components/survivor/philosophy/philosophy-card.tsx
+++ b/components/survivor/philosophy/philosophy-card.tsx
@@ -243,9 +243,11 @@ export function PhilosophyCard({
         ? {
             id: philosophyId,
             philosophy_name: philosophyDetail.philosophy_name,
+            custom: philosophyDetail.custom,
             hunt_xp_milestones: philosophyDetail.hunt_xp_milestones,
             tenet_knowledge_id: philosophyDetail.tenet_knowledge_id,
-            tier: philosophyDetail.tier
+            tier: philosophyDetail.tier,
+            author_username: philosophyDetail.author_username
           }
         : null
 
@@ -260,7 +262,11 @@ export function PhilosophyCard({
         ? {
             id: matchedNeurosis.id,
             neurosis_name: matchedNeurosis.neurosis_name,
-            rules: null
+            custom: matchedNeurosis.custom,
+            rules: null,
+            // Neuroses are a global catalog (getNeuroses); author_username is
+            // not surfaced for them. Keep it null for type compatibility.
+            author_username: null
           }
         : null
 
@@ -277,10 +283,12 @@ export function PhilosophyCard({
         ? {
             id: matchedKnowledge.knowledge_id,
             knowledge_name: matchedKnowledge.knowledge_name,
+            custom: matchedKnowledge.custom,
             rules: matchedKnowledge.rules,
             observation_conditions: matchedKnowledge.observation_conditions,
             observation_rank_up_milestone:
-              matchedKnowledge.observation_rank_up_milestone
+              matchedKnowledge.observation_rank_up_milestone,
+            author_username: matchedKnowledge.author_username
           }
         : null
       const newTenetKnowledgeState = {
@@ -394,7 +402,11 @@ export function PhilosophyCard({
         ? {
             id: neurosisId,
             neurosis_name: neurosisDetail.neurosis_name,
-            rules: null
+            custom: neurosisDetail.custom,
+            rules: null,
+            // Neuroses are a global catalog (getNeuroses); author_username is
+            // not surfaced for them. Keep it null for type compatibility.
+            author_username: null
           }
         : null
 
@@ -567,11 +579,13 @@ export function PhilosophyCard({
                 ? {
                     id: knowledgeId,
                     knowledge_name: knowledgeDetail.knowledge_name,
+                    custom: knowledgeDetail.custom,
                     rules: knowledgeDetail.rules,
                     observation_conditions:
                       knowledgeDetail.observation_conditions,
                     observation_rank_up_milestone:
-                      knowledgeDetail.observation_rank_up_milestone
+                      knowledgeDetail.observation_rank_up_milestone,
+                    author_username: knowledgeDetail.author_username
                   }
                 : null,
               tenet_knowledge_observation_rank: 0,

--- a/components/survivor/philosophy/philosophy-card.tsx
+++ b/components/survivor/philosophy/philosophy-card.tsx
@@ -842,7 +842,7 @@ export function PhilosophyCard({
         {/* Neurosis */}
         <div className="flex flex-col gap-1">
           <div className="flex flex-row items-center gap-1">
-            <div className="flex-grow">
+            <div className="grow">
               <SelectNeurosis
                 selectedSettlement={selectedSettlement}
                 value={neurosis?.id ?? ''}
@@ -867,9 +867,9 @@ export function PhilosophyCard({
 
         {/* Tenet Knowledge and Ranks */}
         <div className="flex flex-col lg:flex-row lg:items-start gap-2 mt-1">
-          <div className="flex-grow flex flex-col gap-1">
+          <div className="grow flex flex-col gap-1">
             <div className="flex flex-row items-center gap-1">
-              <div className="flex-grow">
+              <div className="grow">
                 <TenetKnowledgeSelect
                   knowledges={selectedSettlement?.knowledges ?? []}
                   value={tenetKnowledge?.id}

--- a/components/survivor/philosophy/philosophy-card.tsx
+++ b/components/survivor/philosophy/philosophy-card.tsx
@@ -264,8 +264,9 @@ export function PhilosophyCard({
             neurosis_name: matchedNeurosis.neurosis_name,
             custom: matchedNeurosis.custom,
             rules: null,
-            // Neuroses are a global catalog (getNeuroses); author_username is
-            // not surfaced for them. Keep it null for type compatibility.
+            // This optimistic cascade only has the picker/catalog neurosis
+            // data, so author_username remains null until the next refetch
+            // hydrates the full survivor neurosis detail.
             author_username: null
           }
         : null
@@ -404,8 +405,8 @@ export function PhilosophyCard({
             neurosis_name: neurosisDetail.neurosis_name,
             custom: neurosisDetail.custom,
             rules: null,
-            // Neuroses are a global catalog (getNeuroses); author_username is
-            // not surfaced for them. Keep it null for type compatibility.
+            // This optimistic local neurosis detail does not carry authorship;
+            // keep author_username null here and let the next refetch backfill it.
             author_username: null
           }
         : null

--- a/components/survivor/sanity/sanity-card.tsx
+++ b/components/survivor/sanity/sanity-card.tsx
@@ -365,7 +365,7 @@ export function SanityCard({
                 value={insanity}
                 min={0}
                 onChange={(value) => updateInsanity(value)}
-                className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 !bg-transparent border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                className="absolute top-[50%] left-7 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12 text-xl sm:text-xl md:text-xl text-center p-0 bg-transparent! border-none no-spinners focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
               />
             </div>
             {displayText && <Label className="text-xs">Insanity</Label>}

--- a/components/survivor/scout-selection/scout-selection-card.tsx
+++ b/components/survivor/scout-selection/scout-selection-card.tsx
@@ -40,7 +40,7 @@ export function ScoutSelectionCard({
   survivor
 }: ScoutSelectionCardProps): ReactElement {
   return (
-    <div className="w-[200px] h-[280px] border-4 rounded-xl border-border/20 hover:border-border/50 transition-all duration-200">
+    <div className="w-50 h-70 border-4 rounded-xl border-border/20 hover:border-border/50 transition-all duration-200">
       <Button
         variant={isCurrentlySelected ? 'default' : 'outline'}
         className="justify-start flex flex-col p-0 w-full h-full items-stretch relative overflow-hidden"
@@ -51,7 +51,7 @@ export function ScoutSelectionCard({
         {/* Header with Avatar and Name */}
         <div className="bg-muted/20 p-3 border-b border-border/20">
           <div className="flex items-center gap-3">
-            <Avatar className="h-10 w-10 border-1 border-background items-center justify-center">
+            <Avatar className="h-10 w-10 border border-background items-center justify-center">
               <AvatarFallback className="font-bold text-lg">
                 {survivor.survivor_name
                   ? survivor.survivor_name

--- a/components/survivor/scout-selection/scout-selection-drawer.tsx
+++ b/components/survivor/scout-selection/scout-selection-drawer.tsx
@@ -136,7 +136,7 @@ export function ScoutSelectionDrawer({
         </DrawerHeader>
 
         <div className="px-4 pb-4 h-[60vh] flex gap-4">
-          <div className="flex flex-wrap gap-2 overflow-y-auto min-w-[200px]">
+          <div className="flex flex-wrap gap-2 overflow-y-auto min-w-50">
             {survivors.map((survivor) => (
               <ScoutSelectionCard
                 key={survivor.id}
@@ -150,7 +150,7 @@ export function ScoutSelectionDrawer({
           </div>
 
           {!isMobile && (
-            <div className="w-[450px]">
+            <div className="w-112.5">
               <SurvivorDetailsPanel
                 local={local}
                 survivor={hoveredSurvivor ?? lastHoveredSurvivor}

--- a/components/survivor/survivor-card.tsx
+++ b/components/survivor/survivor-card.tsx
@@ -101,7 +101,7 @@ export function SurvivorCard({
       <CardContent className="px-2">
         <div className="flex flex-col xl:flex-row xl:flex-wrap gap-2 w-full">
           {/* First Column - Essential Stats */}
-          <div className="flex flex-col flex-1 gap-1 xl:min-w-[450px]">
+          <div className="flex flex-col flex-1 gap-1 xl:min-w-112.5">
             <StatusCard
               local={local}
               selectedSurvivor={selectedSurvivor}
@@ -168,7 +168,7 @@ export function SurvivorCard({
           </div>
 
           {/* Second Column - Combat */}
-          <div className="flex flex-col flex-1 gap-1 xl:min-w-[450px]">
+          <div className="flex flex-col flex-1 gap-1 xl:min-w-112.5">
             <AttributeCard
               local={local}
               mode={mode}
@@ -235,7 +235,7 @@ export function SurvivorCard({
           {/* Third Column - ARC */}
           {selectedSettlement?.survivor_type ===
             DatabaseSurvivorType[SurvivorType.ARC] && (
-            <div className="flex flex-col flex-1 gap-1 xl:min-w-[450px] order-3">
+            <div className="flex flex-col flex-1 gap-1 xl:min-w-112.5 order-3">
               <PhilosophyCard
                 local={local}
                 selectedSettlement={selectedSettlement}
@@ -254,7 +254,7 @@ export function SurvivorCard({
           )}
 
           {/* Fourth Column - Gear Grid */}
-          <div className="flex flex-col flex-1 gap-1 xl:min-w-[320px] xl:max-w-[420px]">
+          <div className="flex flex-col flex-1 gap-1 xl:min-w-[320px] xl:max-w-105">
             <GearGridCard
               local={local}
               selectedSettlement={selectedSettlement}

--- a/components/survivor/survivor-details-panel.tsx
+++ b/components/survivor/survivor-details-panel.tsx
@@ -35,7 +35,7 @@ export function SurvivorDetailsPanel({
   survivors
 }: SurvivorDetailsPanelProps): ReactElement {
   return survivor === null ? (
-    <div className="w-[450px] h-full flex items-center justify-center text-muted-foreground">
+    <div className="w-112.5 h-full flex items-center justify-center text-muted-foreground">
       <div className="text-center">
         {survivors && survivors.length > 0 ? (
           <>
@@ -52,7 +52,7 @@ export function SurvivorDetailsPanel({
       </div>
     </div>
   ) : (
-    <div className="w-[450px] h-full bg-gradient-to-br from-background to-background/95 border-2 border-border rounded-lg">
+    <div className="w-112.5 h-full bg-linear-to-br from-background to-background/95 border-2 border-border rounded-lg">
       {/* Header */}
       <div className="bg-muted/30 border-b border-border/30 p-4">
         <div className="flex items-center gap-4">
@@ -126,7 +126,7 @@ export function SurvivorDetailsPanel({
                 {survivor.secret_fighting_arts.map((art, index) => (
                   <div
                     key={index}
-                    className="text-xs bg-gradient-to-r from-yellow-100 to-yellow-50 dark:from-yellow-900/30 dark:to-yellow-800/20 border border-yellow-200/50 dark:border-yellow-700/30 rounded px-2 py-1">
+                    className="text-xs bg-linear-to-r from-yellow-100 to-yellow-50 dark:from-yellow-900/30 dark:to-yellow-800/20 border border-yellow-200/50 dark:border-yellow-700/30 rounded px-2 py-1">
                     {art.secret_fighting_art_name}
                   </div>
                 ))}
@@ -234,7 +234,7 @@ export function SurvivorDetailsPanel({
                 {survivor.cursed_gear.map((gear, index) => (
                   <div
                     key={index}
-                    className="text-xs bg-gradient-to-r from-purple-100 to-purple-50 dark:from-purple-900/30 dark:to-purple-800/20 border border-purple-200/50 dark:border-purple-700/30 rounded px-2 py-1">
+                    className="text-xs bg-linear-to-r from-purple-100 to-purple-50 dark:from-purple-900/30 dark:to-purple-800/20 border border-purple-200/50 dark:border-purple-700/30 rounded px-2 py-1">
                     {gear.gear_name}
                   </div>
                 ))}
@@ -252,7 +252,7 @@ export function SurvivorDetailsPanel({
                 {survivor.next_departure.map((departure, index) => (
                   <div
                     key={index}
-                    className="text-xs bg-gradient-to-r from-teal-100 to-teal-50 dark:from-teal-900/30 dark:to-teal-800/20 border border-teal-200/50 dark:border-teal-700/30 rounded px-2 py-1">
+                    className="text-xs bg-linear-to-r from-teal-100 to-teal-50 dark:from-teal-900/30 dark:to-teal-800/20 border border-teal-200/50 dark:border-teal-700/30 rounded px-2 py-1">
                     {departure}
                   </div>
                 ))}

--- a/components/survivor/survivor-selection/survivor-selection-card.tsx
+++ b/components/survivor/survivor-selection/survivor-selection-card.tsx
@@ -42,7 +42,7 @@ export function SurvivorSelectionCard({
   tempSelection
 }: SurvivorSelectionCardProps): ReactElement {
   return (
-    <div className="w-[200px] h-[280px] border-4 rounded-xl border-border/20 hover:border-border/50 transition-all duration-200">
+    <div className="w-50 h-70 border-4 rounded-xl border-border/20 hover:border-border/50 transition-all duration-200">
       <Button
         variant={tempSelection.includes(survivor.id) ? 'default' : 'outline'}
         className="justify-start flex flex-col p-0 w-full h-full items-stretch relative overflow-hidden"
@@ -53,7 +53,7 @@ export function SurvivorSelectionCard({
         {/* Header with Avatar and Name */}
         <div className="bg-muted/20 p-3 border-b border-border/20">
           <div className="flex items-center gap-3">
-            <Avatar className="h-10 w-10 border-1 border-background items-center justify-center">
+            <Avatar className="h-10 w-10 border border-background items-center justify-center">
               <AvatarFallback className="font-bold text-lg">
                 {survivor.survivor_name
                   ? survivor.survivor_name

--- a/components/survivor/survivor-selection/survivor-selection-drawer.tsx
+++ b/components/survivor/survivor-selection/survivor-selection-drawer.tsx
@@ -139,7 +139,7 @@ export function SurvivorSelectionDrawer({
         </DrawerHeader>
 
         <div className="px-4 pb-4 h-[60vh] flex gap-4">
-          <div className="flex flex-wrap gap-2 overflow-y-auto min-w-[200px]">
+          <div className="flex flex-wrap gap-2 overflow-y-auto min-w-50">
             {survivors.map((survivor) => (
               <SurvivorSelectionCard
                 key={survivor.id}
@@ -158,7 +158,7 @@ export function SurvivorSelectionDrawer({
           </div>
 
           {!isMobile && (
-            <div className="w-[450px]">
+            <div className="w-112.5">
               <SurvivorDetailsPanel
                 local={local}
                 survivor={hoveredSurvivor ?? lastHoveredSurvivor}

--- a/components/survivor/weapon-proficiency/weapon-proficiency-card.tsx
+++ b/components/survivor/weapon-proficiency/weapon-proficiency-card.tsx
@@ -212,7 +212,7 @@ export function WeaponProficiencyCard({
                     <Checkbox
                       key={j}
                       disabled
-                      className="!bg-white border border-gray-300 h-3 w-3"
+                      className="bg-white! border border-gray-300 h-3 w-3"
                     />
                   ))}
                   {i === 0 ? (

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -14,7 +14,7 @@ function BreadcrumbList({ className, ...props }: ComponentProps<'ol'>) {
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        'text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5',
+        'text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm wrap-break-word sm:gap-2.5',
         className
       )}
       {...props}

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -61,7 +61,7 @@ function DrawerContent({
           className
         )}
         {...props}>
-        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div className="bg-muted mx-auto mt-4 hidden h-2 w-25 shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/lib/dal/hunt-monster.ts
+++ b/lib/dal/hunt-monster.ts
@@ -1,4 +1,5 @@
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { createClient } from '@/lib/supabase/client'
 import {
   HuntMonsterDetail,
@@ -8,15 +9,52 @@ import {
 } from '@/lib/types'
 
 /**
+ * Catalog Row With Authorship
+ *
+ * Raw shape of a `trait` / `mood` / `survivor_status` embed coming back from
+ * Supabase before `author_username` is resolved. The `user_id` is dropped on
+ * the way out so it never leaks into `HuntMonsterDetail`.
+ */
+type WithAuthorship<T> = T & { user_id: string | null }
+
+/**
+ * Resolve Author Username
+ *
+ * Returns the catalog author's username for custom rows, or `null` for
+ * built-ins / rows authored by users no longer connected to the settlement.
+ *
+ * @param row Catalog Row With `custom` + `user_id`
+ * @param memberUsernames Settlement Member Username Map
+ * @returns Author Username Or Null
+ */
+function resolveAuthorUsername(
+  row: { custom: boolean; user_id: string | null } | null | undefined,
+  memberUsernames: Map<string, string>
+): string | null {
+  if (!row || !row.custom || !row.user_id) return null
+  return memberUsernames.get(row.user_id) ?? null
+}
+
+/**
  * Get Hunt Monsters
  *
  * Retrieves all monsters assigned to a hunt.
  *
+ * Each embedded `trait` / `mood` / `survivor_status` row carries
+ * `author_username` — `null` for built-ins, and the catalog author's
+ * username for custom rows so the UI can render the "By @username" chip
+ * (E2.8; see `local/sharing-architecture.md` §7.4 / §10 Phase 2 item 2.6).
+ *
  * @param huntId Hunt ID
+ * @param prefetchedMemberUsernames Optional in-flight (or resolved)
+ *   member-username map. When called from {@link getHunt} (which fetches
+ *   the map once for the whole settlement load), pass the promise to skip
+ *   the extra RPC.
  * @returns Hunt Monsters
  */
 export async function getHuntMonsters(
-  huntId: string | null | undefined
+  huntId: string | null | undefined,
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<{ [key: string]: HuntMonsterDetail } | null> {
   if (!huntId) return null
 
@@ -25,12 +63,27 @@ export async function getHuntMonsters(
   const { data, error } = await supabase
     .from('hunt_monster')
     .select(
-      'id, accuracy, accuracy_tokens, ai_deck_id, ai_deck_remaining, damage, damage_tokens, evasion, evasion_tokens, hunt_id, knocked_down, luck, luck_tokens, monster_name, movement, movement_tokens, notes, settlement_id, speed, speed_tokens, strength, strength_tokens, toughness, wounds, hunt_ai_deck(id, advanced_cards, basic_cards, legendary_cards, overtone_cards), hunt_monster_trait(trait(id, custom, trait_name, rules)), hunt_monster_mood(mood(id, custom, mood_name, rules)), hunt_monster_survivor_status(survivor_status(id, custom, survivor_status_name, rules))'
+      'id, accuracy, accuracy_tokens, ai_deck_id, ai_deck_remaining, damage, damage_tokens, evasion, evasion_tokens, hunt_id, knocked_down, luck, luck_tokens, monster_name, movement, movement_tokens, notes, settlement_id, speed, speed_tokens, strength, strength_tokens, toughness, wounds, hunt_ai_deck(id, advanced_cards, basic_cards, legendary_cards, overtone_cards), hunt_monster_trait(trait(id, custom, user_id, trait_name, rules)), hunt_monster_mood(mood(id, custom, user_id, mood_name, rules)), hunt_monster_survivor_status(survivor_status(id, custom, user_id, survivor_status_name, rules))'
     )
     .eq('hunt_id', huntId)
 
   if (error) throw new Error(`Error Fetching Hunt Monsters: ${error.message}`)
   if (!data) return null
+
+  // Derive the settlement scope from the first hunt-monster row (all rows for
+  // a hunt share the same settlement). Skip the RPC entirely when there are
+  // no monsters yet.
+  const settlementId =
+    (data[0] as { settlement_id?: string | null } | undefined)?.settlement_id ??
+    null
+
+  const memberUsernames =
+    data.length === 0
+      ? new Map<string, string>()
+      : await (prefetchedMemberUsernames ??
+          (settlementId
+            ? getSettlementMemberUsernames(settlementId)
+            : Promise.resolve(new Map<string, string>())))
 
   const huntMonsterMap: { [key: string]: HuntMonsterDetail } = {}
 
@@ -38,18 +91,18 @@ export async function getHuntMonsters(
     const aiDeck = m.hunt_ai_deck as unknown as HuntMonsterDetail['ai_deck']
     const traitRows = (
       m as unknown as {
-        hunt_monster_trait: { trait: TraitDetail | null }[]
+        hunt_monster_trait: { trait: WithAuthorship<TraitDetail> | null }[]
       }
     ).hunt_monster_trait
     const moodRows = (
       m as unknown as {
-        hunt_monster_mood: { mood: MoodDetail | null }[]
+        hunt_monster_mood: { mood: WithAuthorship<MoodDetail> | null }[]
       }
     ).hunt_monster_mood
     const statusRows = (
       m as unknown as {
         hunt_monster_survivor_status: {
-          survivor_status: SurvivorStatusDetail | null
+          survivor_status: WithAuthorship<SurvivorStatusDetail> | null
         }[]
       }
     ).hunt_monster_survivor_status
@@ -59,13 +112,34 @@ export async function getHuntMonsters(
       ai_deck: aiDeck ?? null,
       traits: (traitRows ?? [])
         .map((r) => r.trait)
-        .filter((t): t is TraitDetail => t !== null),
+        .filter((t): t is WithAuthorship<TraitDetail> => t !== null)
+        .map(({ user_id, ...trait }) => ({
+          ...trait,
+          author_username: resolveAuthorUsername(
+            { custom: trait.custom, user_id },
+            memberUsernames
+          )
+        })),
       moods: (moodRows ?? [])
         .map((r) => r.mood)
-        .filter((m): m is MoodDetail => m !== null),
+        .filter((m): m is WithAuthorship<MoodDetail> => m !== null)
+        .map(({ user_id, ...mood }) => ({
+          ...mood,
+          author_username: resolveAuthorUsername(
+            { custom: mood.custom, user_id },
+            memberUsernames
+          )
+        })),
       survivor_statuses: (statusRows ?? [])
         .map((r) => r.survivor_status)
-        .filter((s): s is SurvivorStatusDetail => s !== null)
+        .filter((s): s is WithAuthorship<SurvivorStatusDetail> => s !== null)
+        .map(({ user_id, ...status }) => ({
+          ...status,
+          author_username: resolveAuthorUsername(
+            { custom: status.custom, user_id },
+            memberUsernames
+          )
+        }))
     }
   }
 

--- a/lib/dal/hunt.ts
+++ b/lib/dal/hunt.ts
@@ -1,6 +1,7 @@
 import { getHuntHuntBoard } from '@/lib/dal/hunt-hunt-board'
 import { getHuntMonsters } from '@/lib/dal/hunt-monster'
 import { getHuntSurvivors } from '@/lib/dal/hunt-survivor'
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { HuntDetail } from '@/lib/types'
@@ -9,6 +10,11 @@ import { HuntDetail } from '@/lib/types'
  * Get Hunt
  *
  * Gets the unique hunt for a settlement.
+ *
+ * Starts the settlement member-username RPC once and shares the in-flight
+ * promise with {@link getHuntMonsters} so the trait / mood / survivor-status
+ * `author_username` resolution does not issue a duplicate RPC (E2.8; see
+ * `local/sharing-architecture.md` §7.4 / §10 Phase 2 item 2.6).
  *
  * @param settlementId Settlement ID
  * @returns Hunt Data
@@ -31,9 +37,14 @@ export async function getHunt(
   if (error) throw new Error(`Error Fetching Hunt: ${error.message}`)
   if (!data) return null
 
+  // Start the member-username RPC once and share the in-flight promise with
+  // the monster fetch (the only sub-query that materializes custom catalog
+  // rows). The board and hunt-survivor fetches don't need it.
+  const memberUsernamesPromise = getSettlementMemberUsernames(settlementId)
+
   const [huntHuntBoard, huntMonsters, huntSurvivors] = await Promise.all([
     getHuntHuntBoard(data.id),
-    getHuntMonsters(data.id),
+    getHuntMonsters(data.id, memberUsernamesPromise),
     getHuntSurvivors(data.id)
   ])
 

--- a/lib/dal/showdown-monster.ts
+++ b/lib/dal/showdown-monster.ts
@@ -1,4 +1,5 @@
 import { TablesInsert } from '@/lib/database.types'
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { createClient } from '@/lib/supabase/client'
 import {
   MoodDetail,
@@ -8,15 +9,52 @@ import {
 } from '@/lib/types'
 
 /**
+ * Catalog Row With Authorship
+ *
+ * Raw shape of a `trait` / `mood` / `survivor_status` embed coming back from
+ * Supabase before `author_username` is resolved. The `user_id` is dropped on
+ * the way out so it never leaks into `ShowdownMonsterDetail`.
+ */
+type WithAuthorship<T> = T & { user_id: string | null }
+
+/**
+ * Resolve Author Username
+ *
+ * Returns the catalog author's username for custom rows, or `null` for
+ * built-ins / rows authored by users no longer connected to the settlement.
+ *
+ * @param row Catalog Row With `custom` + `user_id`
+ * @param memberUsernames Settlement Member Username Map
+ * @returns Author Username Or Null
+ */
+function resolveAuthorUsername(
+  row: { custom: boolean; user_id: string | null } | null | undefined,
+  memberUsernames: Map<string, string>
+): string | null {
+  if (!row || !row.custom || !row.user_id) return null
+  return memberUsernames.get(row.user_id) ?? null
+}
+
+/**
  * Get Showdown Monsters
  *
  * Retrieves all monsters assigned to a showdown.
  *
+ * Each embedded `trait` / `mood` / `survivor_status` row carries
+ * `author_username` — `null` for built-ins, and the catalog author's
+ * username for custom rows so the UI can render the "By @username" chip
+ * (E2.8; see `local/sharing-architecture.md` §7.4 / §10 Phase 2 item 2.6).
+ *
  * @param showdownId Showdown ID
+ * @param prefetchedMemberUsernames Optional in-flight (or resolved)
+ *   member-username map. When called from {@link getShowdown} (which
+ *   fetches the map once for the whole settlement load), pass the promise
+ *   to skip the extra RPC.
  * @returns Showdown Monsters
  */
 export async function getShowdownMonsters(
-  showdownId: string | null | undefined
+  showdownId: string | null | undefined,
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<{ [key: string]: ShowdownMonsterDetail } | null> {
   if (!showdownId) return null
 
@@ -25,13 +63,28 @@ export async function getShowdownMonsters(
   const { data, error } = await supabase
     .from('showdown_monster')
     .select(
-      'id, accuracy, accuracy_tokens, ai_card_drawn, ai_deck_id, ai_deck_remaining, damage, damage_tokens, evasion, evasion_tokens, knocked_down, luck, luck_tokens, monster_name, movement, movement_tokens, notes, settlement_id, showdown_id, speed, speed_tokens, strength, strength_tokens, toughness, wounds, showdown_ai_deck(id, advanced_cards, basic_cards, legendary_cards, overtone_cards), showdown_monster_trait(trait(id, custom, trait_name, rules)), showdown_monster_mood(mood(id, custom, mood_name, rules)), showdown_monster_survivor_status(survivor_status(id, custom, survivor_status_name, rules))'
+      'id, accuracy, accuracy_tokens, ai_card_drawn, ai_deck_id, ai_deck_remaining, damage, damage_tokens, evasion, evasion_tokens, knocked_down, luck, luck_tokens, monster_name, movement, movement_tokens, notes, settlement_id, showdown_id, speed, speed_tokens, strength, strength_tokens, toughness, wounds, showdown_ai_deck(id, advanced_cards, basic_cards, legendary_cards, overtone_cards), showdown_monster_trait(trait(id, custom, user_id, trait_name, rules)), showdown_monster_mood(mood(id, custom, user_id, mood_name, rules)), showdown_monster_survivor_status(survivor_status(id, custom, user_id, survivor_status_name, rules))'
     )
     .eq('showdown_id', showdownId)
 
   if (error)
     throw new Error(`Error Fetching Showdown Monsters: ${error.message}`)
   if (!data) return null
+
+  // Derive the settlement scope from the first showdown-monster row (all rows
+  // for a showdown share the same settlement). Skip the RPC entirely when
+  // there are no monsters yet.
+  const settlementId =
+    (data[0] as { settlement_id?: string | null } | undefined)?.settlement_id ??
+    null
+
+  const memberUsernames =
+    data.length === 0
+      ? new Map<string, string>()
+      : await (prefetchedMemberUsernames ??
+          (settlementId
+            ? getSettlementMemberUsernames(settlementId)
+            : Promise.resolve(new Map<string, string>())))
 
   const showdownMonsterMap: { [key: string]: ShowdownMonsterDetail } = {}
 
@@ -40,18 +93,18 @@ export async function getShowdownMonsters(
       m.showdown_ai_deck as unknown as ShowdownMonsterDetail['ai_deck']
     const traitRows = (
       m as unknown as {
-        showdown_monster_trait: { trait: TraitDetail | null }[]
+        showdown_monster_trait: { trait: WithAuthorship<TraitDetail> | null }[]
       }
     ).showdown_monster_trait
     const moodRows = (
       m as unknown as {
-        showdown_monster_mood: { mood: MoodDetail | null }[]
+        showdown_monster_mood: { mood: WithAuthorship<MoodDetail> | null }[]
       }
     ).showdown_monster_mood
     const statusRows = (
       m as unknown as {
         showdown_monster_survivor_status: {
-          survivor_status: SurvivorStatusDetail | null
+          survivor_status: WithAuthorship<SurvivorStatusDetail> | null
         }[]
       }
     ).showdown_monster_survivor_status
@@ -61,13 +114,34 @@ export async function getShowdownMonsters(
       ai_deck: aiDeck ?? null,
       traits: (traitRows ?? [])
         .map((r) => r.trait)
-        .filter((t): t is TraitDetail => t !== null),
+        .filter((t): t is WithAuthorship<TraitDetail> => t !== null)
+        .map(({ user_id, ...trait }) => ({
+          ...trait,
+          author_username: resolveAuthorUsername(
+            { custom: trait.custom, user_id },
+            memberUsernames
+          )
+        })),
       moods: (moodRows ?? [])
         .map((r) => r.mood)
-        .filter((m): m is MoodDetail => m !== null),
+        .filter((m): m is WithAuthorship<MoodDetail> => m !== null)
+        .map(({ user_id, ...mood }) => ({
+          ...mood,
+          author_username: resolveAuthorUsername(
+            { custom: mood.custom, user_id },
+            memberUsernames
+          )
+        })),
       survivor_statuses: (statusRows ?? [])
         .map((r) => r.survivor_status)
-        .filter((s): s is SurvivorStatusDetail => s !== null)
+        .filter((s): s is WithAuthorship<SurvivorStatusDetail> => s !== null)
+        .map(({ user_id, ...status }) => ({
+          ...status,
+          author_username: resolveAuthorUsername(
+            { custom: status.custom, user_id },
+            memberUsernames
+          )
+        }))
     }
   }
 

--- a/lib/dal/showdown.ts
+++ b/lib/dal/showdown.ts
@@ -1,5 +1,6 @@
 import { getShowdownMonsters } from '@/lib/dal/showdown-monster'
 import { getShowdownSurvivors } from '@/lib/dal/showdown-survivor'
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import { ShowdownDetail } from '@/lib/types'
@@ -8,6 +9,12 @@ import { ShowdownDetail } from '@/lib/types'
  * Get Showdown
  *
  * Gets the unique showdown for a specific settlement.
+ *
+ * Starts the settlement member-username RPC once and shares the in-flight
+ * promise with {@link getShowdownMonsters} so the trait / mood /
+ * survivor-status `author_username` resolution does not issue a duplicate
+ * RPC (E2.8; see `local/sharing-architecture.md` §7.4 / §10 Phase 2 item
+ * 2.6).
  *
  * @param settlementId Settlement ID
  * @returns Showdown Data
@@ -28,8 +35,13 @@ export async function getShowdown(
   if (error) throw new Error(`Error Fetching Showdown: ${error.message}`)
   if (!data) return null
 
+  // Start the member-username RPC once and share the in-flight promise with
+  // the monster fetch (the only sub-query that materializes custom catalog
+  // rows). The showdown-survivor fetch does not need it.
+  const memberUsernamesPromise = getSettlementMemberUsernames(settlementId)
+
   const [showdownMonsters, showdownSurvivors] = await Promise.all([
-    getShowdownMonsters(data.id),
+    getShowdownMonsters(data.id, memberUsernamesPromise),
     getShowdownSurvivors(data.id)
   ])
 

--- a/lib/dal/survivor.ts
+++ b/lib/dal/survivor.ts
@@ -4,6 +4,7 @@ import {
   SURVIVOR_ON_HUNT_ERROR_MESSAGE,
   SURVIVOR_ON_SHOWDOWN_ERROR_MESSAGE
 } from '@/lib/messages'
+import { getSettlementMemberUsernames } from '@/lib/dal/settlement-shared-user'
 import { createClient } from '@/lib/supabase/client'
 import { SurvivorDetail } from '@/lib/types'
 import { NewSurvivorInput } from '@/schemas/new-survivor-input'
@@ -20,33 +21,47 @@ import { NewSurvivorInput } from '@/schemas/new-survivor-input'
  * - The `knowledge` table appears three times via FK aliases
  *   (`survivor_knowledge_1_id_fkey` etc.) — PostgREST requires the explicit
  *   constraint name to disambiguate.
+ * - Every embed selects the catalog row's `custom` flag and `user_id` so the
+ *   mapper can resolve `author_username` against the settlement-member
+ *   username map (E2.8; see `local/sharing-architecture.md` §7.4 / §10
+ *   Phase 2 item 2.6).
  */
 const SURVIVOR_SELECT = `
   *,
   abilities_impairments:survivor_ability_impairment(
-    ability_impairment(id, custom, ability_impairment_name, rules)
+    ability_impairment(id, custom, user_id, ability_impairment_name, rules)
   ),
   cursed_gear:survivor_cursed_gear(
-    gear(id, gear_name)
+    gear(id, custom, user_id, gear_name)
   ),
   disorders:survivor_disorder(
-    disorder(id, custom, disorder_name, rules)
+    disorder(id, custom, user_id, disorder_name, rules)
   ),
   fighting_arts:survivor_fighting_art(
-    fighting_art(id, custom, fighting_art_name, rules)
+    fighting_art(id, custom, user_id, fighting_art_name, rules)
   ),
   secret_fighting_arts:survivor_secret_fighting_art(
-    secret_fighting_art(id, custom, secret_fighting_art_name, rules)
+    secret_fighting_art(id, custom, user_id, secret_fighting_art_name, rules)
   ),
   gear_grid(id, pos_top_left, pos_top_center, pos_top_right, pos_mid_left, pos_mid_center, pos_mid_right, pos_bottom_left, pos_bottom_center, pos_bottom_right, selected_armor_set_id),
   hunt_survivor(survivor_id),
   showdown_survivor(survivor_id),
-  knowledge_1:knowledge!survivor_knowledge_1_id_fkey(id, knowledge_name, rules, observation_conditions, observation_rank_up_milestone),
-  knowledge_2:knowledge!survivor_knowledge_2_id_fkey(id, knowledge_name, rules, observation_conditions, observation_rank_up_milestone),
-  neurosis(id, neurosis_name, rules),
-  philosophy(id, philosophy_name, hunt_xp_milestones, tenet_knowledge_id, tier),
-  tenet_knowledge:knowledge!survivor_tenet_knowledge_id_fkey(id, knowledge_name, rules, observation_conditions, observation_rank_up_milestone)
+  knowledge_1:knowledge!survivor_knowledge_1_id_fkey(id, custom, user_id, knowledge_name, rules, observation_conditions, observation_rank_up_milestone),
+  knowledge_2:knowledge!survivor_knowledge_2_id_fkey(id, custom, user_id, knowledge_name, rules, observation_conditions, observation_rank_up_milestone),
+  neurosis(id, custom, user_id, neurosis_name, rules),
+  philosophy(id, custom, user_id, philosophy_name, hunt_xp_milestones, tenet_knowledge_id, tier),
+  tenet_knowledge:knowledge!survivor_tenet_knowledge_id_fkey(id, custom, user_id, knowledge_name, rules, observation_conditions, observation_rank_up_milestone)
 `
+
+/**
+ * Catalog Row With Authorship
+ *
+ * Helper that augments a `SurvivorDetail` collection entry with the raw
+ * `user_id` returned by the embedded catalog row. The DAL strips `user_id`
+ * during the map step so it never leaks into `SurvivorDetail`, but it's
+ * required transiently to look up `author_username`.
+ */
+type WithAuthorship<T> = T & { user_id: string | null }
 
 /**
  * Raw Survivor Row Shape
@@ -54,39 +69,119 @@ const SURVIVOR_SELECT = `
  * Captures the runtime shape returned by Supabase for `SURVIVOR_SELECT`.
  * Generated types can't express the FK-aliased projections precisely, so a
  * focused interface keeps the mapper type-safe without `as unknown` casts.
+ *
+ * The embedded catalog rows carry `user_id` here (stripped during the map
+ * step before reaching `SurvivorDetail`) so each row's `author_username`
+ * can be resolved from the settlement member-username map.
  */
 type SurvivorRow = Tables<'survivor'> & {
   abilities_impairments: {
-    ability_impairment: SurvivorDetail['abilities_impairments'][number] | null
+    ability_impairment: WithAuthorship<
+      Omit<SurvivorDetail['abilities_impairments'][number], 'author_username'>
+    > | null
   }[]
-  cursed_gear: { gear: SurvivorDetail['cursed_gear'][number] | null }[]
-  disorders: { disorder: SurvivorDetail['disorders'][number] | null }[]
+  cursed_gear: {
+    gear: WithAuthorship<
+      Omit<SurvivorDetail['cursed_gear'][number], 'author_username'>
+    > | null
+  }[]
+  disorders: {
+    disorder: WithAuthorship<
+      Omit<SurvivorDetail['disorders'][number], 'author_username'>
+    > | null
+  }[]
   fighting_arts: {
-    fighting_art: SurvivorDetail['fighting_arts'][number] | null
+    fighting_art: WithAuthorship<
+      Omit<SurvivorDetail['fighting_arts'][number], 'author_username'>
+    > | null
   }[]
   secret_fighting_arts: {
-    secret_fighting_art: SurvivorDetail['secret_fighting_arts'][number] | null
+    secret_fighting_art: WithAuthorship<
+      Omit<SurvivorDetail['secret_fighting_arts'][number], 'author_username'>
+    > | null
   }[]
   gear_grid: SurvivorDetail['gear_grid'] | SurvivorDetail['gear_grid'][] | null
   hunt_survivor: { survivor_id: string }[]
   showdown_survivor: { survivor_id: string }[]
-  knowledge_1: SurvivorDetail['knowledge_1']
-  knowledge_2: SurvivorDetail['knowledge_2']
-  neurosis: SurvivorDetail['neurosis']
-  philosophy: SurvivorDetail['philosophy']
-  tenet_knowledge: SurvivorDetail['tenet_knowledge']
+  knowledge_1: WithAuthorship<
+    Omit<NonNullable<SurvivorDetail['knowledge_1']>, 'author_username'>
+  > | null
+  knowledge_2: WithAuthorship<
+    Omit<NonNullable<SurvivorDetail['knowledge_2']>, 'author_username'>
+  > | null
+  neurosis: WithAuthorship<
+    Omit<NonNullable<SurvivorDetail['neurosis']>, 'author_username'>
+  > | null
+  philosophy: WithAuthorship<
+    Omit<NonNullable<SurvivorDetail['philosophy']>, 'author_username'>
+  > | null
+  tenet_knowledge: WithAuthorship<
+    Omit<NonNullable<SurvivorDetail['tenet_knowledge']>, 'author_username'>
+  > | null
+}
+
+/**
+ * Resolve Author Username
+ *
+ * Returns the catalog author's username for custom rows, or `null` for
+ * built-ins / rows authored by users no longer connected to the settlement.
+ * Mirrors the canonical pattern in `settlement_*` collection DALs.
+ *
+ * @param row Catalog Row With `custom` + `user_id`
+ * @param memberUsernames Settlement Member Username Map
+ * @returns Author Username Or Null
+ */
+function resolveAuthorUsername(
+  row: { custom: boolean; user_id: string | null } | null | undefined,
+  memberUsernames: Map<string, string>
+): string | null {
+  if (!row || !row.custom || !row.user_id) return null
+  return memberUsernames.get(row.user_id) ?? null
+}
+
+/**
+ * Strip Author User ID
+ *
+ * Returns a new object with the embedded `user_id` removed and the resolved
+ * `author_username` attached. Keeps `user_id` from leaking into
+ * `SurvivorDetail` while preserving every other catalog field.
+ *
+ * @param row Catalog Row With `user_id`
+ * @param memberUsernames Settlement Member Username Map
+ * @returns Catalog Row With `author_username`
+ */
+function withAuthorUsername<
+  T extends { custom: boolean; user_id: string | null }
+>(
+  row: T,
+  memberUsernames: Map<string, string>
+): Omit<T, 'user_id'> & { author_username: string | null } {
+  const { user_id, ...rest } = row
+  return {
+    ...rest,
+    author_username: resolveAuthorUsername(
+      { custom: row.custom, user_id },
+      memberUsernames
+    )
+  }
 }
 
 /**
  * Map Survivor Row to SurvivorDetail
  *
  * Flattens the junction-table embeds (`[{ disorder: {...} }]` →
- * `[{...}]`) and derives the `embarked` flag from hunt/showdown membership.
+ * `[{...}]`), derives the `embarked` flag from hunt/showdown membership,
+ * and resolves `author_username` for every custom catalog row using the
+ * settlement member-username map.
  *
  * @param row Survivor Row
+ * @param memberUsernames Settlement Member Username Map
  * @returns Survivor Detail
  */
-function mapSurvivorRow(row: SurvivorRow): SurvivorDetail {
+function mapSurvivorRow(
+  row: SurvivorRow,
+  memberUsernames: Map<string, string>
+): SurvivorDetail {
   const {
     abilities_impairments,
     cursed_gear,
@@ -96,6 +191,11 @@ function mapSurvivorRow(row: SurvivorRow): SurvivorDetail {
     gear_grid,
     hunt_survivor,
     showdown_survivor,
+    knowledge_1,
+    knowledge_2,
+    neurosis,
+    philosophy,
+    tenet_knowledge,
     ...survivor
   } = row
 
@@ -109,26 +209,53 @@ function mapSurvivorRow(row: SurvivorRow): SurvivorDetail {
   return {
     ...survivor,
     abilities_impairments: abilities_impairments
-      .map((r) => r.ability_impairment)
+      .map((r) =>
+        r.ability_impairment
+          ? withAuthorUsername(r.ability_impairment, memberUsernames)
+          : null
+      )
       .filter((x): x is SurvivorDetail['abilities_impairments'][number] =>
         Boolean(x)
       ),
     cursed_gear: cursed_gear
-      .map((r) => r.gear)
+      .map((r) => (r.gear ? withAuthorUsername(r.gear, memberUsernames) : null))
       .filter((x): x is SurvivorDetail['cursed_gear'][number] => Boolean(x)),
     disorders: disorders
-      .map((r) => r.disorder)
+      .map((r) =>
+        r.disorder ? withAuthorUsername(r.disorder, memberUsernames) : null
+      )
       .filter((x): x is SurvivorDetail['disorders'][number] => Boolean(x)),
     embarked: hunt_survivor.length > 0 || showdown_survivor.length > 0,
     fighting_arts: fighting_arts
-      .map((r) => r.fighting_art)
+      .map((r) =>
+        r.fighting_art
+          ? withAuthorUsername(r.fighting_art, memberUsernames)
+          : null
+      )
       .filter((x): x is SurvivorDetail['fighting_arts'][number] => Boolean(x)),
     gear_grid: gridRow,
+    knowledge_1: knowledge_1
+      ? withAuthorUsername(knowledge_1, memberUsernames)
+      : null,
+    knowledge_2: knowledge_2
+      ? withAuthorUsername(knowledge_2, memberUsernames)
+      : null,
+    neurosis: neurosis ? withAuthorUsername(neurosis, memberUsernames) : null,
+    philosophy: philosophy
+      ? withAuthorUsername(philosophy, memberUsernames)
+      : null,
     secret_fighting_arts: secret_fighting_arts
-      .map((r) => r.secret_fighting_art)
+      .map((r) =>
+        r.secret_fighting_art
+          ? withAuthorUsername(r.secret_fighting_art, memberUsernames)
+          : null
+      )
       .filter((x): x is SurvivorDetail['secret_fighting_arts'][number] =>
         Boolean(x)
-      )
+      ),
+    tenet_knowledge: tenet_knowledge
+      ? withAuthorUsername(tenet_knowledge, memberUsernames)
+      : null
   }
 }
 
@@ -166,11 +293,22 @@ export async function addSquiresOfTheCitadelSurvivors(
  * (disorders, fighting arts, etc.) resolved to their display names. Issues
  * a single PostgREST request that joins every related entity in one call.
  *
+ * Each embedded catalog row carries `author_username` so the UI can render
+ * the "By @username" chip on custom rows (E2.8; see
+ * `local/sharing-architecture.md` §7.4 / §10 Phase 2 item 2.6). The
+ * username map is fetched alongside the main query via the
+ * `get_settlement_member_usernames` SECURITY DEFINER RPC.
+ *
  * @param survivorId Survivor ID
+ * @param prefetchedMemberUsernames Optional in-flight (or resolved)
+ *   member-username map. When the caller already has the map (e.g. when
+ *   loading a settlement page that also fetches survivors), pass the
+ *   promise to avoid an extra RPC.
  * @returns Survivor Data with Embarked Status
  */
 export async function getSurvivor(
-  survivorId: string | null | undefined
+  survivorId: string | null | undefined,
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SurvivorDetail | null> {
   if (!survivorId) throw new Error('Required: Survivor ID')
 
@@ -185,7 +323,13 @@ export async function getSurvivor(
   if (error) throw new Error(`Error Fetching Survivor: ${error.message}`)
   if (!data) return null
 
-  return mapSurvivorRow(data)
+  // The survivor row carries `settlement_id` regardless of whether the
+  // caller provided a prefetched map, so we can derive the settlement
+  // scope here without an extra round-trip.
+  const memberUsernames = await (prefetchedMemberUsernames ??
+    getSettlementMemberUsernames(data.settlement_id))
+
+  return mapSurvivorRow(data, memberUsernames)
 }
 
 /**
@@ -195,27 +339,37 @@ export async function getSurvivor(
  * Issues a single PostgREST request that joins every related entity in one
  * call.
  *
+ * Each embedded catalog row carries `author_username`; see {@link getSurvivor}
+ * for details.
+ *
  * @param settlementId Settlement ID
+ * @param prefetchedMemberUsernames Optional in-flight (or resolved)
+ *   member-username map. When called from an aggregator that already
+ *   fetches the map, pass the promise to skip the extra RPC.
  * @returns List of Survivors with Embarked Status
  */
 export async function getSurvivors(
-  settlementId: string | null
+  settlementId: string | null,
+  prefetchedMemberUsernames?: Promise<Map<string, string>>
 ): Promise<SurvivorDetail[] | null> {
   if (!settlementId) return null
 
   const supabase = createClient()
 
-  const { data, error } = await supabase
-    .from('survivor')
-    .select(SURVIVOR_SELECT)
-    .eq('settlement_id', settlementId)
-    .order('id', { ascending: true })
-    .returns<SurvivorRow[]>()
+  const [{ data, error }, memberUsernames] = await Promise.all([
+    supabase
+      .from('survivor')
+      .select(SURVIVOR_SELECT)
+      .eq('settlement_id', settlementId)
+      .order('id', { ascending: true })
+      .returns<SurvivorRow[]>(),
+    prefetchedMemberUsernames ?? getSettlementMemberUsernames(settlementId)
+  ])
 
   if (error) throw new Error(`Error Fetching Survivors: ${error.message}`)
   if (!data?.length) return null
 
-  return data.map(mapSurvivorRow)
+  return data.map((row) => mapSurvivorRow(row, memberUsernames))
 }
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -400,12 +400,30 @@ export type HuntMonsterDetail = Omit<
 > & {
   /** AI Deck */
   ai_deck: HuntAIDeckDetail
-  /** Traits (joined from hunt_monster_trait → trait) */
-  traits: TraitDetail[]
-  /** Moods (joined from hunt_monster_mood → mood) */
-  moods: MoodDetail[]
-  /** Survivor statuses (joined from hunt_monster_survivor_status → survivor_status) */
-  survivor_statuses: SurvivorStatusDetail[]
+  /**
+   * Traits (joined from hunt_monster_trait → trait).
+   *
+   * Each entry carries `author_username` — `null` for built-in (non-custom)
+   * traits, and the catalog author's username for custom traits so the UI can
+   * render the "By @username" chip (E2.8; see `local/sharing-architecture.md`
+   * §7.4 / §10 Phase 2 item 2.6).
+   */
+  traits: (TraitDetail & { author_username: string | null })[]
+  /**
+   * Moods (joined from hunt_monster_mood → mood).
+   *
+   * Each entry carries `author_username`; see `traits` above.
+   */
+  moods: (MoodDetail & { author_username: string | null })[]
+  /**
+   * Survivor statuses (joined from hunt_monster_survivor_status →
+   * survivor_status).
+   *
+   * Each entry carries `author_username`; see `traits` above.
+   */
+  survivor_statuses: (SurvivorStatusDetail & {
+    author_username: string | null
+  })[]
 }
 
 /**
@@ -1192,12 +1210,30 @@ export type ShowdownMonsterDetail = Omit<
 > & {
   /** AI Deck */
   ai_deck: ShowdownAIDeckDetail
-  /** Traits (joined from showdown_monster_trait → trait) */
-  traits: TraitDetail[]
-  /** Moods (joined from showdown_monster_mood → mood) */
-  moods: MoodDetail[]
-  /** Survivor statuses (joined from showdown_monster_survivor_status → survivor_status) */
-  survivor_statuses: SurvivorStatusDetail[]
+  /**
+   * Traits (joined from showdown_monster_trait → trait).
+   *
+   * Each entry carries `author_username` — `null` for built-in (non-custom)
+   * traits, and the catalog author's username for custom traits so the UI can
+   * render the "By @username" chip (E2.8; see `local/sharing-architecture.md`
+   * §7.4 / §10 Phase 2 item 2.6).
+   */
+  traits: (TraitDetail & { author_username: string | null })[]
+  /**
+   * Moods (joined from showdown_monster_mood → mood).
+   *
+   * Each entry carries `author_username`; see `traits` above.
+   */
+  moods: (MoodDetail & { author_username: string | null })[]
+  /**
+   * Survivor statuses (joined from showdown_monster_survivor_status →
+   * survivor_status).
+   *
+   * Each entry carries `author_username`; see `traits` above.
+   */
+  survivor_statuses: (SurvivorStatusDetail & {
+    author_username: string | null
+  })[]
 }
 
 /**
@@ -1227,7 +1263,14 @@ export type StrainMilestoneDetail = Omit<
  * Includes additional information not present in the survivor table.
  */
 export type SurvivorDetail = Tables<'survivor'> & {
-  /** Abilities and Impairments */
+  /**
+   * Abilities and Impairments.
+   *
+   * Each entry carries `author_username` — `null` for built-in (non-custom)
+   * rows, and the catalog author's username for custom rows so the UI can
+   * render the "By @username" chip (E2.8; see
+   * `local/sharing-architecture.md` §7.4 / §10 Phase 2 item 2.6).
+   */
   abilities_impairments: {
     /** Ability or Impairment Name */
     ability_impairment_name: string
@@ -1237,15 +1280,29 @@ export type SurvivorDetail = Tables<'survivor'> & {
     id: string
     /** Rules */
     rules: string
+    /** Author Username (null for built-ins / unknown authors) */
+    author_username: string | null
   }[]
-  /** Cursed Gear */
+  /**
+   * Cursed Gear.
+   *
+   * Each entry carries `author_username`; see `abilities_impairments` above.
+   */
   cursed_gear: {
+    /** Custom */
+    custom: boolean
     /** Cursed Gear Name */
     gear_name: string
     /** Cursed Gear ID */
     id: string
+    /** Author Username (null for built-ins / unknown authors) */
+    author_username: string | null
   }[]
-  /** Disorders */
+  /**
+   * Disorders.
+   *
+   * Each entry carries `author_username`; see `abilities_impairments` above.
+   */
   disorders: {
     /** Custom */
     custom: boolean
@@ -1255,75 +1312,127 @@ export type SurvivorDetail = Tables<'survivor'> & {
     id: string
     /** Rules */
     rules: string
+    /** Author Username (null for built-ins / unknown authors) */
+    author_username: string | null
   }[]
   /** Survivor Embarked on Hunt/Showdown */
   embarked: boolean
-  /** Fighting Arts */
-  fighting_arts: FightingArtDetail[]
+  /**
+   * Fighting Arts.
+   *
+   * Each entry carries `author_username`; see `abilities_impairments` above.
+   */
+  fighting_arts: (FightingArtDetail & { author_username: string | null })[]
   /** Gear Grid (3x3 of equipped gear; null until first edit) */
   gear_grid: GearGridDetail | null
-  /** Knowledge 1 */
+  /**
+   * Knowledge 1.
+   *
+   * Carries `author_username`; see `abilities_impairments` above.
+   */
   knowledge_1: {
     /** Knowledge ID */
     id: string
     /** Knowledge Name */
     knowledge_name: string
+    /** Custom */
+    custom: boolean
     /** Rules */
     rules: string | null
     /** Observation Conditions */
     observation_conditions: string | null
     /** Observation Rank Up Milestone */
     observation_rank_up_milestone: number | null
+    /** Author Username (null for built-ins / unknown authors) */
+    author_username: string | null
   } | null
-  /** Knowledge 2 */
+  /**
+   * Knowledge 2.
+   *
+   * Carries `author_username`; see `abilities_impairments` above.
+   */
   knowledge_2: {
     /** Knowledge ID */
     id: string
     /** Knowledge Name */
     knowledge_name: string
+    /** Custom */
+    custom: boolean
     /** Rules */
     rules: string | null
     /** Observation Conditions */
     observation_conditions: string | null
     /** Observation Rank Up Milestone */
     observation_rank_up_milestone: number | null
+    /** Author Username (null for built-ins / unknown authors) */
+    author_username: string | null
   } | null
-  /** Neurosis */
+  /**
+   * Neurosis.
+   *
+   * Carries `author_username`; see `abilities_impairments` above.
+   */
   neurosis: {
     /** Neurosis ID */
     id: string
     /** Neurosis Name */
     neurosis_name: string
+    /** Custom */
+    custom: boolean
     /** Rules */
     rules: string | null
+    /** Author Username (null for built-ins / unknown authors) */
+    author_username: string | null
   } | null
-  /** Philosophy */
+  /**
+   * Philosophy.
+   *
+   * Carries `author_username`; see `abilities_impairments` above.
+   */
   philosophy: {
     /** Philosophy ID */
     id: string
     /** Philosophy Name */
     philosophy_name: string
+    /** Custom */
+    custom: boolean
     /** Hunt XP Milestones */
     hunt_xp_milestones: number[] | null
     /** Tenet Knowledge ID */
     tenet_knowledge_id: string | null
     /** Tier */
     tier: number | null
+    /** Author Username (null for built-ins / unknown authors) */
+    author_username: string | null
   } | null
-  /** Secret Fighting Arts */
-  secret_fighting_arts: SecretFightingArtDetail[]
-  /** Tenet Knowledge */
+  /**
+   * Secret Fighting Arts.
+   *
+   * Each entry carries `author_username`; see `abilities_impairments` above.
+   */
+  secret_fighting_arts: (SecretFightingArtDetail & {
+    author_username: string | null
+  })[]
+  /**
+   * Tenet Knowledge.
+   *
+   * Carries `author_username`; see `abilities_impairments` above.
+   */
   tenet_knowledge: {
     /** Knowledge ID */
     id: string
     /** Knowledge Name */
     knowledge_name: string
+    /** Custom */
+    custom: boolean
     /** Rules */
     rules: string | null
     /** Observation Conditions */
     observation_conditions: string | null
     /** Observation Rank Up Milestone */
     observation_rank_up_milestone: number | null
+    /** Author Username (null for built-ins / unknown authors) */
+    author_username: string | null
   } | null
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.22",
+  "version": "0.61.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.22",
+      "version": "0.61.23",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.22",
+  "version": "0.61.23",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

Closes the remaining scope of #158. PR #222 already wired `author_username` through `SettlementDetail` (E2.8); this PR extends the same pattern to the other domains that materialize custom-bearing catalog rows so E2.9 can render the "By @username" chip everywhere those rows appear:

- `SurvivorDetail` — `cursed_gear`, `disorders`, `fighting_arts`, `secret_fighting_arts`, `knowledge_1` / `knowledge_2` / `tenet_knowledge`, `neurosis`, `philosophy`, `abilities_impairments`
- `HuntMonsterDetail` — `traits`, `moods`, `survivor_statuses`
- `ShowdownMonsterDetail` — `traits`, `moods`, `survivor_statuses`

`SettlementPhase` was reviewed and intentionally **out of scope**: it does not materialize any catalog rows that carry a `custom` flag.

## How

- **Reuses the existing RPC.** `get_settlement_member_usernames` (introduced by PR #222) is the source of truth. No new migration, no new SQL.
- **DAL changes.** Each affected DAL now extends its `SELECT` projection with `custom, user_id` on every catalog embed, then `Promise.all`s the main query with `getSettlementMemberUsernames(settlementId)`. Per-row mapping resolves `author_username` (`custom && user_id ? map.get(user_id) ?? null : null`) and strips `user_id` so it never leaks into the public detail types.
- **Promise sharing.** `getSurvivor`, `getSurvivors`, `getHuntMonsters`, `getShowdownMonsters` now accept an optional `prefetchedMemberUsernames: Promise<Map<string, string>>`. `getHunt` and `getShowdown` start the RPC once and forward the in-flight promise to their monster sub-DAL to avoid a duplicate round-trip. This mirrors the canonical pattern from PR #222.
- **Settlement scope derivation.** `getSurvivor` derives the settlement scope from the survivor row's `settlement_id`, so callers without a prefetched map still get correct authorship without an extra round-trip. `getHuntMonsters` / `getShowdownMonsters` derive it from the first monster row and skip the RPC entirely when the query returns zero rows.

## Types

- `lib/types.ts`: every collection entry listed above now carries `author_username: string | null`. Where the catalog row didn't already include `custom`, it was added (e.g. `cursed_gear`, `knowledge_*`, `neurosis`, `philosophy`, `tenet_knowledge`). `fighting_arts` and `secret_fighting_arts` use intersection types over the existing `FightingArtDetail` / `SecretFightingArtDetail`.

## UI cascades

Optimistic-update sites and picker adapters that previously constructed catalog rows without `author_username` were widened to the new shapes and now emit `author_username: null` placeholders at construction time. The next realtime refetch (or aggregator load) backfills the real value via the RPC, identical to how PR #222 handles it.

Affected components:

- `components/survivor/cursed-gear/cursed-gear-card.tsx`
- `components/survivor/fighting-arts/fighting-arts-card.tsx`
- `components/survivor/knowledge/knowledge-card.tsx`
- `components/survivor/philosophy/philosophy-card.tsx`
- `components/monster/traits-moods/traits-moods.tsx`
- `components/hunt/hunt-monster/hunt-monster-card.tsx`
- `components/hunt/create-hunt/create-hunt-card.tsx`
- `components/showdown/showdown-monster/showdown-monster-card.tsx`
- `components/showdown/create-showdown/create-showdown-card.tsx`

## Tests

- **DAL unit tests** (`survivor.test.ts`, `hunt-monster.test.ts`, `showdown-monster.test.ts`): added `mockSupabase.rpc` and new cases covering:
  - Custom rows authored by a settlement member → `author_username` resolved to the member's username
  - Custom rows authored by a ghost (user who left the settlement) → `null`
  - Built-in rows → `null`
  - Empty-monster path skips the RPC entirely
  - Prefetched-map path avoids issuing a duplicate RPC
- **Aggregator tests** (`hunt.test.ts`, `showdown.test.ts`): mock `getSettlementMemberUsernames` and assert the aggregator forwards the in-flight promise into its monster sub-DAL.

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — **1929 passed (1929)**
- `npm run lint` — clean
- `npm run format:check` — clean

## Acceptance criteria (per #158)

- [x] Loading a settlement returns the author's username for every custom row, across survivor / hunt / showdown materializations
- [x] Built-ins get `null`
- [x] Type checks pass

## Dependencies

No new dependencies. `package.json` / `package-lock.json` bumped **0.61.22 → 0.61.23**.

## Out of scope

- `SettlementPhase` — no custom-bearing catalog rows.
- The UI chip itself — that lives in **E2.9** and is unblocked by this PR.

## Related

- Continuation of #222 (E2.8 — SettlementDetail)
- Closes the remaining scope of #158