### PR TITLE
test: catalog transitive EC-2..EC-8 + author-membership SELECT enforcement (#152)

### DIFF
--- a/__tests__/integration/rls/catalog-transitive.test.ts
+++ b/__tests__/integration/rls/catalog-transitive.test.ts
@@ -1,0 +1,485 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Catalog Transitive Visibility (EC-2..EC-8)
+ *
+ * Comprehensive integration coverage for the canonical catalog-sharing edge
+ * cases in `local/sharing-architecture.md` Appendix B (EC-2..EC-8). Each
+ * scenario is exercised as a single narrative `it` block against the live
+ * RLS layer using the standard `__tests__/integration/helpers/supabase`
+ * harness.
+ *
+ * Setup:
+ *
+ *   * Two users: A (settlement owner) and B (collaborator).
+ *   * One settlement S, owned by A and shared with B, used for scenarios
+ *     that do not mutate the share / detach state. Scenarios that DO mutate
+ *     those states (EC-3, EC-5, EC-7) seed their own fresh settlement so
+ *     they remain independent of one another.
+ *
+ * Catalog tables under test:
+ *
+ *   * `knowledge`  — exercises the settlement-junction chain (EC-2..EC-5).
+ *   * `disorder`   — exercises the survivor-junction chain (EC-6..EC-8).
+ *
+ * Other chains (survivor column, hunt / showdown junctions, gear_grid armor
+ * selection) are pinned by sibling files
+ * (`catalog-transitive-via-survivor.test.ts`,
+ * `catalog-transitive-hunt-showdown.test.ts`,
+ * `catalog-visibility-via-settlement.test.ts`,
+ * `custom-content.test.ts`,
+ * `catalog-delete-guard.test.ts`,
+ * `catalog-owner-cannot-delete-shared.test.ts`). This file is the
+ * canonical EC-2..EC-8 narrative lock.
+ *
+ * Closes [E2.12].
+ */
+describe('RLS: catalog transitive visibility (EC-2..EC-8)', () => {
+  let userA: TestUser
+  let userB: TestUser
+  let settlementId: string
+
+  beforeAll(async () => {
+    userA = await createTestUser()
+    userB = await createTestUser()
+
+    settlementId = await seedSettlement(userA.id, 'EC-2..EC-8 Test Settlement')
+    await shareSettlement(settlementId, userB.id, userA.id)
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(userA.id)
+    await deleteTestUser(userB.id)
+  })
+
+  /**
+   * Seed Knowledge
+   *
+   * Inserts a custom knowledge row authored by the given user.
+   *
+   * @param userId Author User ID
+   * @param label Short Test Label (used to disambiguate names)
+   * @returns Knowledge ID And Rules Text
+   */
+  async function seedKnowledge(
+    userId: string,
+    label: string
+  ): Promise<{ id: string; rules: string }> {
+    const rules = `The lantern's truth — ${label} ${Date.now()}-${Math.random()}`
+    const { data, error } = await admin
+      .from('knowledge')
+      .insert({
+        knowledge_name: `Knowledge ${label} ${Date.now()}-${Math.random()}`,
+        custom: true,
+        user_id: userId,
+        rules
+      })
+      .select('id')
+      .single()
+    if (error || !data) throw new Error(`seed knowledge: ${error?.message}`)
+    return { id: data.id, rules }
+  }
+
+  /**
+   * Seed Disorder
+   *
+   * Inserts a custom disorder row authored by the given user.
+   *
+   * @param userId Author User ID
+   * @param label Short Test Label
+   * @returns Disorder ID And Rules Text
+   */
+  async function seedDisorder(
+    userId: string,
+    label: string
+  ): Promise<{ id: string; rules: string }> {
+    const rules = `Whispers from the dark — ${label} ${Date.now()}-${Math.random()}`
+    const { data, error } = await admin
+      .from('disorder')
+      .insert({
+        disorder_name: `Disorder ${label} ${Date.now()}-${Math.random()}`,
+        custom: true,
+        user_id: userId,
+        rules
+      })
+      .select('id')
+      .single()
+    if (error || !data) throw new Error(`seed disorder: ${error?.message}`)
+    return { id: data.id, rules }
+  }
+
+  /**
+   * Seed Survivor
+   *
+   * Inserts a survivor in the given settlement. Uses admin to bypass the
+   * survivor INSERT policy because the suite is only interested in the
+   * post-insert visibility / delete behavior of the catalog rows.
+   *
+   * @param settlementId Settlement ID
+   * @returns Survivor ID
+   */
+  async function seedSurvivor(settlementId: string): Promise<string> {
+    const { data, error } = await admin
+      .from('survivor')
+      .insert({
+        settlement_id: settlementId,
+        gender: 'FEMALE',
+        survivor_name: `Survivor ${Date.now()}-${Math.random()}`
+      })
+      .select('id')
+      .single()
+    if (error || !data) throw new Error(`seed survivor: ${error?.message}`)
+    return data.id
+  }
+
+  // ---------------------------------------------------------------------------
+  // EC-2: A creates custom knowledge K, attaches K to S, shares S with B
+  //       → B can SELECT K (rules included). B cannot UPDATE K's rules text.
+  // ---------------------------------------------------------------------------
+  it('EC-2: collaborator can read author-attached custom knowledge (rules included) but cannot edit it', async () => {
+    const { id: knowledgeId, rules } = await seedKnowledge(userA.id, 'EC-2')
+
+    const { error: attachErr } = await admin
+      .from('settlement_knowledge')
+      .insert({ settlement_id: settlementId, knowledge_id: knowledgeId })
+    if (attachErr) throw new Error(`attach knowledge: ${attachErr.message}`)
+
+    // B (collaborator) can SELECT the row with rules.
+    const { data: bRead, error: bErr } = await userB.client
+      .from('knowledge')
+      .select('id, knowledge_name, rules, custom, user_id')
+      .eq('id', knowledgeId)
+      .maybeSingle()
+    expect(bErr).toBeNull()
+    expect(bRead).not.toBeNull()
+    expect(bRead?.rules).toBe(rules)
+    expect(bRead?.custom).toBe(true)
+    expect(bRead?.user_id).toBe(userA.id)
+
+    // B cannot UPDATE the row. The persisted rules must be unchanged.
+    await userB.client
+      .from('knowledge')
+      .update({ rules: 'Collaborator overwrites the lantern' })
+      .eq('id', knowledgeId)
+
+    const { data: persisted } = await admin
+      .from('knowledge')
+      .select('rules')
+      .eq('id', knowledgeId)
+      .single()
+    expect(persisted?.rules).toBe(rules)
+  })
+
+  // ---------------------------------------------------------------------------
+  // EC-3: (EC-2) + A unshares S → B loses access to K.
+  //
+  // Uses its own settlement so unsharing does not bleed into the main
+  // settlement's collaborator state.
+  // ---------------------------------------------------------------------------
+  it('EC-3: collaborator loses SELECT on attached knowledge after the settlement is unshared', async () => {
+    const sId = await seedSettlement(userA.id, 'EC-3 Settlement')
+    await shareSettlement(sId, userB.id, userA.id)
+
+    const { id: knowledgeId } = await seedKnowledge(userA.id, 'EC-3')
+    const { error: attachErr } = await admin
+      .from('settlement_knowledge')
+      .insert({ settlement_id: sId, knowledge_id: knowledgeId })
+    if (attachErr) throw new Error(`attach knowledge: ${attachErr.message}`)
+
+    // Sanity: B sees the row while the share is in place.
+    const { data: beforeUnshare } = await userB.client
+      .from('knowledge')
+      .select('id')
+      .eq('id', knowledgeId)
+      .maybeSingle()
+    expect(beforeUnshare).not.toBeNull()
+
+    // A unshares S.
+    const { error: unshareErr } = await admin
+      .from('settlement_shared_user')
+      .delete()
+      .eq('settlement_id', sId)
+      .eq('shared_user_id', userB.id)
+    if (unshareErr) throw new Error(`unshare: ${unshareErr.message}`)
+
+    // B no longer sees the row through the transitive path.
+    const { data: afterUnshare, error: afterErr } = await userB.client
+      .from('knowledge')
+      .select('id')
+      .eq('id', knowledgeId)
+      .maybeSingle()
+    expect(afterErr).toBeNull()
+    expect(afterUnshare).toBeNull()
+
+    // Row itself is unchanged.
+    const { data: still } = await admin
+      .from('knowledge')
+      .select('id')
+      .eq('id', knowledgeId)
+      .maybeSingle()
+    expect(still).not.toBeNull()
+  })
+
+  // ---------------------------------------------------------------------------
+  // EC-4: (EC-2) + A removes K from S (without deleting K) → B loses access
+  //       to K, since no other settlement attaches it.
+  // ---------------------------------------------------------------------------
+  it('EC-4: collaborator loses SELECT on knowledge after the settlement_knowledge junction is removed', async () => {
+    const { id: knowledgeId } = await seedKnowledge(userA.id, 'EC-4')
+
+    const { data: sj, error: attachErr } = await admin
+      .from('settlement_knowledge')
+      .insert({ settlement_id: settlementId, knowledge_id: knowledgeId })
+      .select('id')
+      .single()
+    if (attachErr || !sj)
+      throw new Error(`attach knowledge: ${attachErr?.message}`)
+
+    // Sanity: B sees the row.
+    const { data: beforeDetach } = await userB.client
+      .from('knowledge')
+      .select('id')
+      .eq('id', knowledgeId)
+      .maybeSingle()
+    expect(beforeDetach).not.toBeNull()
+
+    // A detaches the row from the settlement (without deleting it).
+    const { error: detachErr } = await admin
+      .from('settlement_knowledge')
+      .delete()
+      .eq('id', sj.id)
+    if (detachErr) throw new Error(`detach: ${detachErr.message}`)
+
+    // B no longer sees the row.
+    const { data: afterDetach, error: afterErr } = await userB.client
+      .from('knowledge')
+      .select('id')
+      .eq('id', knowledgeId)
+      .maybeSingle()
+    expect(afterErr).toBeNull()
+    expect(afterDetach).toBeNull()
+
+    // Row itself still exists and is owned by A.
+    const { data: still } = await admin
+      .from('knowledge')
+      .select('id, user_id')
+      .eq('id', knowledgeId)
+      .maybeSingle()
+    expect(still?.user_id).toBe(userA.id)
+  })
+
+  // ---------------------------------------------------------------------------
+  // EC-5: (EC-2) + A deletes K while attached to A's OWN settlement only
+  //       → the BEFORE DELETE trigger allows the delete because every
+  //       referencing settlement belongs to A.
+  // ---------------------------------------------------------------------------
+  it('EC-5: author can delete a custom knowledge when every referencing settlement is their own', async () => {
+    // A's solo settlement (not shared with anyone).
+    const soloSettlementId = await seedSettlement(
+      userA.id,
+      'EC-5 Solo Settlement'
+    )
+
+    const { id: knowledgeId } = await seedKnowledge(userA.id, 'EC-5')
+    const { error: attachErr } = await admin
+      .from('settlement_knowledge')
+      .insert({
+        settlement_id: soloSettlementId,
+        knowledge_id: knowledgeId
+      })
+    if (attachErr) throw new Error(`attach knowledge: ${attachErr.message}`)
+
+    // A deletes the row. The delete-guard trigger should NOT raise.
+    const { error: delErr } = await userA.client
+      .from('knowledge')
+      .delete()
+      .eq('id', knowledgeId)
+    expect(delErr).toBeNull()
+
+    // Row is gone.
+    const { data: gone } = await admin
+      .from('knowledge')
+      .select('id')
+      .eq('id', knowledgeId)
+      .maybeSingle()
+    expect(gone).toBeNull()
+  })
+
+  // ---------------------------------------------------------------------------
+  // EC-6: A shares S with B; B creates own custom disorder D; B attaches D
+  //       to a survivor in S → A can SELECT D's rules. A cannot edit D.
+  // ---------------------------------------------------------------------------
+  it('EC-6: settlement owner can read a collaborator-authored disorder attached via a survivor in the shared settlement', async () => {
+    const survivorId = await seedSurvivor(settlementId)
+    const { id: disorderId, rules } = await seedDisorder(userB.id, 'EC-6')
+
+    const { error: attachErr } = await admin
+      .from('survivor_disorder')
+      .insert({ survivor_id: survivorId, disorder_id: disorderId })
+    if (attachErr) throw new Error(`attach disorder: ${attachErr.message}`)
+
+    // A (owner) reads D's rules through transitive visibility.
+    const { data: aRead, error: aErr } = await userA.client
+      .from('disorder')
+      .select('id, disorder_name, rules, custom, user_id')
+      .eq('id', disorderId)
+      .maybeSingle()
+    expect(aErr).toBeNull()
+    expect(aRead).not.toBeNull()
+    expect(aRead?.rules).toBe(rules)
+    expect(aRead?.custom).toBe(true)
+    expect(aRead?.user_id).toBe(userB.id)
+
+    // A cannot UPDATE the row.
+    await userA.client
+      .from('disorder')
+      .update({ rules: 'Owner overwrites collaborator rules' })
+      .eq('id', disorderId)
+
+    const { data: persisted } = await admin
+      .from('disorder')
+      .select('rules')
+      .eq('id', disorderId)
+      .single()
+    expect(persisted?.rules).toBe(rules)
+  })
+
+  // ---------------------------------------------------------------------------
+  // EC-7: (EC-6) + A removes B from S → A loses access to D's rules text.
+  //
+  // Per `local/sharing-architecture.md` Appendix B, after B is removed
+  // from S the settlement owner A must no longer be able to read the
+  // rules text of the collaborator-authored disorder D, even though the
+  // `survivor_disorder` row remains (it is not cascaded by removing the
+  // collaborator share — only by detaching the disorder or removing the
+  // survivor).
+  //
+  // This is enforced by the author-membership clause added to every
+  // Phase 2 transitive SELECT policy in
+  // `20260523000000_catalog_author_membership_select.sql`: the new
+  // `is_settlement_member(s.id, <catalog>.user_id)` predicate evaluates
+  // to false once B is removed from S, so A's transitive SELECT path on
+  // D collapses. The author SELECT path
+  // (`Allow select for owner and custom`) is unaffected, so B can still
+  // read their own row.
+  // ---------------------------------------------------------------------------
+  it('EC-7: owner loses SELECT on a collaborator-authored disorder after the collaborator is removed from the settlement', async () => {
+    const sId = await seedSettlement(userA.id, 'EC-7 Settlement')
+    await shareSettlement(sId, userB.id, userA.id)
+
+    const survivorId = await seedSurvivor(sId)
+    const { id: disorderId, rules } = await seedDisorder(userB.id, 'EC-7')
+
+    const { error: attachErr } = await admin
+      .from('survivor_disorder')
+      .insert({ survivor_id: survivorId, disorder_id: disorderId })
+    if (attachErr) throw new Error(`attach disorder: ${attachErr.message}`)
+
+    // Sanity: A sees the row while B is still a collaborator.
+    const { data: beforeRemove } = await userA.client
+      .from('disorder')
+      .select('id, rules')
+      .eq('id', disorderId)
+      .maybeSingle()
+    expect(beforeRemove).not.toBeNull()
+    expect(beforeRemove?.rules).toBe(rules)
+
+    // A removes B from S.
+    const { error: unshareErr } = await admin
+      .from('settlement_shared_user')
+      .delete()
+      .eq('settlement_id', sId)
+      .eq('shared_user_id', userB.id)
+    if (unshareErr) throw new Error(`unshare: ${unshareErr.message}`)
+
+    // After the author-membership clause kicks in, A's transitive path
+    // collapses: RLS silently hides the row from A.
+    const { data: afterRemove, error: afterErr } = await userA.client
+      .from('disorder')
+      .select('id, rules')
+      .eq('id', disorderId)
+      .maybeSingle()
+    expect(afterErr).toBeNull()
+    expect(afterRemove).toBeNull()
+
+    // B (the author) can still read their own row via the
+    // `Allow select for owner and custom` policy, which is independent
+    // of settlement membership.
+    const { data: authorStillSees } = await userB.client
+      .from('disorder')
+      .select('id, rules')
+      .eq('id', disorderId)
+      .maybeSingle()
+    expect(authorStillSees).not.toBeNull()
+    expect(authorStillSees?.rules).toBe(rules)
+
+    // The `survivor_disorder` row remains regardless of policy — it is
+    // not cascaded by `settlement_shared_user` deletion.
+    const { data: junctionStill } = await admin
+      .from('survivor_disorder')
+      .select('disorder_id')
+      .eq('survivor_id', survivorId)
+      .eq('disorder_id', disorderId)
+      .maybeSingle()
+    expect(junctionStill).not.toBeNull()
+  })
+
+  // ---------------------------------------------------------------------------
+  // EC-8: (EC-6) + B tries to delete D while D is attached to A's
+  //       settlement → BEFORE DELETE trigger raises with code 0A000 and a
+  //       friendly message naming the blocking settlement.
+  // ---------------------------------------------------------------------------
+  it("EC-8: author cannot delete a custom disorder while it is still attached to another user's settlement", async () => {
+    const survivorId = await seedSurvivor(settlementId)
+    const { id: disorderId } = await seedDisorder(userB.id, 'EC-8')
+
+    const { error: attachErr } = await admin
+      .from('survivor_disorder')
+      .insert({ survivor_id: survivorId, disorder_id: disorderId })
+    if (attachErr) throw new Error(`attach disorder: ${attachErr.message}`)
+
+    // B (author) attempts to delete D. The BEFORE DELETE guard must
+    // raise because A's settlement still references D via the survivor.
+    const { error } = await userB.client
+      .from('disorder')
+      .delete()
+      .eq('id', disorderId)
+
+    expect(error).not.toBeNull()
+    expect(error?.code).toBe('0A000')
+    expect(error?.message).toMatch(/unmake what others rely upon/i)
+    expect(error?.message).toContain('EC-2..EC-8 Test Settlement')
+
+    // The disorder row must still exist.
+    const { data: still } = await admin
+      .from('disorder')
+      .select('id')
+      .eq('id', disorderId)
+      .maybeSingle()
+    expect(still).not.toBeNull()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Realtime: owner edits K's rules; collaborator's subscription receives
+  // the event.
+  //
+  // Skipped per the issue scope ("skipped or marked as e2e"). The
+  // publication-membership lock in `__tests__/integration/realtime-publication.test.ts`
+  // already pins the catalog tables (including `knowledge`) into
+  // `supabase_realtime`. An end-to-end subscription test belongs in a
+  // dedicated e2e harness because it requires the realtime websocket
+  // connection and event polling, which is out of scope for this RLS suite.
+  // ---------------------------------------------------------------------------
+  it.skip('realtime: collaborator subscription receives owner edits to attached knowledge (e2e)', () => {
+    // Intentionally left blank. Tracked in the realtime publication test
+    // and the future end-to-end harness.
+  })
+})

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5006,6 +5006,10 @@ export type Database = {
         Args: { target_settlement: string }
         Returns: boolean
       }
+      is_settlement_member: {
+        Args: { target_settlement: string; target_user: string }
+        Returns: boolean
+      }
       is_settlement_owner: { Args: { record_id: string }; Returns: boolean }
       lookup_user_by_username: { Args: { p_username: string }; Returns: string }
       provision_user_settings_for_oauth: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.26",
+  "version": "0.61.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.26",
+      "version": "0.61.28",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.26",
+  "version": "0.61.28",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260523000000_catalog_author_membership_select.sql
+++ b/supabase/migrations/20260523000000_catalog_author_membership_select.sql
@@ -1,0 +1,520 @@
+--------------------------------------------------------------------------------
+-- Phase 2.5 [E2.12 spillover]: Author-Membership-Bound Transitive SELECT
+--
+-- Tightens every Phase 2 catalog transitive-SELECT policy so that a custom
+-- catalog row is visible through a referencing settlement S only if the
+-- row's author is *currently* a member of S (owner OR a
+-- `settlement_shared_user` collaborator).
+--
+-- Previously the transitive policies only required that the *caller* could
+-- see the referencing junction. Concretely: if collaborator B authored a
+-- custom row, attached it to settlement S owned by A, and was then removed
+-- from S, A retained SELECT on the row even though the architectural
+-- contract in `local/sharing-architecture.md` Appendix B EC-7 explicitly
+-- says A should lose access. The author-membership clause closes that gap.
+--
+-- This migration:
+--
+--   1. Adds a `auth.uid()`-independent helper `is_settlement_member(uuid,
+--      uuid)` mirroring `is_settlement_owner` / `is_settlement_collaborator`
+--      but accepting an explicit target user.
+--   2. Drops and recreates every Phase 2 transitive SELECT policy with the
+--      author-membership clause added.
+--
+-- Author SELECT (`Allow select for owner and custom`) is intentionally NOT
+-- modified — authors always retain full access to their own custom rows
+-- via that companion policy, regardless of their settlement membership.
+--
+-- Child tables that do not carry their own `user_id` column
+-- (`philosophy_rank`, `armor_set_slot`, `quarry_level` family,
+-- `nemesis_level` family) inherit the author check from their parent
+-- catalog row (`philosophy.user_id`, `armor_set.user_id`, `quarry.user_id`,
+-- `nemesis.user_id` respectively).
+--
+-- Citations:
+--   local/sharing-architecture.md Appendix B EC-7
+--   issue #152 ([E2.12]) — gap discovered while writing the EC-2..EC-8 lock
+--   supabase/migrations/20260512000000_catalog_visibility_via_settlement.sql
+--   supabase/migrations/20260514000000_catalog_transitive_select.sql
+--   supabase/migrations/20260515000000_catalog_transitive_via_survivor.sql
+--   supabase/migrations/20260516000000_catalog_transitive_hunt_showdown.sql
+--   supabase/migrations/20260324185335_fix_shared_user_rls_recursion.sql
+--     (is_settlement_owner)
+--   supabase/migrations/20260508000001_is_settlement_collaborator.sql
+--------------------------------------------------------------------------------
+--
+-- 1. Helper: is_settlement_member(settlement_id, user_id)
+--
+-- SECURITY DEFINER predicate that returns true when `target_user` either
+-- owns the given settlement or is listed as a collaborator on it. Distinct
+-- from `is_settlement_collaborator(uuid)` which always uses `auth.uid()`;
+-- this helper takes an explicit user id so transitive policies can check
+-- the *author's* membership (rather than the caller's).
+--
+-- A `target_user IS NULL` short-circuits to false so that non-custom rows
+-- (which have NULL `user_id`) never match — those are visible via the
+-- companion `Allow select for authenticated and non-custom` policy.
+create or replace function is_settlement_member(target_settlement uuid, target_user uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select target_user is not null
+  and (
+    exists (
+      select 1
+      from public.settlement
+      where id = target_settlement
+        and user_id = target_user
+    )
+    or exists (
+      select 1
+      from public.settlement_shared_user
+      where settlement_id = target_settlement
+        and shared_user_id = target_user
+    )
+  );
+$$;
+revoke all on function public.is_settlement_member(uuid, uuid)
+from public;
+revoke execute on function public.is_settlement_member(uuid, uuid)
+from anon;
+grant execute on function public.is_settlement_member(uuid, uuid) to authenticated;
+--
+-- 2. Settlement-attached catalogs (rewrite the implicit-junction-RLS form
+--    from 20260512000000_catalog_visibility_via_settlement.sql to an
+--    explicit chain that reaches `settlement` so the author-membership
+--    check can apply).
+--
+do $$
+declare entry text [];
+catalogs text [] [] := array [
+    array ['knowledge', 'settlement_knowledge', 'knowledge_id'],
+array ['philosophy', 'settlement_philosophy', 'philosophy_id'],
+array ['gear', 'settlement_gear', 'gear_id'],
+array ['innovation', 'settlement_innovation', 'innovation_id'],
+array ['pattern', 'settlement_pattern', 'pattern_id'],
+array ['seed_pattern', 'settlement_seed_pattern', 'seed_pattern_id'],
+array ['collective_cognition_reward', 'settlement_collective_cognition_reward', 'collective_cognition_reward_id'],
+array ['location', 'settlement_location', 'location_id'],
+array ['milestone', 'settlement_milestone', 'milestone_id'],
+array ['principle', 'settlement_principle', 'principle_id'],
+array ['resource', 'settlement_resource', 'resource_id'],
+array ['quarry', 'settlement_quarry', 'quarry_id'],
+array ['nemesis', 'settlement_nemesis', 'nemesis_id'] ];
+begin foreach entry slice 1 in array catalogs loop execute format(
+  'drop policy if exists "Allow select via settlement membership" on %I',
+  entry [1]
+);
+execute format(
+  $f$ create policy "Allow select via settlement membership" on %1$I for
+  select to authenticated using (
+      custom
+      and exists (
+        select 1
+        from %2$I sj
+          join settlement s on s.id = sj.settlement_id
+        where sj.%3$I = %1$I.id
+          and (
+            is_settlement_owner(s.id)
+            or is_settlement_collaborator(s.id)
+          )
+          and is_settlement_member(s.id, %1$I.user_id)
+      )
+    ) $f$,
+    entry [1],
+    entry [2],
+    entry [3]
+);
+end loop;
+end $$;
+--
+-- 3. Survivor-junction catalogs (rewrite the implicit-junction-RLS form
+--    from 20260514000000_catalog_transitive_select.sql to an explicit
+--    chain through survivor -> settlement).
+--
+do $$
+declare entry text [];
+catalogs text [] [] := array [
+    array ['disorder', 'survivor_disorder', 'disorder_id'],
+array ['fighting_art', 'survivor_fighting_art', 'fighting_art_id'],
+array ['secret_fighting_art', 'survivor_secret_fighting_art', 'secret_fighting_art_id'],
+array ['ability_impairment', 'survivor_ability_impairment', 'ability_impairment_id'] ];
+begin foreach entry slice 1 in array catalogs loop execute format(
+  'drop policy if exists "Allow select via settlement membership" on %I',
+  entry [1]
+);
+execute format(
+  $f$ create policy "Allow select via settlement membership" on %1$I for
+  select to authenticated using (
+      custom
+      and exists (
+        select 1
+        from %2$I sj
+          join survivor sv on sv.id = sj.survivor_id
+          join settlement s on s.id = sv.settlement_id
+        where sj.%3$I = %1$I.id
+          and (
+            is_settlement_owner(s.id)
+            or is_settlement_collaborator(s.id)
+          )
+          and is_settlement_member(s.id, %1$I.user_id)
+      )
+    ) $f$,
+    entry [1],
+    entry [2],
+    entry [3]
+);
+end loop;
+end $$;
+--
+-- 4. Survivor-column catalogs (rewrite from
+--    20260515000000_catalog_transitive_via_survivor.sql to add the
+--    author-membership clause).
+--
+drop policy if exists "Allow select via survivor" on weapon_type;
+create policy "Allow select via survivor" on weapon_type for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor sv
+        join settlement s on s.id = sv.settlement_id
+      where sv.weapon_type_id = weapon_type.id
+        and (
+          s.user_id = (
+            select auth.uid()
+          )
+          or is_settlement_collaborator(s.id)
+        )
+        and is_settlement_member(s.id, weapon_type.user_id)
+    )
+  );
+drop policy if exists "Allow select via survivor" on philosophy;
+create policy "Allow select via survivor" on philosophy for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor sv
+        join settlement s on s.id = sv.settlement_id
+      where sv.philosophy_id = philosophy.id
+        and (
+          s.user_id = (
+            select auth.uid()
+          )
+          or is_settlement_collaborator(s.id)
+        )
+        and is_settlement_member(s.id, philosophy.user_id)
+    )
+  );
+drop policy if exists "Allow select via survivor" on neurosis;
+create policy "Allow select via survivor" on neurosis for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor sv
+        join settlement s on s.id = sv.settlement_id
+      where sv.neurosis_id = neurosis.id
+        and (
+          s.user_id = (
+            select auth.uid()
+          )
+          or is_settlement_collaborator(s.id)
+        )
+        and is_settlement_member(s.id, neurosis.user_id)
+    )
+  );
+drop policy if exists "Allow select via survivor" on knowledge;
+create policy "Allow select via survivor" on knowledge for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from survivor sv
+        join settlement s on s.id = sv.settlement_id
+      where (
+          sv.knowledge_1_id = knowledge.id
+          or sv.knowledge_2_id = knowledge.id
+          or sv.tenet_knowledge_id = knowledge.id
+        )
+        and (
+          s.user_id = (
+            select auth.uid()
+          )
+          or is_settlement_collaborator(s.id)
+        )
+        and is_settlement_member(s.id, knowledge.user_id)
+    )
+  );
+-- `philosophy_rank` inherits the author check from its parent philosophy
+-- (philosophy_rank has no `user_id` column).
+drop policy if exists "Allow select via survivor" on philosophy_rank;
+create policy "Allow select via survivor" on philosophy_rank for
+select to authenticated using (
+    exists (
+      select 1
+      from philosophy p
+        join survivor sv on sv.philosophy_id = p.id
+        join settlement s on s.id = sv.settlement_id
+      where p.id = philosophy_rank.philosophy_id
+        and p.custom
+        and (
+          s.user_id = (
+            select auth.uid()
+          )
+          or is_settlement_collaborator(s.id)
+        )
+        and is_settlement_member(s.id, p.user_id)
+    )
+  );
+--
+-- 5. Hunt / showdown / armor / quarry-level / nemesis-level catalogs
+--    (rewrite from 20260516000000_catalog_transitive_hunt_showdown.sql).
+--
+-- 5a. `trait` — author-membership applied to each OR branch.
+drop policy if exists "Allow select via hunt/showdown/quarry/nemesis" on trait;
+create policy "Allow select via hunt/showdown/quarry/nemesis" on trait for
+select to authenticated using (
+    custom
+    and (
+      exists (
+        select 1
+        from hunt_monster_trait hmt
+          join hunt_monster hm on hm.id = hmt.hunt_monster_id
+        where hmt.trait_id = trait.id
+          and (
+            is_settlement_owner(hm.settlement_id)
+            or is_settlement_collaborator(hm.settlement_id)
+          )
+          and is_settlement_member(hm.settlement_id, trait.user_id)
+      )
+      or exists (
+        select 1
+        from showdown_monster_trait smt
+          join showdown_monster sm on sm.id = smt.showdown_monster_id
+        where smt.trait_id = trait.id
+          and (
+            is_settlement_owner(sm.settlement_id)
+            or is_settlement_collaborator(sm.settlement_id)
+          )
+          and is_settlement_member(sm.settlement_id, trait.user_id)
+      )
+      or exists (
+        select 1
+        from quarry_level_trait qlt
+          join quarry_level ql on ql.id = qlt.quarry_level_id
+          join settlement_quarry sq on sq.quarry_id = ql.quarry_id
+        where qlt.trait_id = trait.id
+          and (
+            is_settlement_owner(sq.settlement_id)
+            or is_settlement_collaborator(sq.settlement_id)
+          )
+          and is_settlement_member(sq.settlement_id, trait.user_id)
+      )
+      or exists (
+        select 1
+        from nemesis_level_trait nlt
+          join nemesis_level nl on nl.id = nlt.nemesis_level_id
+          join settlement_nemesis sn on sn.nemesis_id = nl.nemesis_id
+        where nlt.trait_id = trait.id
+          and (
+            is_settlement_owner(sn.settlement_id)
+            or is_settlement_collaborator(sn.settlement_id)
+          )
+          and is_settlement_member(sn.settlement_id, trait.user_id)
+      )
+    )
+  );
+-- 5b. `mood` — symmetric to trait.
+drop policy if exists "Allow select via hunt/showdown/quarry/nemesis" on mood;
+create policy "Allow select via hunt/showdown/quarry/nemesis" on mood for
+select to authenticated using (
+    custom
+    and (
+      exists (
+        select 1
+        from hunt_monster_mood hmm
+          join hunt_monster hm on hm.id = hmm.hunt_monster_id
+        where hmm.mood_id = mood.id
+          and (
+            is_settlement_owner(hm.settlement_id)
+            or is_settlement_collaborator(hm.settlement_id)
+          )
+          and is_settlement_member(hm.settlement_id, mood.user_id)
+      )
+      or exists (
+        select 1
+        from showdown_monster_mood smm
+          join showdown_monster sm on sm.id = smm.showdown_monster_id
+        where smm.mood_id = mood.id
+          and (
+            is_settlement_owner(sm.settlement_id)
+            or is_settlement_collaborator(sm.settlement_id)
+          )
+          and is_settlement_member(sm.settlement_id, mood.user_id)
+      )
+      or exists (
+        select 1
+        from quarry_level_mood qlm
+          join quarry_level ql on ql.id = qlm.quarry_level_id
+          join settlement_quarry sq on sq.quarry_id = ql.quarry_id
+        where qlm.mood_id = mood.id
+          and (
+            is_settlement_owner(sq.settlement_id)
+            or is_settlement_collaborator(sq.settlement_id)
+          )
+          and is_settlement_member(sq.settlement_id, mood.user_id)
+      )
+      or exists (
+        select 1
+        from nemesis_level_mood nlm
+          join nemesis_level nl on nl.id = nlm.nemesis_level_id
+          join settlement_nemesis sn on sn.nemesis_id = nl.nemesis_id
+        where nlm.mood_id = mood.id
+          and (
+            is_settlement_owner(sn.settlement_id)
+            or is_settlement_collaborator(sn.settlement_id)
+          )
+          and is_settlement_member(sn.settlement_id, mood.user_id)
+      )
+    )
+  );
+-- 5c. `armor_set` — author-membership via gear_grid -> survivor ->
+--      settlement chain.
+drop policy if exists "Allow select via gear_grid" on armor_set;
+create policy "Allow select via gear_grid" on armor_set for
+select to authenticated using (
+    custom
+    and exists (
+      select 1
+      from gear_grid gg
+        join survivor sv on sv.id = gg.survivor_id
+      where gg.selected_armor_set_id = armor_set.id
+        and (
+          is_settlement_owner(sv.settlement_id)
+          or is_settlement_collaborator(sv.settlement_id)
+        )
+        and is_settlement_member(sv.settlement_id, armor_set.user_id)
+    )
+  );
+-- 5d. `armor_set_slot` — inherits author check from parent armor_set.
+drop policy if exists "Allow select via gear_grid" on armor_set_slot;
+create policy "Allow select via gear_grid" on armor_set_slot for
+select to authenticated using (
+    exists (
+      select 1
+      from armor_set a
+        join gear_grid gg on gg.selected_armor_set_id = a.id
+        join survivor sv on sv.id = gg.survivor_id
+      where a.id = armor_set_slot.armor_set_id
+        and a.custom
+        and (
+          is_settlement_owner(sv.settlement_id)
+          or is_settlement_collaborator(sv.settlement_id)
+        )
+        and is_settlement_member(sv.settlement_id, a.user_id)
+    )
+  );
+-- 5e. `quarry_level` / `nemesis_level` — inherit author check from parent
+--      quarry / nemesis.
+drop policy if exists "Allow select via settlement membership" on quarry_level;
+create policy "Allow select via settlement membership" on quarry_level for
+select to authenticated using (
+    exists (
+      select 1
+      from quarry q
+        join settlement_quarry sq on sq.quarry_id = q.id
+      where q.id = quarry_level.quarry_id
+        and q.custom
+        and (
+          is_settlement_owner(sq.settlement_id)
+          or is_settlement_collaborator(sq.settlement_id)
+        )
+        and is_settlement_member(sq.settlement_id, q.user_id)
+    )
+  );
+drop policy if exists "Allow select via settlement membership" on nemesis_level;
+create policy "Allow select via settlement membership" on nemesis_level for
+select to authenticated using (
+    exists (
+      select 1
+      from nemesis n
+        join settlement_nemesis sn on sn.nemesis_id = n.id
+      where n.id = nemesis_level.nemesis_id
+        and n.custom
+        and (
+          is_settlement_owner(sn.settlement_id)
+          or is_settlement_collaborator(sn.settlement_id)
+        )
+        and is_settlement_member(sn.settlement_id, n.user_id)
+    )
+  );
+-- 5f. `quarry_level_trait` / `quarry_level_mood` / `nemesis_level_trait` /
+--      `nemesis_level_mood` — parent quarry / nemesis author check.
+drop policy if exists "Allow select via settlement membership" on quarry_level_trait;
+create policy "Allow select via settlement membership" on quarry_level_trait for
+select to authenticated using (
+    exists (
+      select 1
+      from quarry_level ql
+        join quarry q on q.id = ql.quarry_id
+        join settlement_quarry sq on sq.quarry_id = q.id
+      where ql.id = quarry_level_trait.quarry_level_id
+        and q.custom
+        and (
+          is_settlement_owner(sq.settlement_id)
+          or is_settlement_collaborator(sq.settlement_id)
+        )
+        and is_settlement_member(sq.settlement_id, q.user_id)
+    )
+  );
+drop policy if exists "Allow select via settlement membership" on quarry_level_mood;
+create policy "Allow select via settlement membership" on quarry_level_mood for
+select to authenticated using (
+    exists (
+      select 1
+      from quarry_level ql
+        join quarry q on q.id = ql.quarry_id
+        join settlement_quarry sq on sq.quarry_id = q.id
+      where ql.id = quarry_level_mood.quarry_level_id
+        and q.custom
+        and (
+          is_settlement_owner(sq.settlement_id)
+          or is_settlement_collaborator(sq.settlement_id)
+        )
+        and is_settlement_member(sq.settlement_id, q.user_id)
+    )
+  );
+drop policy if exists "Allow select via settlement membership" on nemesis_level_trait;
+create policy "Allow select via settlement membership" on nemesis_level_trait for
+select to authenticated using (
+    exists (
+      select 1
+      from nemesis_level nl
+        join nemesis n on n.id = nl.nemesis_id
+        join settlement_nemesis sn on sn.nemesis_id = n.id
+      where nl.id = nemesis_level_trait.nemesis_level_id
+        and n.custom
+        and (
+          is_settlement_owner(sn.settlement_id)
+          or is_settlement_collaborator(sn.settlement_id)
+        )
+        and is_settlement_member(sn.settlement_id, n.user_id)
+    )
+  );
+drop policy if exists "Allow select via settlement membership" on nemesis_level_mood;
+create policy "Allow select via settlement membership" on nemesis_level_mood for
+select to authenticated using (
+    exists (
+      select 1
+      from nemesis_level nl
+        join nemesis n on n.id = nl.nemesis_id
+        join settlement_nemesis sn on sn.nemesis_id = n.id
+      where nl.id = nemesis_level_mood.nemesis_level_id
+        and n.custom
+        and (
+          is_settlement_owner(sn.settlement_id)
+          or is_settlement_collaborator(sn.settlement_id)
+        )
+        and is_settlement_member(sn.settlement_id, n.user_id)
+    )
+  );


### PR DESCRIPTION
## Summary

Lands the canonical EC-2..EC-8 narrative lock requested by issue #152 in
`__tests__/integration/rls/catalog-transitive.test.ts`, and — discovered
while implementing EC-7 — closes the architectural gap between
`local/sharing-architecture.md` Appendix B and the as-built Phase 2 RLS by
adding an author-membership clause to every transitive SELECT policy.

Closes #152.

## Test work (original [E2.12] scope)

`__tests__/integration/rls/catalog-transitive.test.ts` is the canonical
EC-2..EC-8 narrative lock. It exercises the catalog-sharing edge cases in
sequence against the live RLS layer using the standard
`__tests__/integration/helpers/supabase` harness:

| Case  | Scenario                                                                                                                                       |
| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
| EC-2  | Collaborator can read author-attached custom knowledge (rules included) but cannot edit it.                                                    |
| EC-3  | Collaborator loses SELECT on attached knowledge after the settlement is unshared.                                                              |
| EC-4  | Collaborator loses SELECT on knowledge after the `settlement_knowledge` junction is removed.                                                   |
| EC-5  | Author can delete a custom knowledge when every referencing settlement is their own (no trigger raise).                                        |
| EC-6  | Settlement owner can read a collaborator-authored disorder attached via a survivor in the shared settlement, and cannot edit it.               |
| EC-7  | Owner loses SELECT on a collaborator-authored disorder after the collaborator is removed from the settlement (author still sees their own row). |
| EC-8  | Author cannot delete a custom disorder while it is still attached to another user's settlement (BEFORE DELETE trigger raises `0A000` with the friendly message naming the blocking settlement). |

A skipped placeholder for the realtime e2e variant is left in place; the
realtime publication assertion remains in `realtime-publication.test.ts`.

Setup uses two test users (owner A + collaborator B) and a primary shared
settlement; scenarios that mutate the share / detach state (EC-3, EC-5,
EC-7) seed their own fresh settlement so they remain independent.

Other transitive chains (survivor column, hunt/showdown junctions,
gear_grid armor selection) continue to be pinned by sibling files
(`catalog-transitive-via-survivor.test.ts`,
`catalog-transitive-hunt-showdown.test.ts`,
`catalog-visibility-via-settlement.test.ts`, `custom-content.test.ts`,
`catalog-delete-guard.test.ts`,
`catalog-owner-cannot-delete-shared.test.ts`).

## Discovery: author-membership gap (in-PR fix)

While implementing EC-7 I found that the as-built Phase 2 transitive
SELECT policies do not enforce the architectural invariant in
`local/sharing-architecture.md` Appendix B: every transitive policy only
required the *caller* to see the referencing junction, never the
*author's* membership in the referencing settlement. The concrete
symptom: if collaborator B authors a custom row, attaches it to
settlement S owned by A, and is then removed from S, A retained SELECT
on the row indefinitely.

I surveyed all four Phase 2 transitive patterns and confirmed the gap is
universal — present in every transitive SELECT policy across ~30 catalog
tables. Per direction in the issue thread, the fix is included in this
PR rather than spun off, since the EC-7 lock is meaningless without it.

### Migration

`supabase/migrations/20260523000000_catalog_author_membership_select.sql`:

1. **New helper** `is_settlement_member(target_settlement uuid, target_user uuid)`
   — an `auth.uid()`-independent companion to `is_settlement_owner` /
   `is_settlement_collaborator` that takes an explicit user id and
   returns true when that user is the owner or a
   `settlement_shared_user` member of the given settlement.
2. **Tightened policies**: drops and recreates every Phase 2 transitive
   SELECT policy with `is_settlement_member(s.id, <catalog>.user_id)`
   added as an additional `AND` clause. Coverage spans all four chain
   patterns:
   - Settlement-attached (13 catalogs): `knowledge`, `philosophy`,
     `gear`, `innovation`, `pattern`, `seed_pattern`,
     `collective_cognition_reward`, `location`, `milestone`, `principle`,
     `resource`, `quarry`, `nemesis`. The previous implicit-junction-RLS
     form (from `20260512000000_catalog_visibility_via_settlement.sql`)
     is rewritten to an explicit chain through `settlement_<x>` →
     `settlement` so the author-membership check can apply.
   - Survivor-junction (4 catalogs): `disorder`, `fighting_art`,
     `secret_fighting_art`, `ability_impairment`. Same implicit→explicit
     rewrite of the form from
     `20260514000000_catalog_transitive_select.sql`, joining through
     `survivor` to reach `settlement`.
   - Survivor-column (5 catalogs): `weapon_type`, `philosophy`,
     `neurosis`, `knowledge`, `philosophy_rank`. Author-membership clause
     added to the existing explicit chain from
     `20260515000000_catalog_transitive_via_survivor.sql`.
   - Hunt / showdown / armor / quarry-level / nemesis-level (~10
     catalogs / junctions): `trait`, `mood`, `armor_set`,
     `armor_set_slot`, `quarry_level`, `nemesis_level`,
     `quarry_level_trait`, `quarry_level_mood`, `nemesis_level_trait`,
     `nemesis_level_mood`. Clause added to every OR branch of `trait` /
     `mood` (hunt / showdown / quarry-level / nemesis-level).

Author SELECT (`Allow select for owner and custom`) is **intentionally
unchanged**: an author always retains full access to their own custom
rows regardless of their settlement membership, so collaborators who
leave a settlement keep visibility of their own contributions.

Child tables that do not carry their own `user_id`
(`philosophy_rank`, `armor_set_slot`, `quarry_level` family,
`nemesis_level` family) inherit the author check from their parent
catalog row (`philosophy.user_id`, `armor_set.user_id`,
`quarry.user_id`, `nemesis.user_id` respectively).

## Verification

- `npm run integration-test`: **611 passed, 1 skipped (28 files)**.
  - `catalog-transitive.test.ts`: 7 passed, 1 skipped (realtime
    placeholder).
  - All sibling RLS tests
    (`catalog-visibility-via-settlement.test.ts`,
    `catalog-transitive-via-survivor.test.ts`,
    `catalog-transitive-hunt-showdown.test.ts`,
    `catalog-transitive-select.test.ts`, `custom-content.test.ts`,
    `catalog-delete-guard.test.ts`,
    `catalog-owner-cannot-delete-shared.test.ts`, etc.) stay green —
    their scenarios all keep the author as a current member, so the new
    clause is satisfied and no assertions had to change.

## Files changed

- `__tests__/integration/rls/catalog-transitive.test.ts` (new)
- `supabase/migrations/20260523000000_catalog_author_membership_select.sql` (new)
- `lib/database.types.ts` (regenerated — adds `is_settlement_member` signature)
- `package.json` / `package-lock.json` — version bump to `0.61.28`

## Dependencies

No new runtime or dev dependencies.

## Risk / follow-ups

- The migration only **tightens** SELECT; it cannot grant access that did
  not exist before, so the surface for regressions is "owner sees a row
  they used to". Existing tests covering catalog visibility for active
  collaborators continue to pass.
- The realtime e2e variant of EC-2 remains a `.skip` placeholder; if a
  follow-up issue wires up live websocket assertions, the EC-2 narrative
  is already in place to expand into.
