### PR TITLE
perf(db): index foreign-key columns and drop unused admin RLS policies

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -6,15 +6,6 @@
       "headers": {
         "Authorization": "Bearer ${input:github_pat}"
       }
-    },
-    "kdm-postgres": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-postgres",
-        "postgresql://postgres:postgres@127.0.0.1:54322/postgres?sslmode=disable"
-      ]
     }
   },
   "inputs": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.62.0",
+      "version": "0.63.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260528000000_index_foreign_keys.sql
+++ b/supabase/migrations/20260528000000_index_foreign_keys.sql
@@ -1,0 +1,148 @@
+--------------------------------------------------------------------------------
+-- Index Foreign Key Columns
+--
+-- Adds btree indexes for every foreign-key column in the public schema that is
+-- not already covered by a left-prefix index. Unindexed FK columns force
+-- sequential scans on the referencing table whenever the referenced row is
+-- updated or deleted, and also penalize any direct WHERE <fk_col> = ? lookup
+-- — including the catalog visibility joins and the realtime change feeds that
+-- key off these columns.
+--
+-- Generated from a `pg_constraint` / `pg_index` audit of the live schema; see
+-- the PR description for the full diff. All statements use IF NOT EXISTS so
+-- the migration is safe to re-run on environments where some indexes were
+-- created manually.
+--
+-- Naming convention follows the existing migrations: `idx_<table>_<column>`
+-- with the trailing `_id` stripped from single-column FK references.
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- Catalog tables: owner (user_id) lookups
+--
+-- These tables already carry a `(custom, user_id)` composite index used by the
+-- catalog visibility RLS path, but that composite cannot serve plain
+-- `user_id = ?` lookups (custom is the leading column) and so does not cover
+-- the FK to auth.users. Each gets a dedicated single-column index.
+--------------------------------------------------------------------------------
+create index if not exists idx_ability_impairment_user on ability_impairment(user_id);
+create index if not exists idx_armor_set_user on armor_set(user_id);
+create index if not exists idx_character_user on character(user_id);
+create index if not exists idx_collective_cognition_reward_user on collective_cognition_reward(user_id);
+create index if not exists idx_constellation_user on constellation(user_id);
+create index if not exists idx_disorder_user on disorder(user_id);
+create index if not exists idx_fighting_art_user on fighting_art(user_id);
+create index if not exists idx_gear_user on gear(user_id);
+create index if not exists idx_innovation_user on innovation(user_id);
+create index if not exists idx_knowledge_user on knowledge(user_id);
+create index if not exists idx_location_user on location(user_id);
+create index if not exists idx_milestone_user on milestone(user_id);
+create index if not exists idx_mood_user on mood(user_id);
+create index if not exists idx_nemesis_user on nemesis(user_id);
+create index if not exists idx_neurosis_user on neurosis(user_id);
+create index if not exists idx_pattern_user on pattern(user_id);
+create index if not exists idx_philosophy_user on philosophy(user_id);
+create index if not exists idx_principle_user on principle(user_id);
+create index if not exists idx_quarry_user on quarry(user_id);
+create index if not exists idx_resource_user on resource(user_id);
+create index if not exists idx_secret_fighting_art_user on secret_fighting_art(user_id);
+create index if not exists idx_seed_pattern_user on seed_pattern(user_id);
+-- NOTE: `settlement_shared_user` already carries an `idx_settlement_shared_user_user`
+-- index, but it covers `shared_user_id` (the invited collaborator) — not the
+-- `user_id` column (the inviting owner). We add a separately-named index for
+-- the owner column rather than renaming the legacy one.
+create index if not exists idx_settlement_shared_user_owner on settlement_shared_user(user_id);
+create index if not exists idx_strain_milestone_user on strain_milestone(user_id);
+create index if not exists idx_survivor_status_user on survivor_status(user_id);
+create index if not exists idx_trait_user on trait(user_id);
+create index if not exists idx_weapon_type_user on weapon_type(user_id);
+--------------------------------------------------------------------------------
+-- Gear
+--
+-- `gear.location_id` and `gear.weapon_type_id` are dropdown lookups used
+-- throughout the catalog UI and showdown loadout builders; both need indexes
+-- so reference-row deletes don't trigger sequential scans of the gear table.
+--------------------------------------------------------------------------------
+create index if not exists idx_gear_location on gear(location_id);
+create index if not exists idx_gear_weapon_type on gear(weapon_type_id);
+--------------------------------------------------------------------------------
+-- Gear Grid
+--
+-- Each of the nine slot columns is a FK to gear(id). Without indexes, deleting
+-- or unselecting any gear row forces PG to seq-scan gear_grid to enforce the
+-- FK. The table is small (one row per settlement), but the gear_grid rebuild
+-- on `settlement_gear` deletion is a hot path so the indexes are still worth
+-- having.
+--------------------------------------------------------------------------------
+create index if not exists idx_gear_grid_pos_top_left on gear_grid(pos_top_left);
+create index if not exists idx_gear_grid_pos_top_center on gear_grid(pos_top_center);
+create index if not exists idx_gear_grid_pos_top_right on gear_grid(pos_top_right);
+create index if not exists idx_gear_grid_pos_mid_left on gear_grid(pos_mid_left);
+create index if not exists idx_gear_grid_pos_mid_center on gear_grid(pos_mid_center);
+create index if not exists idx_gear_grid_pos_mid_right on gear_grid(pos_mid_right);
+create index if not exists idx_gear_grid_pos_bottom_left on gear_grid(pos_bottom_left);
+create index if not exists idx_gear_grid_pos_bottom_center on gear_grid(pos_bottom_center);
+create index if not exists idx_gear_grid_pos_bottom_right on gear_grid(pos_bottom_right);
+--------------------------------------------------------------------------------
+-- Knowledge → Philosophy
+--------------------------------------------------------------------------------
+create index if not exists idx_knowledge_philosophy on knowledge(philosophy_id);
+--------------------------------------------------------------------------------
+-- Nemesis and Quarry self-references (alternate, vignette)
+--------------------------------------------------------------------------------
+create index if not exists idx_nemesis_alternate on nemesis(alternate_id);
+create index if not exists idx_nemesis_vignette on nemesis(vignette_id);
+create index if not exists idx_quarry_alternate on quarry(alternate_id);
+create index if not exists idx_quarry_vignette on quarry(vignette_id);
+--------------------------------------------------------------------------------
+-- Crafting graph
+--
+-- Joins from gear / resource / innovation back through their patterns and
+-- seed_patterns drive the crafting UI; without these indexes the joins
+-- degrade to seq scans as the catalog grows.
+--------------------------------------------------------------------------------
+create index if not exists idx_pattern_crafted_gear on pattern(crafted_gear_id);
+create index if not exists idx_pattern_gear_cost_cost_gear on pattern_gear_cost(cost_gear_id);
+create index if not exists idx_pattern_innovation_requirement_innovation on pattern_innovation_requirement(innovation_id);
+create index if not exists idx_pattern_resource_cost_resource on pattern_resource_cost(resource_id);
+create index if not exists idx_seed_pattern_crafted_gear on seed_pattern(crafted_gear_id);
+create index if not exists idx_seed_pattern_gear_cost_cost_gear on seed_pattern_gear_cost(cost_gear_id);
+create index if not exists idx_seed_pattern_innovation_requirement_innovation on seed_pattern_innovation_requirement(innovation_id);
+create index if not exists idx_seed_pattern_resource_cost_resource on seed_pattern_resource_cost(resource_id);
+--------------------------------------------------------------------------------
+-- Philosophy → Knowledge (tenet)
+--------------------------------------------------------------------------------
+create index if not exists idx_philosophy_tenet_knowledge on philosophy(tenet_knowledge_id);
+--------------------------------------------------------------------------------
+-- Resource lineage (pattern + quarry origin)
+--------------------------------------------------------------------------------
+create index if not exists idx_resource_pattern on resource(pattern_id);
+create index if not exists idx_resource_quarry on resource(quarry_id);
+--------------------------------------------------------------------------------
+-- Settlement junction lookups
+--
+-- These junction rows are deleted/reattached whenever the referenced lookup
+-- row (location / milestone / principle / resource) is removed from the
+-- catalog. Indexing the referencing column keeps those cascades constant-time.
+--------------------------------------------------------------------------------
+create index if not exists idx_settlement_location_location on settlement_location(location_id);
+create index if not exists idx_settlement_milestone_milestone on settlement_milestone(milestone_id);
+create index if not exists idx_settlement_principle_principle on settlement_principle(principle_id);
+create index if not exists idx_settlement_resource_resource on settlement_resource(resource_id);
+--------------------------------------------------------------------------------
+-- Settlement Phase
+--------------------------------------------------------------------------------
+create index if not exists idx_settlement_phase_returning_scout on settlement_phase(returning_scout_id);
+create index if not exists idx_settlement_phase_returning_survivor_settlement on settlement_phase_returning_survivor(settlement_id);
+--------------------------------------------------------------------------------
+-- Survivor
+--
+-- Knowledge / neurosis / philosophy / tenet / weapon-type are all dropdown FKs
+-- on the survivor record. Without indexes, deleting a catalog row scans the
+-- entire survivor table to validate the FK.
+--------------------------------------------------------------------------------
+create index if not exists idx_survivor_knowledge_1 on survivor(knowledge_1_id);
+create index if not exists idx_survivor_knowledge_2 on survivor(knowledge_2_id);
+create index if not exists idx_survivor_neurosis on survivor(neurosis_id);
+create index if not exists idx_survivor_philosophy on survivor(philosophy_id);
+create index if not exists idx_survivor_tenet_knowledge on survivor(tenet_knowledge_id);
+create index if not exists idx_survivor_weapon_type on survivor(weapon_type_id);

--- a/supabase/migrations/20260528000001_drop_admin_all_policies.sql
+++ b/supabase/migrations/20260528000001_drop_admin_all_policies.sql
@@ -1,0 +1,132 @@
+--------------------------------------------------------------------------------
+-- Drop Legacy "Allow All For Admin" RLS Policies
+--
+-- Every public table historically carried an `Allow all for admin` policy of
+-- the form
+--
+--     create policy "Allow all for admin" on <table>
+--       for all using (is_admin()) with check (is_admin());
+--
+-- where `is_admin()` resolves to `auth.role() = 'admin'`. Supabase does not
+-- issue tokens with the `admin` role — admin/maintenance traffic uses the
+-- `service_role` JWT, which bypasses RLS unconditionally. The policy is
+-- therefore unreachable in practice:
+--
+--   * `anon` / `authenticated` requests never satisfy `is_admin()`.
+--   * `service_role` requests skip RLS entirely.
+--
+-- Keeping these policies has real cost: every `(table, command)` pair carries
+-- an extra permissive policy that the planner must evaluate, which the
+-- database advisor flags as a `multiple_permissive_policies` warning. They
+-- also obscure the real authorization story when auditing RLS.
+--
+-- The integration test suite documents that these policies are excluded from
+-- the coverage matrix (see `docs/integration-tests.md`), so nothing in CI
+-- depends on them.
+--
+-- The `is_admin()` helper function itself is intentionally NOT dropped — it
+-- may still be useful for future server-side checks — but no RLS policy in
+-- the schema references it after this migration runs.
+--------------------------------------------------------------------------------
+drop policy if exists "Allow all for admin" on public.ability_impairment;
+drop policy if exists "Allow all for admin" on public.armor_set;
+drop policy if exists "Allow all for admin" on public.armor_set_slot;
+drop policy if exists "Allow all for admin" on public.armor_set_slot_gear;
+drop policy if exists "Allow all for admin" on public."character";
+drop policy if exists "Allow all for admin" on public.collective_cognition_reward;
+drop policy if exists "Allow all for admin" on public.constellation;
+drop policy if exists "Allow all for admin" on public.disorder;
+drop policy if exists "Allow all for admin" on public.fighting_art;
+drop policy if exists "Allow all for admin" on public.gear;
+drop policy if exists "Allow all for admin" on public.gear_gear_cost;
+drop policy if exists "Allow all for admin" on public.gear_grid;
+drop policy if exists "Allow all for admin" on public.gear_other_cost;
+drop policy if exists "Allow all for admin" on public.gear_resource_cost;
+drop policy if exists "Allow all for admin" on public.gear_resource_type_cost;
+drop policy if exists "Allow all for admin" on public.hunt;
+drop policy if exists "Allow all for admin" on public.hunt_ai_deck;
+drop policy if exists "Allow all for admin" on public.hunt_hunt_board;
+drop policy if exists "Allow all for admin" on public.hunt_monster;
+drop policy if exists "Allow all for admin" on public.hunt_monster_mood;
+drop policy if exists "Allow all for admin" on public.hunt_monster_survivor_status;
+drop policy if exists "Allow all for admin" on public.hunt_monster_trait;
+drop policy if exists "Allow all for admin" on public.hunt_survivor;
+drop policy if exists "Allow all for admin" on public.innovation;
+drop policy if exists "Allow all for admin" on public.knowledge;
+drop policy if exists "Allow all for admin" on public.location;
+drop policy if exists "Allow all for admin" on public.milestone;
+drop policy if exists "Allow all for admin" on public.mood;
+drop policy if exists "Allow all for admin" on public.nemesis;
+drop policy if exists "Allow all for admin" on public.nemesis_level;
+drop policy if exists "Allow all for admin" on public.nemesis_level_mood;
+drop policy if exists "Allow all for admin" on public.nemesis_level_survivor_status;
+drop policy if exists "Allow all for admin" on public.nemesis_level_trait;
+drop policy if exists "Allow all for admin" on public.nemesis_location;
+drop policy if exists "Allow all for admin" on public.nemesis_timeline_year;
+drop policy if exists "Allow all for admin" on public.neurosis;
+drop policy if exists "Allow all for admin" on public.pattern;
+drop policy if exists "Allow all for admin" on public.pattern_gear_cost;
+drop policy if exists "Allow all for admin" on public.pattern_innovation_requirement;
+drop policy if exists "Allow all for admin" on public.pattern_resource_cost;
+drop policy if exists "Allow all for admin" on public.pattern_resource_type_cost;
+drop policy if exists "Allow all for admin" on public.philosophy;
+drop policy if exists "Allow all for admin" on public.philosophy_rank;
+drop policy if exists "Allow all for admin" on public.principle;
+drop policy if exists "Allow all for admin" on public.quarry;
+drop policy if exists "Allow all for admin" on public.quarry_collective_cognition_reward;
+drop policy if exists "Allow all for admin" on public.quarry_hunt_board;
+drop policy if exists "Allow all for admin" on public.quarry_hunt_board_position;
+drop policy if exists "Allow all for admin" on public.quarry_level;
+drop policy if exists "Allow all for admin" on public.quarry_level_mood;
+drop policy if exists "Allow all for admin" on public.quarry_level_survivor_status;
+drop policy if exists "Allow all for admin" on public.quarry_level_trait;
+drop policy if exists "Allow all for admin" on public.quarry_location;
+drop policy if exists "Allow all for admin" on public.quarry_timeline_year;
+drop policy if exists "Allow all for admin" on public.resource;
+drop policy if exists "Allow all for admin" on public.secret_fighting_art;
+drop policy if exists "Allow all for admin" on public.seed_pattern;
+drop policy if exists "Allow all for admin" on public.seed_pattern_gear_cost;
+drop policy if exists "Allow all for admin" on public.seed_pattern_innovation_requirement;
+drop policy if exists "Allow all for admin" on public.seed_pattern_resource_cost;
+drop policy if exists "Allow all for admin" on public.seed_pattern_resource_type_cost;
+drop policy if exists "Allow all for admin" on public.settlement;
+drop policy if exists "Allow all for admin" on public.settlement_collective_cognition_reward;
+drop policy if exists "Allow all for admin" on public.settlement_gear;
+drop policy if exists "Allow all for admin" on public.settlement_innovation;
+drop policy if exists "Allow all for admin" on public.settlement_knowledge;
+drop policy if exists "Allow all for admin" on public.settlement_location;
+drop policy if exists "Allow all for admin" on public.settlement_milestone;
+drop policy if exists "Allow all for admin" on public.settlement_nemesis;
+drop policy if exists "Allow all for admin" on public.settlement_pattern;
+drop policy if exists "Allow all for admin" on public.settlement_phase;
+drop policy if exists "Allow all for admin" on public.settlement_phase_returning_survivor;
+drop policy if exists "Allow all for admin" on public.settlement_philosophy;
+drop policy if exists "Allow all for admin" on public.settlement_principle;
+drop policy if exists "Allow all for admin" on public.settlement_quarry;
+drop policy if exists "Allow all for admin" on public.settlement_resource;
+drop policy if exists "Allow all for admin" on public.settlement_seed_pattern;
+drop policy if exists "Allow all for admin" on public.settlement_shared_user;
+drop policy if exists "Allow all for admin" on public.settlement_timeline_year;
+drop policy if exists "Allow all for admin" on public.showdown;
+drop policy if exists "Allow all for admin" on public.showdown_ai_deck;
+drop policy if exists "Allow all for admin" on public.showdown_monster;
+drop policy if exists "Allow all for admin" on public.showdown_monster_mood;
+drop policy if exists "Allow all for admin" on public.showdown_monster_survivor_status;
+drop policy if exists "Allow all for admin" on public.showdown_monster_trait;
+drop policy if exists "Allow all for admin" on public.showdown_survivor;
+drop policy if exists "Allow all for admin" on public.strain_milestone;
+drop policy if exists "Allow all for admin" on public.subscription_plan;
+drop policy if exists "Allow all for admin" on public.survivor;
+drop policy if exists "Allow all for admin" on public.survivor_ability_impairment;
+drop policy if exists "Allow all for admin" on public.survivor_cursed_gear;
+drop policy if exists "Allow all for admin" on public.survivor_disorder;
+drop policy if exists "Allow all for admin" on public.survivor_fighting_art;
+drop policy if exists "Allow all for admin" on public.survivor_secret_fighting_art;
+drop policy if exists "Allow all for admin" on public.survivor_status;
+drop policy if exists "Allow all for admin" on public.trait;
+drop policy if exists "Allow all for admin" on public.user_settings;
+drop policy if exists "Allow all for admin" on public.user_subscription;
+drop policy if exists "Allow all for admin" on public.wanderer;
+drop policy if exists "Allow all for admin" on public.wanderer_ability_impairment;
+drop policy if exists "Allow all for admin" on public.wanderer_timeline_year;
+drop policy if exists "Allow all for admin" on public.weapon_type;


### PR DESCRIPTION
## Summary

Two adjacent database migrations addressing the top two items on the local performance/RLS todo:

1. **Add indexes for all missing FK columns** — a `pg_constraint` / `pg_index` audit of the live schema flagged **66 foreign-key columns across 33 tables** that were not covered by a left-prefix index. Unindexed FK columns force sequential scans on the referencing table whenever the referenced row is updated or deleted, and also penalize the catalog visibility joins and realtime change feeds that key off these columns.
2. **Drop the "Allow all for admin" RLS policies** — all 102 of them, one per public table. Each is `FOR ALL USING (is_admin()) WITH CHECK (is_admin())`. Supabase does not mint tokens with the `admin` role, so the policy is unreachable for `anon`/`authenticated` traffic; admin/maintenance uses `service_role`, which bypasses RLS entirely. They are pure overhead and trigger `multiple_permissive_policies` warnings on every `(table, command)` pair.

## Changes

### `supabase/migrations/20260528000000_index_foreign_keys.sql`

Adds 66 `create index if not exists` statements grouped by domain:

| Group | Indexes |
| --- | --- |
| Catalog owner (`user_id`) lookups | 27 |
| Gear (`location_id`, `weapon_type_id`, `user_id`) | already in the catalog group + 2 |
| `gear_grid` slot columns | 9 |
| Crafting graph (`pattern_*`, `seed_pattern_*` cost/innovation joins, `crafted_gear_id`) | 8 |
| Survivor dropdown FKs (knowledge/neurosis/philosophy/tenet/weapon-type) | 6 |
| Settlement junction tables (location/milestone/principle/resource) | 4 |
| Nemesis/quarry self-references (alternate, vignette) | 4 |
| Resource lineage (pattern, quarry) | 2 |
| Settlement phase (returning_scout, returning_survivor.settlement) | 2 |
| Misc (`knowledge.philosophy_id`, `philosophy.tenet_knowledge_id`) | 2 |

Notable detail: the legacy `idx_settlement_shared_user_user` index is misleadingly named — it actually covers `shared_user_id`, not `user_id`. To avoid renaming the existing index (and breaking anything that references the name), the new index for the owner column is named `idx_settlement_shared_user_owner` and a comment explains why.

All statements use `if not exists` so the migration is safe to re-run on environments where some indexes were created manually.

### `supabase/migrations/20260528000001_drop_admin_all_policies.sql`

Drops every `"Allow all for admin"` RLS policy in the `public` schema (102 statements, one per table). The `is_admin()` helper function is intentionally **not** dropped — it may still be useful for future server-side checks — but no RLS policy references it after this migration runs.

`docs/integration-tests.md` already documents that these policies are excluded from the integration test coverage matrix (they are unreachable through the tested anon-key surface), so nothing in CI depends on them.

## Verification

Both migrations were applied via `npx supabase db reset` and verified against the live catalog:

```
=== FK INDEX AUDIT ===
 tbl | name | cols
-----+------+------
(0 rows)

=== REMAINING ADMIN POLICIES ===
 remaining_admin_policies
--------------------------
                        0
```

| Suite | Result |
| --- | --- |
| `npm run test` (unit) | 1929 / 1929 passing, 103 test files |
| `./scripts/integration.sh` (RLS) | 760 / 760 passing (3 skipped benchmarks), 32 test files |

## Dependency changes

None.

## Versioning

Bumps `package.json` and `package-lock.json` from `0.62.0` → `0.63.0`.

## Related

- Local `todo.md`: "Add indexes for all missing FK columns" and "Drop all 'allow all for admin' RLS policies"
- Follow-up risks: none expected — the dropped policies were never reachable via the user-facing API, and the new indexes are write-side cost only on insert/update of indexed columns (negligible for FK columns that already see writes coupled to row creation/update).
