### PR TITLE
feat(subscription): subscription_plan + user_subscription schema (3 tiers)

### DIFF
--- a/__tests__/integration/helpers/supabase.ts
+++ b/__tests__/integration/helpers/supabase.ts
@@ -91,6 +91,20 @@ export async function createTestUser(): Promise<TestUser> {
   if (settingsErr)
     throw new Error(`seed user_settings failed: ${settingsErr.message}`)
 
+  // Seed the default `free` subscription row. In production, the email and
+  // OAuth sign-up paths each provision this row automatically (see the
+  // `initialize_user_settings` RPC and `handle_new_oauth_user` trigger).
+  // GoTrue's admin createUser endpoint inserts auth.users with
+  // `provider = 'email'`, which the OAuth trigger short-circuits, and the
+  // test bypasses the email-flow RPC by inserting user_settings directly.
+  // Seeding here keeps RLS gating that consults `user_subscription` (E3.3
+  // and later) working in tests.
+  const { error: subErr } = await admin
+    .from('user_subscription')
+    .insert({ user_id: created.user.id, plan_id: 'free' })
+  if (subErr)
+    throw new Error(`seed user_subscription failed: ${subErr.message}`)
+
   const client = createClient(URL, ANON_KEY, {
     auth: { persistSession: false, autoRefreshToken: false }
   })

--- a/__tests__/integration/rls/subscription.test.ts
+++ b/__tests__/integration/rls/subscription.test.ts
@@ -190,7 +190,7 @@ describe('RLS: subscription_plan + user_subscription', () => {
         .insert({ user_id: owner.id, plan_id: 'lantern_hoard' })
         .select('user_id')
       expect(data ?? []).toEqual([])
-      if (error) expect(error.code).toMatch(/PGRST|42501|23505/)
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
     })
 
     it('owner cannot DELETE their own subscription row', async () => {

--- a/__tests__/integration/rls/subscription.test.ts
+++ b/__tests__/integration/rls/subscription.test.ts
@@ -1,0 +1,211 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — `subscription_plan` + `user_subscription` Tables
+ *
+ * Covers Epic E3.1 acceptance criteria (GitHub issues #168 and #232):
+ *
+ *   * The three canonical plans (`free`, `lantern`, `lantern_hoard`) exist
+ *     with the correct entitlements.
+ *   * Any authenticated user can SELECT the catalog of plans.
+ *   * `user_subscription` is owner-private — readers cannot see another
+ *     user's subscription row, and non-service-role clients cannot
+ *     INSERT/UPDATE/DELETE rows.
+ *   * The integration test helper seeds a `free` row for every new user,
+ *     standing in for the production OAuth / email auto-provisioning
+ *     paths.
+ */
+describe('RLS: subscription_plan + user_subscription', () => {
+  let owner: TestUser
+  let attacker: TestUser
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    attacker = await createTestUser()
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(attacker.id)
+  })
+
+  describe('subscription_plan', () => {
+    it('seeds the three canonical plans with the correct entitlements', async () => {
+      const { data, error } = await admin
+        .from('subscription_plan')
+        .select('*')
+        .order('monthly_price_cents', { ascending: true })
+
+      expect(error).toBeNull()
+      expect(data).toHaveLength(3)
+
+      const byId = Object.fromEntries(
+        (data ?? []).map((row) => [row.id, row])
+      ) as Record<string, NonNullable<typeof data>[number]>
+
+      expect(byId.free).toMatchObject({
+        display_name: 'Wanderer',
+        monthly_price_cents: 0,
+        max_owned_settlements: 5,
+        max_collaborators_per_settlement: null,
+        may_share: false,
+        may_be_invited: true,
+        may_create_custom: true
+      })
+      expect(byId.lantern).toMatchObject({
+        display_name: 'Lantern',
+        monthly_price_cents: 100,
+        max_owned_settlements: null,
+        max_collaborators_per_settlement: null,
+        may_share: false,
+        may_be_invited: true,
+        may_create_custom: true
+      })
+      expect(byId.lantern_hoard).toMatchObject({
+        display_name: 'Lantern Hoard',
+        monthly_price_cents: 500,
+        max_owned_settlements: null,
+        max_collaborators_per_settlement: null,
+        may_share: true,
+        may_be_invited: true,
+        may_create_custom: true
+      })
+    })
+
+    it('any authenticated user can SELECT the plan catalog', async () => {
+      const { data, error } = await owner.client
+        .from('subscription_plan')
+        .select('id')
+      expect(error).toBeNull()
+      expect(data?.map((r) => r.id).sort()).toEqual([
+        'free',
+        'lantern',
+        'lantern_hoard'
+      ])
+    })
+
+    it('authenticated users cannot INSERT plans', async () => {
+      const { data, error } = await owner.client
+        .from('subscription_plan')
+        .insert({
+          id: 'pirate',
+          display_name: 'Pirate',
+          monthly_price_cents: 0
+        })
+        .select('id')
+      // Either RLS denies silently (returning empty data) or PostgREST surfaces
+      // a 42501 / PGRST permission error — both are acceptable RLS outcomes.
+      expect(data ?? []).toEqual([])
+      if (error) expect(error.code).toMatch(/PGRST|42501/)
+    })
+
+    it('authenticated users cannot UPDATE plans', async () => {
+      const { data } = await owner.client
+        .from('subscription_plan')
+        .update({ may_share: true })
+        .eq('id', 'free')
+        .select('id')
+      expect(data ?? []).toEqual([])
+
+      const { data: check } = await admin
+        .from('subscription_plan')
+        .select('may_share')
+        .eq('id', 'free')
+        .single()
+      expect(check?.may_share).toBe(false)
+    })
+  })
+
+  describe('user_subscription', () => {
+    it('every new user is provisioned with a `free` subscription row', async () => {
+      const { data, error } = await owner.client
+        .from('user_subscription')
+        .select('user_id, plan_id, status')
+        .eq('user_id', owner.id)
+        .single()
+      expect(error).toBeNull()
+      expect(data?.plan_id).toBe('free')
+      expect(data?.status).toBe('active')
+    })
+
+    it('owner can SELECT their own subscription', async () => {
+      const { data, error } = await owner.client
+        .from('user_subscription')
+        .select('plan_id')
+      expect(error).toBeNull()
+      expect(data).toHaveLength(1)
+      expect(data?.[0].plan_id).toBe('free')
+    })
+
+    it('attacker cannot SELECT another user subscription', async () => {
+      const { data, error } = await attacker.client
+        .from('user_subscription')
+        .select('user_id')
+        .eq('user_id', owner.id)
+      expect(error).toBeNull()
+      expect(data).toEqual([])
+    })
+
+    it('attacker cannot UPDATE another user subscription', async () => {
+      const { data } = await attacker.client
+        .from('user_subscription')
+        .update({ plan_id: 'lantern_hoard' })
+        .eq('user_id', owner.id)
+        .select('user_id')
+      expect(data ?? []).toEqual([])
+
+      const { data: check } = await admin
+        .from('user_subscription')
+        .select('plan_id')
+        .eq('user_id', owner.id)
+        .single()
+      expect(check?.plan_id).toBe('free')
+    })
+
+    it('owner cannot UPDATE their own plan (write reserved for service role)', async () => {
+      const { data } = await owner.client
+        .from('user_subscription')
+        .update({ plan_id: 'lantern_hoard' })
+        .eq('user_id', owner.id)
+        .select('user_id')
+      expect(data ?? []).toEqual([])
+
+      const { data: check } = await admin
+        .from('user_subscription')
+        .select('plan_id')
+        .eq('user_id', owner.id)
+        .single()
+      expect(check?.plan_id).toBe('free')
+    })
+
+    it('owner cannot INSERT a duplicate / impersonating subscription row', async () => {
+      const { data, error } = await owner.client
+        .from('user_subscription')
+        .insert({ user_id: owner.id, plan_id: 'lantern_hoard' })
+        .select('user_id')
+      expect(data ?? []).toEqual([])
+      if (error) expect(error.code).toMatch(/PGRST|42501|23505/)
+    })
+
+    it('owner cannot DELETE their own subscription row', async () => {
+      const { data } = await owner.client
+        .from('user_subscription')
+        .delete()
+        .eq('user_id', owner.id)
+        .select('user_id')
+      expect(data ?? []).toEqual([])
+
+      const { data: check } = await admin
+        .from('user_subscription')
+        .select('user_id')
+        .eq('user_id', owner.id)
+      expect(check).toHaveLength(1)
+    })
+  })
+})

--- a/docs/settlement-sharing-architecture.md
+++ b/docs/settlement-sharing-architecture.md
@@ -778,7 +778,23 @@ a sketch — concrete details depend on payment provider choice.
 
 ### 9.1 Entitlement model
 
-Two new tables (rough sketch):
+Three tiers, shipped together so the upgrade path is "go pay" rather than "go
+pay and also opt in to a SKU":
+
+| `id`            | Display name  | Price   | `max_owned_settlements` | `may_share` |
+| --------------- | ------------- | ------- | ----------------------- | ----------- |
+| `free`          | Wanderer      | $0 / mo | 5                       | false       |
+| `lantern`       | Lantern       | $1 / mo | unlimited               | false       |
+| `lantern_hoard` | Lantern Hoard | $5 / mo | unlimited               | true        |
+
+Every tier can be invited into someone else's settlement and can author custom
+catalog content. Sharing is the paid wall (Lantern Hoard only); the
+five-settlement cap exists on Free so the free tier remains generous enough to
+play a full campaign but stops short of being a permanent free SaaS for power
+users.
+
+Two tables (shipped in `20260527000000_subscription_plan.sql` and
+`20260527000001_user_subscription.sql`):
 
 ```sql
 create table subscription_plan (
@@ -803,7 +819,12 @@ create table user_subscription (
 );
 ```
 
-A SECURITY DEFINER helper:
+Every new sign-up (email or OAuth) is auto-provisioned with a `free` row, and a
+one-shot backfill in the `user_subscription` migration seeds existing users.
+Subsequent writes are reserved for the (forthcoming) Stripe webhook handler and
+admin operators.
+
+A SECURITY DEFINER helper (to be added in E3.3):
 
 ```sql
 create or replace function user_can_share() returns boolean
@@ -1022,7 +1043,11 @@ rules text → collaborator sees the new text within 300ms.
 ### Phase 3 — Paid-Feature Gating
 
 - **3.1** Add `subscription_plan` and `user_subscription` tables. Pre-populate
-  `subscription_plan` with `free` and one paid tier.
+  `subscription_plan` with `free`, `lantern`, and `lantern_hoard`. _Status:_
+  shipped in `20260527000000_subscription_plan.sql` and
+  `20260527000001_user_subscription.sql`. New sign-ups (email + OAuth) get a
+  `free` row automatically; existing users were backfilled in-place. Sharing RLS
+  still reads the legacy "any authenticated owner" path until 3.3 lands.
 - **3.2** Stripe integration: Checkout session, customer portal, webhook handler
   that writes to `user_subscription`. (note; this will require providing
   documentation to the Stripe account owner so they understand how the webhook

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -4021,6 +4021,39 @@ export type Database = {
         }
         Relationships: []
       }
+      subscription_plan: {
+        Row: {
+          display_name: string
+          id: string
+          max_collaborators_per_settlement: number | null
+          max_owned_settlements: number | null
+          may_be_invited: boolean
+          may_create_custom: boolean
+          may_share: boolean
+          monthly_price_cents: number
+        }
+        Insert: {
+          display_name: string
+          id: string
+          max_collaborators_per_settlement?: number | null
+          max_owned_settlements?: number | null
+          may_be_invited?: boolean
+          may_create_custom?: boolean
+          may_share?: boolean
+          monthly_price_cents: number
+        }
+        Update: {
+          display_name?: string
+          id?: string
+          max_collaborators_per_settlement?: number | null
+          max_owned_settlements?: number | null
+          may_be_invited?: boolean
+          may_create_custom?: boolean
+          may_share?: boolean
+          monthly_price_cents?: number
+        }
+        Relationships: []
+      }
       survivor: {
         Row: {
           absolute_reaper: boolean | null
@@ -4754,6 +4787,44 @@ export type Database = {
         }
         Relationships: []
       }
+      user_subscription: {
+        Row: {
+          current_period_end: string | null
+          plan_id: string
+          status: string
+          stripe_customer_id: string | null
+          stripe_subscription_id: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          current_period_end?: string | null
+          plan_id: string
+          status?: string
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          current_period_end?: string | null
+          plan_id?: string
+          status?: string
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_subscription_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "subscription_plan"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       wanderer: {
         Row: {
           accuracy: number
@@ -5002,6 +5073,26 @@ export type Database = {
       }
       is_admin: { Args: never; Returns: boolean }
       is_armor_set_owner: { Args: { record_id: string }; Returns: boolean }
+      is_collective_cognition_reward_visible_via_quarry_reference: {
+        Args: { ref_ccr_id: string; ref_ccr_user_id: string }
+        Returns: boolean
+      }
+      is_gear_visible_via_cost_reference: {
+        Args: { ref_gear_id: string; ref_gear_user_id: string }
+        Returns: boolean
+      }
+      is_innovation_visible_via_cost_reference: {
+        Args: { ref_innovation_id: string; ref_innovation_user_id: string }
+        Returns: boolean
+      }
+      is_location_visible_via_quarry_nemesis_reference: {
+        Args: { ref_location_id: string; ref_location_user_id: string }
+        Returns: boolean
+      }
+      is_resource_visible_via_cost_reference: {
+        Args: { ref_resource_id: string; ref_resource_user_id: string }
+        Returns: boolean
+      }
       is_settlement_collaborator: {
         Args: { target_settlement: string }
         Returns: boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.61.35",
+  "version": "0.62.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.61.35",
+      "version": "0.62.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.61.35",
+  "version": "0.62.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260527000000_subscription_plan.sql
+++ b/supabase/migrations/20260527000000_subscription_plan.sql
@@ -1,0 +1,90 @@
+--------------------------------------------------------------------------------
+-- Subscription Plan Table
+--
+-- Source of truth for paid-feature gating. Three canonical tiers ship with
+-- the table:
+--
+--   free          (Wanderer)        $0 / mo  — capped at 5 owned settlements,
+--                                              cannot create new shares.
+--   lantern       (Lantern)         $1 / mo  — unlimited owned settlements,
+--                                              cannot create new shares.
+--   lantern_hoard (Lantern Hoard)   $5 / mo  — unlimited owned settlements,
+--                                              unlimited sharing.
+--
+-- Every tier can be invited into someone else's settlement (`may_be_invited`)
+-- and can author custom catalog content (`may_create_custom`); the
+-- collaborator role and custom-content authoring are intentionally not behind
+-- a paywall. See `docs/settlement-sharing-architecture.md` §9 (entitlements)
+-- and Epic E3.1 / GitHub issues #168 and #232.
+--
+-- `max_owned_settlements` and `max_collaborators_per_settlement` use NULL to
+-- mean "unlimited". RLS gating that consults this table will treat NULL as
+-- the absence of a cap.
+--------------------------------------------------------------------------------
+create table subscription_plan (
+  id text primary key,
+  display_name varchar not null,
+  monthly_price_cents int not null,
+  max_owned_settlements int,
+  max_collaborators_per_settlement int,
+  may_share boolean not null default false,
+  may_be_invited boolean not null default true,
+  may_create_custom boolean not null default true
+);
+--------------------------------------------------------------------------------
+-- Canonical Plans
+--
+-- IDs are stable string keys; never re-use or rename them once Stripe price
+-- IDs reference them. Display copy and pricing can move freely.
+--------------------------------------------------------------------------------
+insert into subscription_plan (
+    id,
+    display_name,
+    monthly_price_cents,
+    max_owned_settlements,
+    max_collaborators_per_settlement,
+    may_share,
+    may_be_invited,
+    may_create_custom
+  )
+values (
+    'free',
+    'Wanderer',
+    0,
+    5,
+    null,
+    false,
+    true,
+    true
+  ),
+  (
+    'lantern',
+    'Lantern',
+    100,
+    null,
+    null,
+    false,
+    true,
+    true
+  ),
+  (
+    'lantern_hoard',
+    'Lantern Hoard',
+    500,
+    null,
+    null,
+    true,
+    true,
+    true
+  );
+--------------------------------------------------------------------------------
+-- Row Level Security Policies
+--
+-- Plans are public reference data for any authenticated user (the subscription
+-- page surfaces price and benefits to logged-in shoppers). Mutations are
+-- restricted to admin operators and the service-role migrations themselves.
+--------------------------------------------------------------------------------
+alter table subscription_plan enable row level security;
+create policy "Allow select for authenticated" on subscription_plan for
+select to authenticated using (true);
+create policy "Allow all for admin" on subscription_plan for all using (is_admin()) with check (is_admin());

--- a/supabase/migrations/20260527000001_user_subscription.sql
+++ b/supabase/migrations/20260527000001_user_subscription.sql
@@ -20,7 +20,8 @@
 create table user_subscription (
   user_id uuid primary key references auth.users(id) on delete cascade,
   plan_id text not null references subscription_plan(id),
-  status varchar not null default 'active',
+  status varchar not null default 'active'
+    check (status in ('active', 'past_due', 'canceled', 'trialing', 'incomplete')),
   -- 'active' | 'past_due' | 'canceled' | 'trialing' | 'incomplete'
   current_period_end timestamptz,
   stripe_customer_id text,

--- a/supabase/migrations/20260527000001_user_subscription.sql
+++ b/supabase/migrations/20260527000001_user_subscription.sql
@@ -1,0 +1,177 @@
+--------------------------------------------------------------------------------
+-- User Subscription Table
+--
+-- One row per `auth.users` user pointing at the user's currently-active
+-- `subscription_plan`. The default for every new sign-up is the `free`
+-- plan; the row is upgraded to `lantern` or `lantern_hoard` by the Stripe
+-- webhook handler (planned in Epic E3.7 — not part of this migration).
+--
+-- Writes are reserved for:
+--   * service-role contexts (the future webhook handler)
+--   * admin operators (manual recovery / impersonation testing)
+--   * the auto-provisioning paths below, which always seed `plan_id = 'free'`
+--
+-- Reads are restricted to the owner. RLS gating (E3.3) reads this table via
+-- a SECURITY DEFINER helper, so it bypasses RLS and is safe to consult from
+-- predicates on other tables.
+--
+-- See `docs/settlement-sharing-architecture.md` §9.1 and GitHub issue #168.
+--------------------------------------------------------------------------------
+create table user_subscription (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  plan_id text not null references subscription_plan(id),
+  status varchar not null default 'active',
+  -- 'active' | 'past_due' | 'canceled' | 'trialing' | 'incomplete'
+  current_period_end timestamptz,
+  stripe_customer_id text,
+  stripe_subscription_id text,
+  updated_at timestamptz not null default now()
+);
+--------------------------------------------------------------------------------
+-- Row Level Security Policies
+--------------------------------------------------------------------------------
+alter table user_subscription enable row level security;
+create policy "Allow select own" on user_subscription for
+select to authenticated using (
+    user_id = (
+      select auth.uid()
+    )
+  );
+create policy "Allow all for admin" on user_subscription for all using (is_admin()) with check (is_admin());
+-- INSERT/UPDATE/DELETE only via service_role (Stripe webhook) or admin.
+--------------------------------------------------------------------------------
+-- Indexes
+--------------------------------------------------------------------------------
+create index idx_user_subscription_plan_id on user_subscription(plan_id);
+create index idx_user_subscription_status on user_subscription(status);
+--------------------------------------------------------------------------------
+-- Triggers
+--------------------------------------------------------------------------------
+create trigger set_updated_at before
+update on user_subscription for each row execute function update_updated_at();
+--------------------------------------------------------------------------------
+-- Default-Row Provisioning — Email Sign-Up Path
+--
+-- The email/password sign-up form calls `initialize_user_settings(...)` from
+-- the client immediately after `signUp()` resolves, before the user has
+-- confirmed their email. Extend it to also seed the matching `free`
+-- subscription row so paid-feature gating predicates always find a plan
+-- for an authenticated user.
+--
+-- Idempotent on both inserts (`on conflict do nothing`) so re-invocations
+-- of the RPC and races with the OAuth path are harmless.
+--------------------------------------------------------------------------------
+create or replace function initialize_user_settings(p_user_id uuid, p_username varchar) returns void language plpgsql security definer
+set search_path = public as $$ begin
+insert into user_settings (user_id, username)
+values (p_user_id, p_username) on conflict (user_id) do nothing;
+insert into user_subscription (user_id, plan_id)
+values (p_user_id, 'free') on conflict (user_id) do nothing;
+end;
+$$;
+--------------------------------------------------------------------------------
+-- Default-Row Provisioning — OAuth Sign-Up Path
+--
+-- `provision_user_settings_for_oauth(p_user_id)` (introduced by
+-- 20260508000000_user_settings_avatar_url.sql) is the helper invoked by the
+-- AFTER INSERT trigger on auth.users for non-email providers. Extend it to
+-- seed the user's `free` subscription row alongside their `user_settings`
+-- row. The insert is unconditional (gated only by `on conflict do nothing`)
+-- so it runs even when a user_settings row already exists — this matters
+-- for users created by GoTrue's admin endpoint, where the test path is
+-- forced through the email short-circuit and then `provision_user_settings_for_oauth`
+-- is called manually.
+--------------------------------------------------------------------------------
+create or replace function provision_user_settings_for_oauth(p_user_id uuid) returns void language plpgsql security definer
+set search_path = public as $$
+declare meta jsonb;
+user_email text;
+provider_avatar_url text;
+base_candidate varchar;
+candidate varchar;
+suffix text;
+attempt int := 0;
+max_attempts constant int := 25;
+begin -- Seed the user's subscription row first so it's present even if the
+-- caller already has a user_settings row and the function returns early
+-- below. Free plan; upgrades flow through the Stripe webhook later.
+insert into user_subscription (user_id, plan_id)
+values (p_user_id, 'free') on conflict (user_id) do nothing;
+if exists (
+  select 1
+  from user_settings
+  where user_id = p_user_id
+) then return;
+end if;
+select coalesce(au.raw_user_meta_data, '{}'::jsonb),
+  au.email into meta,
+  user_email
+from auth.users au
+where au.id = p_user_id;
+if meta is null then return;
+end if;
+provider_avatar_url := nullif(meta->>'avatar_url', '');
+base_candidate := coalesce(
+  sanitize_username_candidate(meta->>'user_name'),
+  sanitize_username_candidate(meta->>'preferred_username'),
+  sanitize_username_candidate(meta->>'username'),
+  sanitize_username_candidate(meta->>'global_name'),
+  sanitize_username_candidate(meta->>'name'),
+  sanitize_username_candidate(meta->>'full_name'),
+  sanitize_username_candidate(split_part(coalesce(user_email, ''), '@', 1)),
+  sanitize_username_candidate(
+    'survivor_' || substring(
+      p_user_id::text
+      from 1 for 8
+    )
+  )
+);
+if base_candidate is null then base_candidate := substring(
+  ('u_' || replace(p_user_id::text, '-', ''))
+  from 1 for 20
+)::varchar;
+end if;
+candidate := base_candidate;
+loop begin
+insert into user_settings (user_id, username, avatar_url)
+values (p_user_id, candidate, provider_avatar_url);
+return;
+exception
+when unique_violation then attempt := attempt + 1;
+exit
+when attempt > max_attempts;
+suffix := lpad((floor(random() * 10000))::int::text, 4, '0');
+candidate := (
+  substring(
+    base_candidate
+    from 1 for greatest(1, 20 - char_length(suffix) - 1)
+  ) || '_' || suffix
+)::varchar;
+end;
+end loop;
+candidate := substring(
+  ('u_' || replace(p_user_id::text, '-', ''))
+  from 1 for 20
+)::varchar;
+insert into user_settings (user_id, username, avatar_url)
+values (p_user_id, candidate, provider_avatar_url) on conflict (user_id) do nothing;
+end;
+$$;
+--------------------------------------------------------------------------------
+-- Backfill Existing Users
+--
+-- Every pre-existing user predates the entitlement layer, so they are
+-- entitled to the free plan. The insert is guarded by a NOT EXISTS subquery
+-- against `user_subscription` so re-running the migration (during local
+-- development, `npx supabase db reset`) is a no-op for users that already
+-- have a row.
+--------------------------------------------------------------------------------
+insert into user_subscription (user_id, plan_id)
+select au.id,
+  'free'
+from auth.users au
+where not exists (
+    select 1
+    from user_subscription us
+    where us.user_id = au.id
+  );


### PR DESCRIPTION
## Summary

Implements the entitlement schema for Epic E3 Phase 3 and bakes in the
three-tier pricing model.

Closes #168
Closes #232

### Tiers

| `id`            | Display name  | Price   | `max_owned_settlements` | `may_share` |
| --------------- | ------------- | ------- | ----------------------- | ----------- |
| `free`          | Wanderer      | $0 / mo | 5                       | false       |
| `lantern`       | Lantern       | $1 / mo | unlimited               | false       |
| `lantern_hoard` | Lantern Hoard | $5 / mo | unlimited               | true        |

Every tier can be invited into someone else's settlement and can author custom
catalog content; sharing is the only paywall, and the five-settlement cap on
Free keeps the free tier generous enough to play a full campaign without
becoming a permanent free SaaS for power users.

### Schema

Two new migrations:

- **`supabase/migrations/20260527000000_subscription_plan.sql`** — creates
  `subscription_plan` with the three canonical rows. RLS: public-read for any
  authenticated user; writes reserved for admin / service-role.
- **`supabase/migrations/20260527000001_user_subscription.sql`** — creates
  `user_subscription` (FK to `auth.users` and `subscription_plan`, Stripe ID
  columns, status enum-as-text). RLS: owner-private SELECT; writes reserved for
  admin / service-role (Stripe webhook handler arrives in E3.7).

### Default-Row Provisioning

Both sign-up paths now seed a `free` row, idempotently via `on conflict do
nothing`:

- `initialize_user_settings(p_user_id, p_username)` — extended for the
  email/password sign-up flow.
- `provision_user_settings_for_oauth(p_user_id)` — extended for the OAuth
  trigger path.

A one-shot backfill in the `user_subscription` migration covers existing
`auth.users` (idempotent on `npx supabase db reset`).

### Tests

- New RLS suite: `__tests__/integration/rls/subscription.test.ts` — covers plan
  seeding, owner-only reads, write reservations, and default-row provisioning.
- `createTestUser` fixture now seeds the `free` row (GoTrue's admin
  `createUser` inserts as `provider='email'`, which short-circuits the OAuth
  trigger, and the fixture bypasses the email-flow RPC, so the seed has to be
  explicit).

Unit tests: ✅ 1929 / 1929 passing.

### Docs

- `docs/settlement-sharing-architecture.md` §9.1 rewritten as the 3-tier table.
- §10 Phase 3.1 marked shipped with migration filenames.

### Database Type Regeneration

`lib/database.types.ts` regenerated via `npm run db:generate` against the local
Supabase stack after applying the new migrations. The diff includes a handful
of incidental function-signature entries that were already present in the
schema but missing from the committed types file — these are picked up as a
side effect of the regen and are harmless.

### Out of Scope (follow-ups)

- E3.2 — Stripe Checkout / customer portal / webhook handler.
- E3.3 — `user_can_share()` RLS helper and gating of the
  `settlement_shared_user.INSERT` policy.
- E3.4 — Subscription page, upsell modal, billing-banner.
- Enforcement of `max_owned_settlements` on Free (the cap exists in data but
  is not yet read by RLS — same E3.3 wave).

### Dependencies

No package additions, removals, or upgrades. Version bumped `0.61.35` → `0.62.0`
in `package.json` / `package-lock.json` (minor — new feature, no breaking
changes).
