### PR TITLE
feat(db): user_can_share() SECURITY DEFINER helper (#174)

### DIFF
--- a/__tests__/integration/rls/user-can-share.test.ts
+++ b/__tests__/integration/rls/user-can-share.test.ts
@@ -1,0 +1,118 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { createClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RPC — `user_can_share()`
+ *
+ * SECURITY DEFINER predicate added by `20260530000000_user_can_share.sql`
+ * (Epic E3 — Phase 3.2 / GitHub issue #174). Returns true iff the calling
+ * user is on a `subscription_plan` whose `may_share = true` AND whose
+ * `user_subscription.status` is `active` or `trialing`.
+ *
+ * The acceptance criteria spell out a four-cell matrix:
+ *
+ *   |             | active            | canceled         |
+ *   | ----------- | ----------------- | ---------------- |
+ *   | paid plan   | paid-active  ✅   | paid-canceled ⛔ |
+ *   | free / anon | free          ⛔  | anonymous     ⛔ |
+ *
+ * A `trialing` Lantern Hoard user is asserted alongside the matrix to lock in
+ * the second member of the status whitelist.
+ */
+describe('RPC: user_can_share', () => {
+  let user: TestUser
+
+  beforeAll(async () => {
+    user = await createTestUser()
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(user.id)
+  })
+
+  /**
+   * Set User Subscription
+   *
+   * Drives the test user into the requested entitlement cell. Uses the
+   * service-role `admin` client so the update bypasses the RLS policy that
+   * reserves `user_subscription` writes for service-role / admin contexts.
+   *
+   * @param planId Subscription Plan ID
+   * @param status User Subscription Status
+   */
+  async function setUserSubscription(
+    planId: 'free' | 'lantern' | 'lantern_hoard',
+    status: 'active' | 'past_due' | 'canceled' | 'trialing' | 'incomplete'
+  ): Promise<void> {
+    const { error } = await admin
+      .from('user_subscription')
+      .update({ plan_id: planId, status })
+      .eq('user_id', user.id)
+    expect(error).toBeNull()
+  }
+
+  it('returns true for an active Lantern Hoard subscriber (paid-active)', async () => {
+    await setUserSubscription('lantern_hoard', 'active')
+
+    const { data, error } = await user.client.rpc('user_can_share')
+    expect(error).toBeNull()
+    expect(data).toBe(true)
+  })
+
+  it('returns true for a trialing Lantern Hoard subscriber', async () => {
+    // Locks in the second member of the status whitelist alongside `active`.
+    await setUserSubscription('lantern_hoard', 'trialing')
+
+    const { data, error } = await user.client.rpc('user_can_share')
+    expect(error).toBeNull()
+    expect(data).toBe(true)
+  })
+
+  it('returns false for a canceled Lantern Hoard subscriber (paid-canceled)', async () => {
+    // Existing shares persist (see docs/settlement-sharing-architecture.md
+    // §9.3), but the entitlement is paused so no new shares may be created.
+    await setUserSubscription('lantern_hoard', 'canceled')
+
+    const { data, error } = await user.client.rpc('user_can_share')
+    expect(error).toBeNull()
+    expect(data).toBe(false)
+  })
+
+  it('returns false for an active free-plan user (free)', async () => {
+    await setUserSubscription('free', 'active')
+
+    const { data, error } = await user.client.rpc('user_can_share')
+    expect(error).toBeNull()
+    expect(data).toBe(false)
+  })
+
+  it('rejects an anonymous caller (anonymous)', async () => {
+    // EXECUTE was revoked from PUBLIC and from anon explicitly, so the
+    // anon role cannot invoke the helper. (service_role still holds EXECUTE
+    // via Supabase's default privileges — that's intentional and not what
+    // this test exercises.)
+    const anon = createClient(
+      process.env.SUPABASE_URL ?? '',
+      process.env.SUPABASE_ANON_KEY ?? '',
+      { auth: { persistSession: false, autoRefreshToken: false } }
+    )
+
+    const { data, error } = await anon.rpc('user_can_share')
+
+    expect(data).toBeNull()
+    expect(error).not.toBeNull()
+    // Pin the failure to a permission-denied signal so the test can't
+    // accidentally pass on an unrelated error. PostgREST surfaces
+    // PostgreSQL's 42501 either as a top-level `code` or inside `message`
+    // ("permission denied for function ..."); accept either.
+    expect(
+      error?.code === '42501' || /permission denied/i.test(error?.message ?? '')
+    ).toBe(true)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.65.0",
+      "version": "0.66.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260530000000_user_can_share.sql
+++ b/supabase/migrations/20260530000000_user_can_share.sql
@@ -1,0 +1,74 @@
+--------------------------------------------------------------------------------
+-- Helper: user_can_share()
+--
+-- SECURITY DEFINER predicate that returns true when the calling user is on a
+-- subscription plan whose `may_share = true` AND whose subscription row is in
+-- a usable status (`active` or `trialing`). Any other state — including
+-- canceled, past_due, incomplete, or no subscription row at all — resolves to
+-- false.
+--
+-- Consumed by paid-feature gating on `settlement_shared_user` (Epic E3 —
+-- Phase 3, sub-task 3.3, GitHub issue #175). Putting the predicate in a
+-- SECURITY DEFINER function lets RLS policies read `user_subscription` and
+-- `subscription_plan` without re-entering their own RLS evaluation and
+-- without granting the calling role direct SELECT on those tables across
+-- arbitrary users.
+--
+-- Status whitelist
+-- ----------------
+-- The `user_subscription.status` column accepts `active`, `past_due`,
+-- `canceled`, `trialing`, and `incomplete`. Only `active` and `trialing`
+-- entitle the caller to create new shares:
+--   * `past_due` — payment failed; existing shares persist (see
+--     `docs/settlement-sharing-architecture.md` §9.3) but the feature is
+--     paused while Stripe retries.
+--   * `canceled` — user has explicitly downgraded; same persistence-only
+--     semantics as past_due.
+--   * `incomplete` — initial checkout never confirmed; treat as unpaid.
+--
+-- Search path
+-- -----------
+-- SET search_path = '' (empty) forces all references to be fully qualified
+-- with `public.`, matching the repository-wide convention for SECURITY
+-- DEFINER helpers introduced in 20260508000001_is_settlement_collaborator.sql.
+-- This neutralizes search_path-based escalation attacks against the function
+-- body.
+--
+-- Reference: `docs/settlement-sharing-architecture.md` §9.1 / §10 Phase 3
+-- item 3.3.
+--------------------------------------------------------------------------------
+create or replace function user_can_share() returns boolean language sql stable security definer
+set search_path = '' as $$
+select coalesce(
+    (
+      select sp.may_share
+      from public.user_subscription us
+        join public.subscription_plan sp on sp.id = us.plan_id
+      where us.user_id = auth.uid()
+        and us.status in ('active', 'trialing')
+    ),
+    false
+  );
+$$;
+--------------------------------------------------------------------------------
+-- Privilege lockdown
+--
+-- `CREATE FUNCTION` defaults to granting EXECUTE to PUBLIC. A subsequent
+-- Supabase-specific `ALTER DEFAULT PRIVILEGES` on the `public` schema also
+-- grants EXECUTE to `anon`, `authenticated`, and `service_role` independently
+-- of PUBLIC. Revoking from PUBLIC is therefore not sufficient to deny the
+-- anon role — we must drop it explicitly. See
+-- 20260529000000_lockdown_anon_security_definer_rpcs.sql for the broader
+-- audit that established this pattern.
+--
+-- The function has no legitimate anon caller — paid-feature gating only
+-- applies to authenticated users — so anon EXECUTE is revoked outright.
+-- `authenticated` keeps EXECUTE; `service_role` retains its grant via
+-- default privileges, which is intentional for future webhook handlers and
+-- the integration-test fixture path.
+--------------------------------------------------------------------------------
+revoke all on function public.user_can_share()
+from public;
+revoke execute on function public.user_can_share()
+from anon;
+grant execute on function public.user_can_share() to authenticated;


### PR DESCRIPTION
Closes #174.

## Summary

Adds the `user_can_share()` SECURITY DEFINER predicate scoped in Epic E3 — Phase 3.2. Returns `true` iff the calling user is on a `subscription_plan` whose `may_share = true` AND whose `user_subscription.status` is `active` or `trialing`; falls through to `false` for every other state (`canceled`, `past_due`, `incomplete`, or no subscription row at all).

The helper is consumed by the share-creation gate added in Phase 3.3 (`settlement_shared_user` INSERT policy, issue #175). Wrapping the predicate in a SECURITY DEFINER function lets RLS policies on `settlement_shared_user` evaluate plan entitlement without re-entering the RLS evaluator on `user_subscription` / `subscription_plan` and without exposing those tables to direct cross-user SELECT.

## Migration

`supabase/migrations/20260530000000_user_can_share.sql`:

```sql
create or replace function user_can_share() returns boolean
language sql stable security definer
set search_path = '' as $$
  select coalesce((
    select sp.may_share
      from public.user_subscription us
      join public.subscription_plan sp on sp.id = us.plan_id
     where us.user_id = auth.uid()
       and us.status in ('active', 'trialing')
  ), false);
$$;
revoke all on function public.user_can_share() from public;
revoke execute on function public.user_can_share() from anon;
grant execute on function public.user_can_share() to authenticated;
```

Privilege lockdown mirrors `20260529000000_lockdown_anon_security_definer_rpcs.sql`: explicit `revoke … from anon` defeats Supabase's `ALTER DEFAULT PRIVILEGES` quirk that grants EXECUTE to `anon` independent of PUBLIC. `service_role` keeps its grant via default privileges (intentional for future webhook handlers and integration-test fixtures).

`SET search_path = ''` forces fully-qualified `public.` references inside the body, matching the repo-wide SECURITY DEFINER convention.

## Tests

`__tests__/integration/rls/user-can-share.test.ts` — 5 cases against the live local Supabase stack:

| Case                                | Expected           |
| ----------------------------------- | ------------------ |
| Lantern Hoard + `active`            | `true`             |
| Lantern Hoard + `trialing`          | `true`             |
| Lantern Hoard + `canceled`          | `false`            |
| Free plan + `active` (seeded state) | `false`            |
| Anonymous caller (no JWT)           | `42501` / permission denied |

The anon case asserts on `error.code === '42501'` OR a `/permission denied/i` match on `error.message`, so the test pins the failure mode to the privilege revoke and can't accidentally pass on an unrelated error.

```
✓ __tests__/integration/rls/user-can-share.test.ts (5 tests) 285ms

Test Files  1 passed (1)
     Tests  5 passed (5)
```

## Out of scope

This PR adds the predicate and locks down its execute ACL only. Wiring it into the `settlement_shared_user` INSERT policy (and any client-side / UI gating) ships with E3.3 / issue #175.

## Dependencies

- Built on the `subscription_plan` + `user_subscription` schema from PR #233 (E3.1 / issue #168), already on `main`.
- Unblocks issue #175 (E3.3 — gate share creation on `user_can_share()`).

## Version

`0.65.0` → `0.66.0` (minor — new public DB function). `package.json` and `package-lock.json` both bumped.

## Docs

- `docs/settlement-sharing-architecture.md` §9.1 / §10 Phase 3 — referenced in the migration header. No doc edits needed.

## References

- Issue: #174
- Architecture: `docs/settlement-sharing-architecture.md` §9.1
- Privilege-lockdown convention: PR #235 (migration `20260529000000_lockdown_anon_security_definer_rpcs.sql`)
