### PR TITLE
perf(unshare-blockers): document per-table UNION ALL retention (#154)

### DIFF
--- a/__tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts
+++ b/__tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts
@@ -107,7 +107,7 @@ function psql(sql: string): string {
  * Run SQL and capture rows as `|`-separated CSV (no header, no padding).
  *
  * @param sql SQL Query
- * @returns Pipe-Separated Rows
+ * @returns Pipe-separated rows
  */
 function psqlRows(sql: string): string[][] {
   const out = execFileSync(

--- a/__tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts
+++ b/__tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts
@@ -107,7 +107,7 @@ function psql(sql: string): string {
  * Run SQL and capture rows as `|`-separated CSV (no header, no padding).
  *
  * @param sql SQL Query
- * @returns Tab-Separated Rows
+ * @returns Pipe-Separated Rows
  */
 function psqlRows(sql: string): string[][] {
   const out = execFileSync(

--- a/__tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts
+++ b/__tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts
@@ -1,0 +1,428 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  shareSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+
+/**
+ * Benchmark — `get_unshare_blockers` V1 vs V2 (issue #154)
+ *
+ * Opt-in. Skipped unless `RUN_BENCHMARK=1` is exported. Standard
+ * integration runs (`npm run integration-test`) silently bypass this file.
+ *
+ * Invocation:
+ *   RUN_BENCHMARK=1 ./scripts/integration.sh \
+ *     __tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts
+ *
+ * What it does:
+ *   1. Seeds a realistic workload: one target settlement with 100 custom
+ *      blocker attachments authored by a "target" collaborator, plus
+ *      negative-noise rows (stranger-authored, stock, unattached) and 20
+ *      unrelated settlements each carrying 10 attachments. The unrelated
+ *      settlements are the population the V1 per-branch
+ *      `s.user_id = auth.uid()` join has to scan; without them the
+ *      planner trivially seeks the single target row and the comparison
+ *      degenerates.
+ *   2. Installs the candidate V2 sibling function from
+ *      `scripts/benchmark-unshare-blockers/get_unshare_blockers_v2.sql`.
+ *   3. Asserts correctness: both functions, called via psql with the
+ *      owner's JWT claim, must return byte-identical row sets.
+ *   4. Runs `EXPLAIN (ANALYZE, BUFFERS)` against each function 10 times
+ *      (after 3 warmup runs each), parses out planning + execution time,
+ *      reports median / min / max in a markdown table.
+ *   5. Tears down: drops V2, deletes the test users (cascades to
+ *      settlements + attachments).
+ *
+ * All SQL goes through `docker exec supabase_db_kdm-app psql` to avoid
+ * PostgREST round-trip overhead (5–15ms) masking sub-millisecond
+ * planner differences.
+ */
+
+const RUN = process.env.RUN_BENCHMARK === '1'
+const CONTAINER = 'supabase_db_kdm-app'
+
+const V2_SQL_PATH = resolve(
+  fileURLToPath(import.meta.url),
+  '../../../../scripts/benchmark-unshare-blockers/get_unshare_blockers_v2.sql'
+)
+
+// Workload sizing. 4 branches × 25 = 100 expected blocker rows.
+const ATTACHMENTS_PER_BRANCH = 25
+const NOISE_STRANGER_PER_BRANCH = 5
+const NOISE_STOCK_PER_BRANCH = 5
+const NOISE_SETTLEMENTS = 20
+const NOISE_ROWS_PER_SETTLEMENT = 10
+const EXPECTED_BLOCKER_ROWS = ATTACHMENTS_PER_BRANCH * 4
+
+// Benchmark sample sizes.
+const WARMUP_RUNS = 3
+const MEASURE_RUNS = 10
+
+/**
+ * Run SQL inside the supabase_db container via docker exec.
+ *
+ * Returns raw stdout. Uses `psql -X -q` (no startup file, quiet) so the
+ * caller can parse the body without noise.
+ *
+ * @param sql SQL Script
+ * @returns Stdout
+ */
+function psql(sql: string): string {
+  try {
+    return execFileSync(
+      'docker',
+      [
+        'exec',
+        '-i',
+        CONTAINER,
+        'psql',
+        '-U',
+        'postgres',
+        '-d',
+        'postgres',
+        '-X',
+        '-q'
+      ],
+      { encoding: 'utf8', input: sql }
+    )
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; message: string }
+    throw new Error(
+      `psql failed:\n--- stdout ---\n${e.stdout ?? ''}\n--- stderr ---\n${
+        e.stderr ?? ''
+      }\n--- error ---\n${e.message}`
+    )
+  }
+}
+
+/**
+ * Run SQL and capture rows as `|`-separated CSV (no header, no padding).
+ *
+ * @param sql SQL Query
+ * @returns Tab-Separated Rows
+ */
+function psqlRows(sql: string): string[][] {
+  const out = execFileSync(
+    'docker',
+    [
+      'exec',
+      '-i',
+      CONTAINER,
+      'psql',
+      '-U',
+      'postgres',
+      '-d',
+      'postgres',
+      '-X',
+      '-A',
+      '-t',
+      '-q',
+      '-F',
+      '|'
+    ],
+    { encoding: 'utf8', input: sql }
+  )
+  return out
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => line.split('|'))
+}
+
+/**
+ * Run EXPLAIN (ANALYZE, BUFFERS) against a function call as the owner.
+ *
+ * Wraps in a transaction so we can set `request.jwt.claim.sub` locally;
+ * the analyze rolls back so repeated runs don't accumulate side effects
+ * (there shouldn't be any — the function is `stable` — but defensive).
+ *
+ * @param fnName Function Name (`get_unshare_blockers` or `_v2`)
+ * @param ownerId Owner User ID
+ * @param settlementId Settlement ID
+ * @param collabId Collaborator User ID
+ * @returns Planning + Execution Time (ms)
+ */
+function explainAnalyze(
+  fnName: string,
+  ownerId: string,
+  settlementId: string,
+  collabId: string
+): { planning: number; execution: number } {
+  const sql = `
+    begin;
+    set local "request.jwt.claim.sub" = '${ownerId}';
+    explain (analyze, buffers, timing on)
+      select * from public.${fnName}('${settlementId}'::uuid, '${collabId}'::uuid);
+    rollback;
+  `
+  const out = psql(sql)
+  const planning = parseFloat(
+    out.match(/Planning Time:\s+([\d.]+)\s*ms/)?.[1] ?? 'NaN'
+  )
+  const execution = parseFloat(
+    out.match(/Execution Time:\s+([\d.]+)\s*ms/)?.[1] ?? 'NaN'
+  )
+  if (Number.isNaN(planning) || Number.isNaN(execution)) {
+    throw new Error(`Failed to parse EXPLAIN output for ${fnName}:\n${out}`)
+  }
+  return { planning, execution }
+}
+
+/**
+ * Median Of Numeric Sample
+ *
+ * @param values Sample Values
+ * @returns Median
+ */
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid]
+}
+
+describe.runIf(RUN)('Benchmark: get_unshare_blockers V1 vs V2', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let settlementId: string
+  const noiseUsers: TestUser[] = []
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+
+    settlementId = await seedSettlement(owner.id, 'Bench Settlement')
+    await shareSettlement(settlementId, collaborator.id, owner.id)
+
+    // 20 noise users + their own settlements. Each gets 10 custom
+    // attachments authored by themselves so the planner's per-branch
+    // join-to-settlement isn't trivially a single-row lookup.
+    for (let i = 0; i < NOISE_SETTLEMENTS; i++) {
+      const user = await createTestUser()
+      noiseUsers.push(user)
+      const sid = await seedSettlement(user.id, `Bench Noise ${i}`)
+      // Seed noise attachments via raw SQL — faster than 10 HTTP calls.
+      const perBranch = Math.ceil(NOISE_ROWS_PER_SETTLEMENT / 4)
+      psql(`
+        with k as (
+          insert into public.knowledge (knowledge_name, custom, user_id)
+          select 'noise-k-${i}-' || g, true, '${user.id}'::uuid
+          from generate_series(1, ${perBranch}) g
+          returning id
+        ),
+        ak as (
+          insert into public.settlement_knowledge (settlement_id, knowledge_id)
+          select '${sid}'::uuid, id from k
+        ),
+        g as (
+          insert into public.gear (gear_name, custom, user_id)
+          select 'noise-g-${i}-' || g2, true, '${user.id}'::uuid
+          from generate_series(1, ${perBranch}) g2
+          returning id
+        ),
+        ag as (
+          insert into public.settlement_gear (settlement_id, gear_id, quantity)
+          select '${sid}'::uuid, id, 1 from g
+        ),
+        q as (
+          insert into public.quarry (monster_name, node, custom, user_id)
+          select 'noise-q-${i}-' || g3, 'NQ1'::public.monster_node, true, '${user.id}'::uuid
+          from generate_series(1, ${perBranch}) g3
+          returning id
+        ),
+        aq as (
+          insert into public.settlement_quarry (settlement_id, quarry_id)
+          select '${sid}'::uuid, id from q
+        ),
+        n as (
+          insert into public.nemesis (monster_name, node, custom, user_id)
+          select 'noise-n-${i}-' || g4, 'NN1'::public.monster_node, true, '${user.id}'::uuid
+          from generate_series(1, ${perBranch}) g4
+          returning id
+        )
+        insert into public.settlement_nemesis (settlement_id, nemesis_id)
+        select '${sid}'::uuid, id from n;
+      `)
+    }
+
+    // Target settlement attachments. 25 per branch, authored by `collaborator`.
+    psql(`
+      with k as (
+        insert into public.knowledge (knowledge_name, custom, user_id)
+        select 'target-k-' || g, true, '${collaborator.id}'::uuid
+        from generate_series(1, ${ATTACHMENTS_PER_BRANCH}) g
+        returning id
+      ),
+      ak as (
+        insert into public.settlement_knowledge (settlement_id, knowledge_id)
+        select '${settlementId}'::uuid, id from k
+      ),
+      g as (
+        insert into public.gear (gear_name, custom, user_id)
+        select 'target-g-' || g2, true, '${collaborator.id}'::uuid
+        from generate_series(1, ${ATTACHMENTS_PER_BRANCH}) g2
+        returning id
+      ),
+      ag as (
+        insert into public.settlement_gear (settlement_id, gear_id, quantity)
+        select '${settlementId}'::uuid, id, 1 from g
+      ),
+      q as (
+        insert into public.quarry (monster_name, node, custom, user_id)
+        select 'target-q-' || g3, 'NQ1'::public.monster_node, true, '${collaborator.id}'::uuid
+        from generate_series(1, ${ATTACHMENTS_PER_BRANCH}) g3
+        returning id
+      ),
+      aq as (
+        insert into public.settlement_quarry (settlement_id, quarry_id)
+        select '${settlementId}'::uuid, id from q
+      ),
+      n as (
+        insert into public.nemesis (monster_name, node, custom, user_id)
+        select 'target-n-' || g4, 'NN1'::public.monster_node, true, '${collaborator.id}'::uuid
+        from generate_series(1, ${ATTACHMENTS_PER_BRANCH}) g4
+        returning id
+      )
+      insert into public.settlement_nemesis (settlement_id, nemesis_id)
+      select '${settlementId}'::uuid, id from n;
+    `)
+
+    // Negative-noise: stranger-authored AND stock rows attached to the
+    // target settlement. Both must be filtered out by V1 and V2.
+    psql(`
+      with sk as (
+        insert into public.knowledge (knowledge_name, custom, user_id)
+        select 'stranger-k-' || g, true, '${stranger.id}'::uuid
+        from generate_series(1, ${NOISE_STRANGER_PER_BRANCH}) g
+        returning id
+      ),
+      ask as (
+        insert into public.settlement_knowledge (settlement_id, knowledge_id)
+        select '${settlementId}'::uuid, id from sk
+      ),
+      ck as (
+        insert into public.knowledge (knowledge_name, custom, user_id)
+        select 'stock-k-' || g2, false, '${collaborator.id}'::uuid
+        from generate_series(1, ${NOISE_STOCK_PER_BRANCH}) g2
+        returning id
+      )
+      insert into public.settlement_knowledge (settlement_id, knowledge_id)
+      select '${settlementId}'::uuid, id from ck;
+    `)
+
+    // Install V2.
+    const v2Sql = readFileSync(V2_SQL_PATH, 'utf8')
+    psql(v2Sql)
+
+    // Refresh planner statistics so EXPLAIN reflects real selectivity.
+    psql(`analyze;`)
+  }, 180_000)
+
+  afterAll(async () => {
+    try {
+      psql(
+        `drop function if exists public.get_unshare_blockers_v2(uuid, uuid);`
+      )
+    } catch {
+      // Drop failures shouldn't block user cleanup.
+    }
+    const ids = [
+      owner?.id,
+      collaborator?.id,
+      stranger?.id,
+      ...noiseUsers.map((u) => u.id)
+    ].filter((id): id is string => Boolean(id))
+    for (const id of ids) {
+      try {
+        await deleteTestUser(id)
+      } catch {
+        // Best-effort.
+      }
+    }
+  }, 180_000)
+
+  it('V1 and V2 return identical result sets', () => {
+    const project = (rows: string[][]): string =>
+      rows.map((r) => r.join('|')).join('\n')
+
+    // Pull rows via psql with the owner's JWT claim set. Sorted by the
+    // function's own ORDER BY clause so this is a position-by-position
+    // compare.
+    const callSql = (fn: string) => `
+      begin;
+      set local "request.jwt.claim.sub" = '${owner.id}';
+      select kind, item_name, item_id
+        from public.${fn}('${settlementId}'::uuid, '${collaborator.id}'::uuid);
+      rollback;
+    `
+    const v1 = psqlRows(callSql('get_unshare_blockers'))
+    const v2 = psqlRows(callSql('get_unshare_blockers_v2'))
+
+    // Strip blank rollback-noise lines (psqlRows already filters empty
+    // lines; the `BEGIN` / `ROLLBACK` lines aren't emitted in `-t -q`
+    // mode, so this is mostly just defensive).
+    expect(v1.length).toBe(EXPECTED_BLOCKER_ROWS)
+    expect(v2.length).toBe(EXPECTED_BLOCKER_ROWS)
+    expect(project(v2)).toBe(project(v1))
+  })
+
+  it('benchmarks V1 vs V2', () => {
+    const measure = (fn: string) => {
+      // Warmup runs (discarded).
+      for (let i = 0; i < WARMUP_RUNS; i++)
+        explainAnalyze(fn, owner.id, settlementId, collaborator.id)
+      // Sample.
+      const planning: number[] = []
+      const execution: number[] = []
+      for (let i = 0; i < MEASURE_RUNS; i++) {
+        const t = explainAnalyze(fn, owner.id, settlementId, collaborator.id)
+        planning.push(t.planning)
+        execution.push(t.execution)
+      }
+      return {
+        planningMin: Math.min(...planning),
+        planningMed: median(planning),
+        planningMax: Math.max(...planning),
+        executionMin: Math.min(...execution),
+        executionMed: median(execution),
+        executionMax: Math.max(...execution)
+      }
+    }
+
+    const v1 = measure('get_unshare_blockers')
+    const v2 = measure('get_unshare_blockers_v2')
+
+    const fmt = (n: number) => n.toFixed(3).padStart(8)
+    const lines = [
+      '',
+      '## Benchmark: `get_unshare_blockers` V1 vs V2',
+      '',
+      `Workload: ${EXPECTED_BLOCKER_ROWS} target blockers across 4 branches, ${NOISE_SETTLEMENTS} unrelated settlements x ${NOISE_ROWS_PER_SETTLEMENT} rows, ${MEASURE_RUNS} measurement runs after ${WARMUP_RUNS} warmups.`,
+      '',
+      '| Function | Planning (min / med / max ms) | Execution (min / med / max ms) |',
+      '| --- | --- | --- |',
+      `| V1 (current) | ${fmt(v1.planningMin)} / ${fmt(v1.planningMed)} / ${fmt(v1.planningMax)} | ${fmt(v1.executionMin)} / ${fmt(v1.executionMed)} / ${fmt(v1.executionMax)} |`,
+      `| V2 (CTE-hoist) | ${fmt(v2.planningMin)} / ${fmt(v2.planningMed)} / ${fmt(v2.planningMax)} | ${fmt(v2.executionMin)} / ${fmt(v2.executionMed)} / ${fmt(v2.executionMax)} |`,
+      '',
+      `Δ median planning: ${(v2.planningMed - v1.planningMed).toFixed(3)} ms (${(((v2.planningMed - v1.planningMed) / v1.planningMed) * 100).toFixed(1)}%)`,
+      `Δ median execution: ${(v2.executionMed - v1.executionMed).toFixed(3)} ms (${(((v2.executionMed - v1.executionMed) / v1.executionMed) * 100).toFixed(1)}%)`,
+      ''
+    ]
+    console.log(lines.join('\n'))
+
+    // Always passes — the benchmark is informational. The decision (ship
+    // V2 vs leave V1 with a rationale comment) is made by a human reading
+    // the report.
+    expect(true).toBe(true)
+  }, 120_000)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.28",
+  "version": "0.61.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.28",
+      "version": "0.61.29",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.28",
+  "version": "0.61.29",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/scripts/benchmark-unshare-blockers/README.md
+++ b/scripts/benchmark-unshare-blockers/README.md
@@ -1,0 +1,65 @@
+# `get_unshare_blockers` benchmark (issue #154)
+
+Optional performance harness for the
+`public.get_unshare_blockers(p_settlement_id, p_shared_user_id)` RPC introduced
+in
+[`20260511000000_get_unshare_blockers.sql`](../../supabase/migrations/20260511000000_get_unshare_blockers.sql).
+
+## Purpose
+
+Issue [#154](https://github.com/ncalteen/kdm-app/issues/154) called for a
+benchmark to decide whether the per-table `UNION ALL` body should be rewritten
+as a CTE that hoists the `s.user_id = auth.uid()` authorization join out of
+every branch.
+
+The benchmark seeds a realistic workload (100 custom blocker attachments on a
+target settlement, surrounded by 20 unrelated settlements with their own
+attachments) and runs `EXPLAIN (ANALYZE, BUFFERS)` against both shapes ten times
+after warmup.
+
+Result captured during the issue:
+
+| Shape                                     | Execution (median) | Planning (median) |
+| ----------------------------------------- | ------------------ | ----------------- |
+| V1 (current — per-branch settlement join) | ~6.9 ms            | ~0.03 ms          |
+| V2 (CTE-hoisted authorization gate)       | ~6.5 ms            | ~0.03 ms          |
+
+Both shapes are ~14× under the 100 ms acceptance budget. V2 was not adopted
+because the 6% delta sits inside run-to-run noise and the per-table UNION must
+be preserved regardless (each catalog uses a different display-name column —
+`knowledge_name`, `gear_name`, …, `monster_name` for both quarry and nemesis).
+The rationale is documented inline in the V1 migration header.
+
+## When to re-run
+
+- A new catalog joins `get_unshare_blockers` (a 14th branch and beyond).
+- The function shape changes (e.g. a unified transitive view becomes available
+  and the per-table UNION can collapse).
+- Attachment counts on real settlements grow by an order of magnitude and the
+  function starts approaching the 100 ms budget.
+
+## How to run
+
+The benchmark lives in the integration suite but is gated by `RUN_BENCHMARK=1`
+so the default `npm run integration-test` skips it.
+
+```sh
+RUN_BENCHMARK=1 ./scripts/integration.sh \
+  __tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts
+```
+
+Requirements:
+
+- The local Supabase stack must be running (`npx supabase start`); the harness
+  invokes `docker exec supabase_db_kdm-app psql` directly to avoid PostgREST
+  round-trip overhead.
+- The candidate V2 sibling function is installed from
+  [`get_unshare_blockers_v2.sql`](./get_unshare_blockers_v2.sql) into the live
+  database for the duration of the run and dropped in `afterAll`.
+- All test users are created and torn down per run. Failure paths best-effort
+  cleanup; a stray failure may leave seeded rows behind, which
+  `npm run db:reset` clears.
+
+The benchmark always reports its numbers via `console.log` as a markdown table
+and the test itself passes — interpretation is a human decision, not an
+automated gate.

--- a/scripts/benchmark-unshare-blockers/get_unshare_blockers_v2.sql
+++ b/scripts/benchmark-unshare-blockers/get_unshare_blockers_v2.sql
@@ -9,12 +9,13 @@
 -- CTE evaluated once rather than re-joined to `public.settlement` in
 -- every branch.
 --
--- This file exists only to support the issue #154 benchmark (see
--- `scripts/benchmark-unshare-blockers.sh`). It is NOT a real migration:
--- the benchmark installs it in a savepoint, measures both functions
--- against the same fixture, and rolls it back. Promote into a real
--- migration only after the numbers + maintenance trade-off make the
--- case for it.
+-- This file exists only to support the issue #154 benchmark (run from
+-- the Vitest integration benchmark under
+-- `__tests__/integration/benchmarks/...`). It is NOT a real migration:
+-- the benchmark creates this function for the run, measures both
+-- functions against the same fixture, and drops it during cleanup.
+-- Promote into a real migration only after the numbers +
+-- maintenance trade-off make the case for it.
 --
 -- Notes:
 --   - The per-table UNION ALL is preserved because each catalog table

--- a/scripts/benchmark-unshare-blockers/get_unshare_blockers_v2.sql
+++ b/scripts/benchmark-unshare-blockers/get_unshare_blockers_v2.sql
@@ -1,0 +1,175 @@
+--------------------------------------------------------------------------------
+-- Candidate Option B: `get_unshare_blockers_v2`
+--
+-- Sibling of `public.get_unshare_blockers` (introduced in
+-- `supabase/migrations/20260511000000_get_unshare_blockers.sql`). Same
+-- inputs, same return shape, same `security definer` / search_path
+-- hardening, same authorization contract — but the per-table UNION ALL
+-- hoists the `s.user_id = auth.uid()` authorization gate into a single
+-- CTE evaluated once rather than re-joined to `public.settlement` in
+-- every branch.
+--
+-- This file exists only to support the issue #154 benchmark (see
+-- `scripts/benchmark-unshare-blockers.sh`). It is NOT a real migration:
+-- the benchmark installs it in a savepoint, measures both functions
+-- against the same fixture, and rolls it back. Promote into a real
+-- migration only after the numbers + maintenance trade-off make the
+-- case for it.
+--
+-- Notes:
+--   - The per-table UNION ALL is preserved because each catalog table
+--     uses a different display-name column (`knowledge_name`,
+--     `philosophy_name`, …, `monster_name` for quarry/nemesis). A
+--     literal single-SELECT-no-union form would require a unified
+--     view that picks the canonical display name per kind — beyond
+--     scope here.
+--   - `auth.uid()` is evaluated once inside the CTE; the planner does
+--     not have to push it through 13 separate predicates.
+--   - The settlement table is touched exactly once per call (in the
+--     CTE) rather than 13 times.
+--   - Output ordering matches A exactly so the benchmark's
+--     correctness diff is a byte-wise compare.
+--------------------------------------------------------------------------------
+create or replace function get_unshare_blockers_v2(
+    p_settlement_id uuid,
+    p_shared_user_id uuid
+  ) returns table (kind text, item_name text, item_id uuid) language sql security definer
+set search_path = '' stable as $$ -- Authorization gate, evaluated once. Returns the settlement row only
+  -- when the caller is its owner; otherwise empty and the rest of the
+  -- query yields no rows, matching the V1 contract for non-owner
+  -- callers.
+  with owned as (
+    select id
+    from public.settlement
+    where id = p_settlement_id
+      and user_id = auth.uid()
+  )
+select kind,
+  item_name,
+  item_id
+from (
+    select 'knowledge'::text as kind,
+      k.knowledge_name as item_name,
+      k.id as item_id
+    from owned o
+      join public.settlement_knowledge sj on sj.settlement_id = o.id
+      join public.knowledge k on k.id = sj.knowledge_id
+    where k.custom
+      and k.user_id = p_shared_user_id
+    union all
+    select 'philosophy'::text,
+      c.philosophy_name,
+      c.id
+    from owned o
+      join public.settlement_philosophy sj on sj.settlement_id = o.id
+      join public.philosophy c on c.id = sj.philosophy_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'gear'::text,
+      c.gear_name,
+      c.id
+    from owned o
+      join public.settlement_gear sj on sj.settlement_id = o.id
+      join public.gear c on c.id = sj.gear_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'innovation'::text,
+      c.innovation_name,
+      c.id
+    from owned o
+      join public.settlement_innovation sj on sj.settlement_id = o.id
+      join public.innovation c on c.id = sj.innovation_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'pattern'::text,
+      c.pattern_name,
+      c.id
+    from owned o
+      join public.settlement_pattern sj on sj.settlement_id = o.id
+      join public.pattern c on c.id = sj.pattern_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'seed_pattern'::text,
+      c.seed_pattern_name,
+      c.id
+    from owned o
+      join public.settlement_seed_pattern sj on sj.settlement_id = o.id
+      join public.seed_pattern c on c.id = sj.seed_pattern_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'collective_cognition_reward'::text,
+      c.reward_name,
+      c.id
+    from owned o
+      join public.settlement_collective_cognition_reward sj on sj.settlement_id = o.id
+      join public.collective_cognition_reward c on c.id = sj.collective_cognition_reward_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'location'::text,
+      c.location_name,
+      c.id
+    from owned o
+      join public.settlement_location sj on sj.settlement_id = o.id
+      join public.location c on c.id = sj.location_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'milestone'::text,
+      c.milestone_name,
+      c.id
+    from owned o
+      join public.settlement_milestone sj on sj.settlement_id = o.id
+      join public.milestone c on c.id = sj.milestone_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'principle'::text,
+      c.principle_name,
+      c.id
+    from owned o
+      join public.settlement_principle sj on sj.settlement_id = o.id
+      join public.principle c on c.id = sj.principle_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'resource'::text,
+      c.resource_name,
+      c.id
+    from owned o
+      join public.settlement_resource sj on sj.settlement_id = o.id
+      join public.resource c on c.id = sj.resource_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'quarry'::text,
+      c.monster_name,
+      c.id
+    from owned o
+      join public.settlement_quarry sj on sj.settlement_id = o.id
+      join public.quarry c on c.id = sj.quarry_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+    union all
+    select 'nemesis'::text,
+      c.monster_name,
+      c.id
+    from owned o
+      join public.settlement_nemesis sj on sj.settlement_id = o.id
+      join public.nemesis c on c.id = sj.nemesis_id
+    where c.custom
+      and c.user_id = p_shared_user_id
+  ) all_blockers
+order by kind asc,
+  item_name asc;
+$$;
+revoke all on function public.get_unshare_blockers_v2(uuid, uuid)
+from public;
+revoke execute on function public.get_unshare_blockers_v2(uuid, uuid)
+from anon;
+grant execute on function public.get_unshare_blockers_v2(uuid, uuid) to authenticated;

--- a/supabase/migrations/20260511000000_get_unshare_blockers.sql
+++ b/supabase/migrations/20260511000000_get_unshare_blockers.sql
@@ -25,10 +25,30 @@
 --     therefore *not* directly read the collaborator's custom rows to
 --     enumerate them — the join lives on the database side under the
 --     definer's privileges.
---   - Phase 2 (E2.13) will rewrite this function against the new
---     transitive-visibility predicate; the surface area (parameters
---     and return shape) is intentionally stable so the callers don't
---     need to change.
+--
+-- Why the per-table UNION ALL shape is retained (issue #154):
+--   The E2.13 refactor explored a sibling shape that hoists the
+--   per-branch `s.user_id = auth.uid()` authorization join into a
+--   single CTE evaluated once (see
+--   `scripts/benchmark-unshare-blockers/get_unshare_blockers_v2.sql`).
+--   The harness at
+--   `__tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts`
+--   compared both against a 100-blocker target settlement surrounded
+--   by 20 unrelated settlements. V1 ran at ~7 ms / V2 at ~6.5 ms
+--   median execution; both are ~14× under the 100 ms acceptance
+--   budget and the 6% gap sits inside run-to-run variance. The
+--   per-table UNION ALL was kept because:
+--     * Each catalog uses a different display-name column
+--       (`knowledge_name`, `gear_name`, …, `monster_name` for both
+--       quarry and nemesis); a "single SELECT over a transitive
+--       view" cannot project a uniform `item_name` without a
+--       dedicated unified view that doesn't yet exist.
+--     * The repetition is structural, mirroring the per-catalog
+--       `*_shared_user` triads, and the planner already handles the
+--       constant-row settlement-join cheaply once
+--       `settlement(id, user_id)` is hot in cache.
+--   Re-run the benchmark if a new catalog joins this function or
+--   attachment counts grow by an order of magnitude.
 --
 -- Scope:
 --   - Walks every `settlement_*` junction that points at a catalog row
@@ -41,8 +61,9 @@
 --     `survivor_disorder`, etc.). The plan calls those out as part of
 --     a comprehensive walk, but the issue body's example query and
 --     acceptance criterion limit this iteration to settlement
---     junctions. Closing the survivor-side gap is a known follow-up
---     and is naturally absorbed by E2.13's rewrite.
+--     junctions. Closing the survivor-side gap is tracked as a
+--     follow-up (E2.13 decided against the broader rewrite — see the
+--     "Why the per-table UNION ALL shape is retained" note above).
 --
 -- Authorization:
 --   - Returns rows only when `auth.uid()` is the owner of the target


### PR DESCRIPTION
## Summary

Closes #154 — the optional E2.13 refactor of `get_unshare_blockers`.
Decision after benchmarking: **leave V1 in place, document why, ship the benchmark harness for future reuse.**

## Benchmark Result

Harness lives at [`__tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts`](__tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts) and seeds a worst-case workload: one target settlement with 100 custom blocker attachments authored by a "target" collaborator (25 each across `knowledge` / `gear` / `quarry` / `nemesis`), plus negative noise (stranger-authored, stock, owner-authored) and 20 unrelated settlements with their own attachments so the per-branch `s.user_id = auth.uid()` join in V1 isn't a degenerate single-row lookup.

All SQL goes through `docker exec supabase_db_kdm-app psql` to bypass PostgREST round-trip overhead (5–15 ms) that would otherwise mask sub-millisecond planner differences.

| Function | Planning (median ms) | Execution (median ms) |
| --- | --- | --- |
| **V1** (current, per-branch settlement join) | 0.032 | **6.926** |
| **V2** (CTE-hoisted authorization gate) | 0.034 | **6.509** |

- Both shapes are ~14× under the 100 ms acceptance budget.
- V2 is ~6% faster — well inside run-to-run variance.
- V1 and V2 produced byte-identical result sets across the 100-blocker correctness diff.

## Decision

Take the issue's "otherwise" branch: keep V1, add a rationale comment, archive V2 + the benchmark for future reuse.

Reasons:

1. **Per-table UNION ALL is structurally required.** Each catalog projects a different display-name column — `knowledge_name`, `gear_name`, …, `monster_name` for both quarry and nemesis. The issue's "single SELECT over a transitive view" shape can't project a uniform `item_name` without a dedicated unified view that doesn't yet exist.
2. **No performance pressure.** V1 sits at ~7 ms / 100 ms budget. There is no signal that this RPC is anywhere near a bottleneck.
3. **Future maintainability.** Adding a migration whose only impact is shaving 0.4 ms of plan-noise would fragment the migration history without measurable benefit.

## Changes

- **`supabase/migrations/20260511000000_get_unshare_blockers.sql`**: header gains a "Why the per-table UNION ALL shape is retained" section that
  - links to the benchmark + V2 sketch,
  - records the median execution numbers,
  - explains why the per-branch settlement join is structurally cheap (one row, hot in cache),
  - and notes the trigger conditions for a re-benchmark (new catalog joins the function; attachment counts grow by an order of magnitude).
  The "survivor-side scope" note is also updated to reflect that the broader rewrite has been declined.
- **`__tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts`** (new): opt-in vitest harness gated by `RUN_BENCHMARK=1`. The default `npm run integration-test` silently skips it; explicit invocation pattern is documented in the file header and the README. The harness seeds users + a target settlement, installs V2 from the sibling SQL file, asserts a row-by-row correctness diff, then runs `EXPLAIN (ANALYZE, BUFFERS)` 10× after 3 warmups and prints a markdown table.
- **`scripts/benchmark-unshare-blockers/get_unshare_blockers_v2.sql`** (new): the candidate V2 shape, kept as a reference for the next maintainer who looks at this function.
- **`scripts/benchmark-unshare-blockers/README.md`** (new): explains the captured numbers, the rationale for the decision, when to re-run, and the exact command.

## Verification

- `npm run integration-test` — 28 files, 611 passed / 1 skipped (the realtime placeholder; the benchmark file is correctly skipped without `RUN_BENCHMARK=1`).
- `RUN_BENCHMARK=1 ./scripts/integration.sh __tests__/integration/benchmarks/get-unshare-blockers.bench.test.ts` — both tests pass; correctness diff matches; benchmark report rendered.
- `./scripts/integration.sh __tests__/integration/rls/get-unshare-blockers.test.ts` — existing 7 RLS contract tests still green after the migration comment edit.
- `npm test` — 103 files / 1929 passed.
- `npm run format:check` / `npm run lint` — clean.

## Dependencies

None.

## Version

`0.61.28` → `0.61.29` (patch).