### PR TITLE
feat(settlement): enforce free-tier 5-settlement ownership cap

### DIFF
--- a/__tests__/lib/dal/settlement.test.ts
+++ b/__tests__/lib/dal/settlement.test.ts
@@ -75,10 +75,14 @@ vi.mock('@/lib/dal/neurosis', () => ({
 const {
   getSettlement,
   getLostSettlementCount,
+  getOwnedSettlementCount,
+  createSettlement,
   updateSettlement,
   removeSettlement
 } = await import('@/lib/dal/settlement')
 const { getUserId } = await import('@/lib/dal/user')
+const { FREE_TIER_SETTLEMENT_LIMIT } = await import('@/lib/common')
+const { FREE_TIER_SETTLEMENT_LIMIT_MESSAGE } = await import('@/lib/messages')
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -332,5 +336,117 @@ describe('removeSettlement', () => {
     await expect(removeSettlement('s1')).rejects.toThrow(
       'Error Removing Settlement: fail'
     )
+  })
+})
+
+describe('getOwnedSettlementCount', () => {
+  it('returns the count scoped to the authenticated user', async () => {
+    vi.mocked(getUserId).mockResolvedValue('user-1')
+
+    const eq = vi.fn().mockResolvedValue({ count: 3, error: null })
+    const select = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ select })
+
+    expect(await getOwnedSettlementCount()).toBe(3)
+    expect(mockSupabase.from).toHaveBeenCalledWith('settlement')
+    expect(select).toHaveBeenCalledWith('id', { count: 'exact', head: true })
+    expect(eq).toHaveBeenCalledWith('user_id', 'user-1')
+  })
+
+  it('treats a null count as zero', async () => {
+    vi.mocked(getUserId).mockResolvedValue('user-1')
+
+    const eq = vi.fn().mockResolvedValue({ count: null, error: null })
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({ eq })
+    })
+
+    expect(await getOwnedSettlementCount()).toBe(0)
+  })
+
+  it('throws on query error', async () => {
+    vi.mocked(getUserId).mockResolvedValue('user-1')
+
+    const eq = vi
+      .fn()
+      .mockResolvedValue({ count: null, error: { message: 'DB' } })
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({ eq })
+    })
+
+    await expect(getOwnedSettlementCount()).rejects.toThrow(
+      'Error Fetching Owned Settlement Count: DB'
+    )
+  })
+})
+
+describe('createSettlement (free-tier ownership cap)', () => {
+  /**
+   * Minimal `NewSettlementInput` payload. The cap check runs before any
+   * template / campaign work, so the rest of the fields are irrelevant to
+   * this test path — we only need a value the function can destructure.
+   */
+  const baseInput = {
+    campaignType: 'PEOPLE_OF_THE_LANTERN',
+    settlementName: 'Doomed',
+    survivorType: 'CORE',
+    usesScouts: false,
+    monsterIds: {
+      NQ1: [],
+      NQ2: [],
+      NQ3: [],
+      NQ4: [],
+      NN1: [],
+      NN2: [],
+      NN3: [],
+      CO: [],
+      FI: []
+    },
+    wandererIds: []
+    // Cast at the call site to avoid pulling enum mocks into this test.
+  } as unknown as Parameters<typeof createSettlement>[0]
+
+  it('throws the free-tier cap message when the user is at the limit', async () => {
+    vi.mocked(getUserId).mockResolvedValue('user-1')
+
+    // Count query → at-the-cap. createSettlement must short-circuit before
+    // it ever calls `.insert(...)`, so we only stage the count response.
+    const insert = vi.fn()
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({
+          count: FREE_TIER_SETTLEMENT_LIMIT,
+          error: null
+        })
+      }),
+      insert
+    })
+
+    await expect(createSettlement(baseInput)).rejects.toThrow(
+      FREE_TIER_SETTLEMENT_LIMIT_MESSAGE(FREE_TIER_SETTLEMENT_LIMIT)
+    )
+
+    // Defense-in-depth: no insert should fire when the cap is reached.
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it('throws the free-tier cap message when the user is over the limit', async () => {
+    vi.mocked(getUserId).mockResolvedValue('user-1')
+
+    const insert = vi.fn()
+    mockSupabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({
+          count: FREE_TIER_SETTLEMENT_LIMIT + 7,
+          error: null
+        })
+      }),
+      insert
+    })
+
+    await expect(createSettlement(baseInput)).rejects.toThrow(
+      FREE_TIER_SETTLEMENT_LIMIT_MESSAGE(FREE_TIER_SETTLEMENT_LIMIT)
+    )
+    expect(insert).not.toHaveBeenCalled()
   })
 })

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -165,6 +165,7 @@ function MainPage(): ReactElement {
             selectedShowdownMonsterIndex={selectedShowdownMonsterIndex}
             selectedSurvivor={selectedSurvivor}
             selectedTab={selectedTab}
+            settlementList={settlementList}
             setIsCreatingNewSettlement={setIsCreatingNewSettlement}
             setIsCreatingNewSurvivor={setIsCreatingNewSurvivor}
             setPendingSpecialShowdown={setPendingSpecialShowdown}

--- a/components/menu/settlement-switcher.tsx
+++ b/components/menu/settlement-switcher.tsx
@@ -20,7 +20,9 @@ import {
   TooltipContent,
   TooltipTrigger
 } from '@/components/ui/tooltip'
+import { FREE_TIER_SETTLEMENT_LIMIT } from '@/lib/common'
 import { CampaignType } from '@/lib/enums'
+import { FREE_TIER_SETTLEMENT_LIMIT_MESSAGE } from '@/lib/messages'
 import { SettlementDetail, SettlementListEntry } from '@/lib/types'
 import { Check, ChevronsUpDown, House, Plus } from 'lucide-react'
 import { ComponentProps, ReactElement } from 'react'
@@ -106,6 +108,16 @@ export function SettlementSwitcher({
     setSelectedSettlementId(settlementId)
   }
 
+  // Free-tier ownership cap. Collaborator rows are excluded so users who
+  // accept shares are not punished for it. The DAL enforces the same cap on
+  // submit; the UI gate keeps the affordance honest before the user invests
+  // time in the create form.
+  const ownedSettlementCount = settlementList.filter(
+    (s) => s.role === 'owner'
+  ).length
+  const hasReachedSettlementLimit =
+    ownedSettlementCount >= FREE_TIER_SETTLEMENT_LIMIT
+
   if (isSettlementListLoading)
     return (
       <SidebarMenu>
@@ -165,20 +177,48 @@ export function SettlementSwitcher({
             className="w-(--radix-dropdown-menu-trigger-width)"
             align="start">
             {/* Create settlement option */}
-            <DropdownMenuItem
-              onSelect={() => {
-                setIsCreatingNewSettlement(true)
-                setSelectedHuntId(null)
-                setSelectedSettlementId(null)
-                setSelectedSettlementPhaseId(null)
-                setSelectedShowdownId(null)
-                setSelectedSurvivorId(null)
-              }}>
-              <div className="flex items-center">
-                <Plus className="mr-2 h-4 w-4" />
-                <span>Found a settlement</span>
-              </div>
-            </DropdownMenuItem>
+            {hasReachedSettlementLimit ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/*
+                    Wrap the disabled item in a span so the tooltip trigger
+                    can receive pointer events. `DropdownMenuItem` applies
+                    `data-[disabled]:pointer-events-none`, which would
+                    otherwise swallow the hover that opens the tooltip.
+                  */}
+                  <span tabIndex={0} className="block">
+                    <DropdownMenuItem
+                      disabled
+                      onSelect={(e) => e.preventDefault()}>
+                      <div className="flex items-center">
+                        <Plus className="mr-2 h-4 w-4" />
+                        <span>Found a settlement</span>
+                      </div>
+                    </DropdownMenuItem>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="right" className="max-w-xs">
+                  {FREE_TIER_SETTLEMENT_LIMIT_MESSAGE(
+                    FREE_TIER_SETTLEMENT_LIMIT
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <DropdownMenuItem
+                onSelect={() => {
+                  setIsCreatingNewSettlement(true)
+                  setSelectedHuntId(null)
+                  setSelectedSettlementId(null)
+                  setSelectedSettlementPhaseId(null)
+                  setSelectedShowdownId(null)
+                  setSelectedSurvivorId(null)
+                }}>
+                <div className="flex items-center">
+                  <Plus className="mr-2 h-4 w-4" />
+                  <span>Found a settlement</span>
+                </div>
+              </DropdownMenuItem>
+            )}
 
             <DropdownMenuSeparator />
 

--- a/components/settlement/create-settlement-card.tsx
+++ b/components/settlement/create-settlement-card.tsx
@@ -144,8 +144,8 @@ export function CreateSettlementCard({
    * @param values Form Values on Submit
    */
   function onSubmit(values: NewSettlementInput) {
-    try {
-      createSettlement(values).then((settlementId) => {
+    createSettlement(values)
+      .then((settlementId) => {
         setIsCreatingNewSettlement(false)
         setSelectedHuntId(null)
         setSelectedHuntMonsterIndex(0)
@@ -178,10 +178,17 @@ export function CreateSettlementCard({
         // Show success message
         toast.success(SETTLEMENT_CREATED_MESSAGE())
       })
-    } catch (error) {
-      console.error('Settlement Create Error:', error)
-      toast.error(ERROR_MESSAGE())
-    }
+      .catch((error: unknown) => {
+        console.error('Settlement Create Error:', error)
+        // Surface the DAL error message (e.g. the free-tier cap) when it is
+        // available so the user gets actionable feedback instead of the
+        // generic darkness fallback.
+        const message =
+          error instanceof Error && error.message
+            ? error.message
+            : ERROR_MESSAGE()
+        toast.error(message)
+      })
   }
 
   return (

--- a/components/settlement/settlement-card.tsx
+++ b/components/settlement/settlement-card.tsx
@@ -40,8 +40,14 @@ import {
   EmptyHeader,
   EmptyTitle
 } from '@/components/ui/empty'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from '@/components/ui/tooltip'
 import { UserCard } from '@/components/user/user-card'
 import { LocalStateType } from '@/contexts/local-context'
+import { FREE_TIER_SETTLEMENT_LIMIT } from '@/lib/common'
 import { updateSettlement } from '@/lib/dal/settlement'
 import {
   CampaignType,
@@ -51,10 +57,12 @@ import {
   SurvivorType,
   TabType
 } from '@/lib/enums'
+import { FREE_TIER_SETTLEMENT_LIMIT_MESSAGE } from '@/lib/messages'
 import {
   HuntDetail,
   HuntStateSetter,
   SettlementDetail,
+  SettlementListEntry,
   SettlementPhaseDetail,
   SettlementStateSetter,
   ShowdownDetail,
@@ -100,6 +108,8 @@ interface SettlementCardProps {
   selectedSurvivor: SurvivorDetail | null
   /** Selected Tab */
   selectedTab: TabType
+  /** Settlement List (owned + shared, sourced from LocalContext) */
+  settlementList: SettlementListEntry[]
   /** Set Is Creating New Settlement */
   setIsCreatingNewSettlement: (isCreating: boolean) => void
   /** Set New Survivor Being Created */
@@ -165,6 +175,7 @@ export function SettlementCard({
   selectedShowdownMonsterIndex,
   selectedSurvivor,
   selectedTab,
+  settlementList,
   setIsCreatingNewSettlement,
   setIsCreatingNewSurvivor,
   setPendingSpecialShowdown,
@@ -236,7 +247,16 @@ export function SettlementCard({
       />
     )
 
-  if (!selectedSettlement)
+  if (!selectedSettlement) {
+    // Mirror the SettlementSwitcher's free-tier ownership cap so the
+    // empty-state "Found a settlement" affordance can't lure the user into a
+    // form that the DAL will refuse to submit.
+    const ownedSettlementCount = settlementList.filter(
+      (s) => s.role === 'owner'
+    ).length
+    const hasReachedSettlementLimit =
+      ownedSettlementCount >= FREE_TIER_SETTLEMENT_LIMIT
+
     return (
       <Empty className="mx-auto mt-8 max-w-xl border bg-card/40">
         <EmptyHeader>
@@ -250,15 +270,32 @@ export function SettlementCard({
           </EmptyDescription>
         </EmptyHeader>
         <EmptyContent>
-          <Button
-            onClick={() => setIsCreatingNewSettlement(true)}
-            className="w-full">
-            <PlusIcon className="h-4 w-4" />
-            Found a settlement
-          </Button>
+          {hasReachedSettlementLimit ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="w-full">
+                  <Button disabled className="w-full">
+                    <PlusIcon className="h-4 w-4" />
+                    Found a settlement
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                {FREE_TIER_SETTLEMENT_LIMIT_MESSAGE(FREE_TIER_SETTLEMENT_LIMIT)}
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <Button
+              onClick={() => setIsCreatingNewSettlement(true)}
+              className="w-full">
+              <PlusIcon className="h-4 w-4" />
+              Found a settlement
+            </Button>
+          )}
         </EmptyContent>
       </Empty>
     )
+  }
 
   return (
     <div className="pt-(--header-height)">

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -37,6 +37,20 @@ export const SUPPORT_EMAIL = 'ncalteen@archivist.monster'
 export const MARKDOWN_SYNTAX_URL = 'https://www.markdownguide.org/basic-syntax/'
 
 /**
+ * Free-Tier Settlement Limit
+ *
+ * Maximum number of settlements a free-tier user may own. Settlements that a
+ * user only collaborates on (via the sharing flow) do not count toward this
+ * cap — only rows in `settlement` whose `user_id` matches the caller are
+ * included. The limit is enforced in the application layer (the
+ * `createSettlement` DAL) rather than at the database so that direct
+ * admin / service-role traffic — Supabase Studio, integration tests, ad-hoc
+ * SQL — naturally bypasses it for testing purposes. Paid tiers that lift or
+ * remove this cap are not yet implemented.
+ */
+export const FREE_TIER_SETTLEMENT_LIMIT = 5
+
+/**
  * Basic Hunt Board Configuration
  */
 export const basicHuntBoard = {

--- a/lib/dal/settlement.ts
+++ b/lib/dal/settlement.ts
@@ -4,6 +4,7 @@ import { getPeopleOfTheLanternTemplate } from '@/lib/campaigns/potl'
 import { getPeopleOfTheStarsTemplate } from '@/lib/campaigns/potstars'
 import { getPeopleOfTheSunTemplate } from '@/lib/campaigns/potsun'
 import { getSquiresOfTheCitadelTemplate } from '@/lib/campaigns/squires'
+import { FREE_TIER_SETTLEMENT_LIMIT } from '@/lib/common'
 import { getLocationIds } from '@/lib/dal/location'
 import { getNemesisLocationIds } from '@/lib/dal/nemesis-location'
 import { getNemesisTimelineYears } from '@/lib/dal/nemesis-timeline-year'
@@ -60,9 +61,36 @@ import {
   DatabaseSurvivorType,
   SurvivorType
 } from '@/lib/enums'
+import { FREE_TIER_SETTLEMENT_LIMIT_MESSAGE } from '@/lib/messages'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail, SettlementTimelineYearDetail } from '@/lib/types'
 import { NewSettlementInput } from '@/schemas/new-settlement-input'
+
+/**
+ * Get Owned Settlement Count
+ *
+ * Returns the number of settlements whose `user_id` matches the authenticated
+ * caller. Used to enforce the free-tier ownership cap from
+ * `createSettlement`; collaborator-only settlements (rows the caller only
+ * sees through `settlement_shared_user`) are intentionally excluded so the
+ * cap does not punish users who simply accept shares.
+ *
+ * @returns Owned Settlement Count
+ */
+export async function getOwnedSettlementCount(): Promise<number> {
+  const userId = await getUserId()
+  const supabase = createClient()
+
+  const { count, error } = await supabase
+    .from('settlement')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId)
+
+  if (error)
+    throw new Error(`Error Fetching Owned Settlement Count: ${error.message}`)
+
+  return count ?? 0
+}
 
 /**
  * Create Settlement
@@ -76,6 +104,11 @@ import { NewSettlementInput } from '@/schemas/new-settlement-input'
  * locations / timeline / CC-reward data is then committed in one final
  * parallel batch.
  *
+ * Enforces the free-tier ownership cap before any inserts run. The check is
+ * application-layer only — admins driving the database directly
+ * (Supabase Studio, integration tests via service role, etc.) bypass it
+ * naturally because they never enter this code path.
+ *
  * @param options Settlement Input Data
  * @returns Settlement ID
  */
@@ -84,6 +117,14 @@ export async function createSettlement(
 ): Promise<string> {
   const userId = await getUserId()
   const supabase = createClient()
+
+  // Free-tier ownership cap. Counted up-front so we fail fast before any of
+  // the template fan-out work runs.
+  const ownedCount = await getOwnedSettlementCount()
+  if (ownedCount >= FREE_TIER_SETTLEMENT_LIMIT)
+    throw new Error(
+      FREE_TIER_SETTLEMENT_LIMIT_MESSAGE(FREE_TIER_SETTLEMENT_LIMIT)
+    )
 
   const template = await {
     [CampaignType.CUSTOM]: getCustomCampaignTemplate,

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1456,6 +1456,21 @@ export const SETTLEMENT_CREATED_MESSAGE = () =>
   'A lantern pierces the darkness. A new settlement is born.'
 
 /**
+ * Free-Tier Settlement Limit Reached
+ *
+ * Surfaced both as a tooltip on the "Found a settlement" affordance and as a
+ * toast on the rare race where a user submits the form while already at the
+ * cap. Paid tiers that lift this cap are still in progress, so the copy
+ * explicitly calls that out and reminds the user that shared settlements
+ * remain unlimited.
+ *
+ * @param limit Maximum Settlements Allowed On The Free Tier
+ * @returns Free-Tier Settlement Limit Message
+ */
+export const FREE_TIER_SETTLEMENT_LIMIT_MESSAGE = (limit: number) =>
+  `The lantern hoard is full — free survivors may keep watch over ${limit} settlements. Paid tiers are still being forged. Settlements shared with you remain unlimited.`
+
+/**
  * Settlement Deleted
  *
  * @param settlementName Name of the settlement

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.64.0",
+      "version": "0.65.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

Closes #231.

Caps free-tier users at owning **5 settlements**. Settlements shared with the user as a collaborator do not count toward the cap — per the issue, a user "may be added to an unlimited number of settlements via sharing functionality."

The cap is enforced **application-only** (DAL + UI), not at the database. Admins testing through `service_role` (Supabase Studio, integration tests, ad-hoc SQL) bypass the cap naturally because they never enter the DAL. Paid tiers that lift this cap are still being forged; the user-facing message reflects that.

## Changes

**Production**
- `lib/common.ts` — new `FREE_TIER_SETTLEMENT_LIMIT = 5` with rationale JSDoc.
- `lib/messages.ts` — new `FREE_TIER_SETTLEMENT_LIMIT_MESSAGE(limit)` thematic copy ("The lantern hoard is full — free survivors may keep watch over N settlements…").
- `lib/dal/settlement.ts`:
  - New `getOwnedSettlementCount()` helper (counts rows in `settlement` scoped to `user_id`).
  - `createSettlement` now short-circuits with the cap message **before** any template fetch or insert when `getOwnedSettlementCount() >= FREE_TIER_SETTLEMENT_LIMIT`.
- `components/menu/settlement-switcher.tsx` — "Found a settlement" dropdown item is disabled with a side tooltip showing the cap message when at the limit. The disabled `DropdownMenuItem` is wrapped in a `<span>` so the tooltip trigger receives pointer events (Radix dropdown items apply `data-[disabled]:pointer-events-none`, which would otherwise swallow the hover).
- `components/settlement/settlement-card.tsx` — empty-state "Found a settlement" button is disabled with the same tooltip when at the limit. Accepts a new `settlementList` prop.
- `components/settlement/create-settlement-card.tsx` — replaced a broken `try/catch` around the async `.then()` (which never caught DAL errors) with a proper `.catch()` that toasts `error.message`, so a stale-tab race that slips through the UI still surfaces the DAL cap message.
- `app/page.tsx` — threads `settlementList` into `<SettlementCard>`.

**Tests** (`__tests__/lib/dal/settlement.test.ts`)
- `getOwnedSettlementCount`: returns scoped count / treats null as 0 / throws on error.
- `createSettlement`: at-limit and over-limit both throw `FREE_TIER_SETTLEMENT_LIMIT_MESSAGE` and never call `insert`.
- Full suite: **1934 tests / 103 files pass**.

## Why DAL-only (no DB rule)

Per the issue thread and project direction:

> As an admin user I do want to be able to add/edit/remove settlements beyond limits for testing purposes.

Admin testing is done through Supabase Studio / service_role, which bypass the DAL entirely. Putting the check in a DB trigger or RLS policy would prevent that, so it lives in `createSettlement` instead. The constant's JSDoc documents this trade-off so future maintainers don't move it.

## Dependencies

No new dependencies. No `package.json` deps changed — only the version field.

## Version

`0.64.0` → `0.65.0` (minor — new user-visible feature). `package.json` + `package-lock.json` updated.

## Verification

- `npx vitest run --coverage=false` → 1934/1934 pass.
- TypeScript / ESLint clean on every modified file.
- No DB migrations.

## Related

- #231 (issue this PR closes)
- #233 introduced the `subscription_plan` / `user_subscription` schema — once those tiers ship, this constant becomes a per-plan lookup; for now the single free-tier value documents the intended shape.
