### PR TITLE
feat(db): gate settlement_shared_user.INSERT on user_can_share() (#165)

### DIFF
--- a/__tests__/integration/rls/settlement-shared.test.ts
+++ b/__tests__/integration/rls/settlement-shared.test.ts
@@ -1,0 +1,316 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — `settlement_shared_user` paid INSERT gate (E3.3)
+ *
+ * Verifies the policy minted by
+ * `20260531000000_settlement_shared_user_paid_gate.sql`:
+ *
+ *     create policy "Allow insert by paying owner"
+ *       on settlement_shared_user for insert to authenticated
+ *       with check (
+ *         user_can_share()
+ *         and is_settlement_owner(settlement_id)
+ *         and user_id = (select auth.uid())
+ *       );
+ *
+ * Acceptance criteria from GitHub issue #165 (Epic E3, Phase 3.3):
+ *   1. Free user trying to INSERT into `settlement_shared_user` is denied
+ *      at the RLS layer.
+ *   2. Paying user (Lantern Hoard + `active`) can INSERT.
+ *   3. Cancelled user retains existing shares but cannot create new ones
+ *      (EC-12 from `docs/settlement-sharing-architecture.md` §9.3).
+ *   4. Admin bypass (service_role) continues to work — the "Allow all for
+ *      admin" policy is untouched by the migration.
+ *
+ * `trialing` is also exercised because it is the second member of the
+ * `user_can_share()` status whitelist and a separate regression target
+ * from `active`.
+ *
+ * The fixture creates one owner + one collaborator + one stranger.
+ * `createTestUser` already seeds every test user with a default
+ * `free`/`active` `user_subscription` row, so test bodies that need a
+ * different entitlement state mutate the row through the service-role
+ * `admin` client (bypassing the user_subscription RLS write reservation).
+ */
+describe('RLS: settlement_shared_user paid INSERT gate (E3.3)', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let settlementId: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+    settlementId = await seedSettlement(owner.id, 'E3.3 Paid-Gate Settlement')
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+  })
+
+  /**
+   * Set Owner Subscription
+   *
+   * Drives the owner test user into the requested entitlement cell via the
+   * service-role `admin` client. The `user_subscription` table reserves
+   * writes for admin / service-role / Stripe-webhook contexts, so this is
+   * the canonical fixture path.
+   *
+   * @param planId Subscription Plan ID
+   * @param status User Subscription Status
+   */
+  async function setOwnerSubscription(
+    planId: 'free' | 'lantern' | 'lantern_hoard',
+    status: 'active' | 'past_due' | 'canceled' | 'trialing' | 'incomplete'
+  ): Promise<void> {
+    const { error } = await admin
+      .from('user_subscription')
+      .update({ plan_id: planId, status })
+      .eq('user_id', owner.id)
+    expect(error).toBeNull()
+  }
+
+  /**
+   * Clear Shares
+   *
+   * Wipes any `settlement_shared_user` rows for the fixture settlement so
+   * each test case starts from a known-empty state. Uses `admin` so the
+   * cleanup is independent of whatever subscription state the previous
+   * test left the owner in.
+   */
+  async function clearShares(): Promise<void> {
+    const { error } = await admin
+      .from('settlement_shared_user')
+      .delete()
+      .eq('settlement_id', settlementId)
+    expect(error).toBeNull()
+  }
+
+  describe('paid owner CAN create new shares', () => {
+    it('Lantern Hoard + active → INSERT succeeds', async () => {
+      await setOwnerSubscription('lantern_hoard', 'active')
+      await clearShares()
+
+      const { data, error } = await owner.client
+        .from('settlement_shared_user')
+        .insert({
+          settlement_id: settlementId,
+          shared_user_id: collaborator.id,
+          user_id: owner.id
+        })
+        .select('settlement_id, shared_user_id, user_id')
+        .single()
+
+      expect(error).toBeNull()
+      expect(data?.settlement_id).toBe(settlementId)
+      expect(data?.shared_user_id).toBe(collaborator.id)
+      expect(data?.user_id).toBe(owner.id)
+    })
+
+    it('Lantern Hoard + trialing → INSERT succeeds', async () => {
+      // Locks the second member of user_can_share()'s status whitelist
+      // against the policy as well as the helper itself.
+      await setOwnerSubscription('lantern_hoard', 'trialing')
+      await clearShares()
+
+      const { data, error } = await owner.client
+        .from('settlement_shared_user')
+        .insert({
+          settlement_id: settlementId,
+          shared_user_id: collaborator.id,
+          user_id: owner.id
+        })
+        .select('shared_user_id')
+        .single()
+
+      expect(error).toBeNull()
+      expect(data?.shared_user_id).toBe(collaborator.id)
+    })
+  })
+
+  describe('free / unentitled owner CANNOT create new shares', () => {
+    it('free + active → INSERT denied (RLS)', async () => {
+      // Default seeded state — but assert it explicitly so the test is
+      // not coupled to fixture defaults.
+      await setOwnerSubscription('free', 'active')
+      await clearShares()
+
+      const { data, error } = await owner.client
+        .from('settlement_shared_user')
+        .insert({
+          settlement_id: settlementId,
+          shared_user_id: collaborator.id,
+          user_id: owner.id
+        })
+        .select('shared_user_id')
+
+      expect(data ?? []).toEqual([])
+      expect(error).not.toBeNull()
+      // PostgREST surfaces an RLS check-clause failure as either a
+      // `42501` (newer) or a `PGRST` prefix code. Either is acceptable —
+      // both signal the same RLS denial.
+      expect(error?.code).toMatch(/PGRST|42501/)
+
+      // Defense-in-depth: confirm no row was created server-side.
+      const { data: post } = await admin
+        .from('settlement_shared_user')
+        .select('shared_user_id')
+        .eq('settlement_id', settlementId)
+      expect(post ?? []).toEqual([])
+    })
+
+    it('Lantern Hoard + past_due → INSERT denied (status whitelist excludes past_due)', async () => {
+      await setOwnerSubscription('lantern_hoard', 'past_due')
+      await clearShares()
+
+      const { data, error } = await owner.client
+        .from('settlement_shared_user')
+        .insert({
+          settlement_id: settlementId,
+          shared_user_id: collaborator.id,
+          user_id: owner.id
+        })
+        .select('shared_user_id')
+
+      expect(data ?? []).toEqual([])
+      expect(error).not.toBeNull()
+      expect(error?.code).toMatch(/PGRST|42501/)
+    })
+
+    it('lantern (no may_share) + active → INSERT denied (plan whitelist excludes lantern)', async () => {
+      // The middle tier is `active` and current, but `may_share = false`
+      // on the plan row. Pins the policy to the plan flag, not just to
+      // the status whitelist.
+      await setOwnerSubscription('lantern', 'active')
+      await clearShares()
+
+      const { data, error } = await owner.client
+        .from('settlement_shared_user')
+        .insert({
+          settlement_id: settlementId,
+          shared_user_id: collaborator.id,
+          user_id: owner.id
+        })
+        .select('shared_user_id')
+
+      expect(data ?? []).toEqual([])
+      expect(error).not.toBeNull()
+      expect(error?.code).toMatch(/PGRST|42501/)
+    })
+  })
+
+  describe('EC-12: cancelled owner — existing shares persist', () => {
+    it('owner with a paid-era share keeps SELECT/UPDATE/DELETE after downgrade, but cannot create new shares', async () => {
+      // 1. Owner is paying — seeds an existing share to `collaborator`.
+      await setOwnerSubscription('lantern_hoard', 'active')
+      await clearShares()
+      const { error: seedErr } = await owner.client
+        .from('settlement_shared_user')
+        .insert({
+          settlement_id: settlementId,
+          shared_user_id: collaborator.id,
+          user_id: owner.id
+        })
+      expect(seedErr).toBeNull()
+
+      // 2. Owner downgrades — subscription canceled.
+      await setOwnerSubscription('lantern_hoard', 'canceled')
+
+      // 3a. Existing share still visible to the owner.
+      const { data: visible, error: visibleErr } = await owner.client
+        .from('settlement_shared_user')
+        .select('shared_user_id, user_id')
+        .eq('settlement_id', settlementId)
+      expect(visibleErr).toBeNull()
+      expect(visible ?? []).toEqual([
+        { shared_user_id: collaborator.id, user_id: owner.id }
+      ])
+
+      // 3b. Owner can no longer create a NEW share (to the stranger).
+      const { data: newShare, error: newShareErr } = await owner.client
+        .from('settlement_shared_user')
+        .insert({
+          settlement_id: settlementId,
+          shared_user_id: stranger.id,
+          user_id: owner.id
+        })
+        .select('shared_user_id')
+      expect(newShare ?? []).toEqual([])
+      expect(newShareErr).not.toBeNull()
+      expect(newShareErr?.code).toMatch(/PGRST|42501/)
+
+      // 3c. Owner can still DELETE the existing share — the
+      //     "Allow delete for owner" policy is untouched by the migration,
+      //     so revoke-while-cancelled remains possible (matches §9.3).
+      const { data: deleted, error: deleteErr } = await owner.client
+        .from('settlement_shared_user')
+        .delete()
+        .eq('settlement_id', settlementId)
+        .eq('shared_user_id', collaborator.id)
+        .select('shared_user_id')
+      expect(deleteErr).toBeNull()
+      expect(deleted ?? []).toHaveLength(1)
+    })
+  })
+
+  describe('paid owner cannot launder a share through a forged user_id', () => {
+    it('owner with may_share but user_id != auth.uid() → INSERT denied', async () => {
+      // Regression test for the third clause of the policy. Even with
+      // user_can_share() = true and is_settlement_owner() = true, the
+      // `user_id = (select auth.uid())` clause prevents the owner from
+      // attributing the grant to anyone else.
+      await setOwnerSubscription('lantern_hoard', 'active')
+      await clearShares()
+
+      const { data, error } = await owner.client
+        .from('settlement_shared_user')
+        .insert({
+          settlement_id: settlementId,
+          shared_user_id: collaborator.id,
+          // Spoof: claim the share was created by the stranger.
+          user_id: stranger.id
+        })
+        .select('shared_user_id')
+
+      expect(data ?? []).toEqual([])
+      expect(error).not.toBeNull()
+      expect(error?.code).toMatch(/PGRST|42501/)
+    })
+  })
+
+  describe('admin / service-role bypass survives the migration', () => {
+    it('service_role can INSERT regardless of the owner subscription state', async () => {
+      // The fixture `admin` client uses the service_role key. Even with
+      // the owner explicitly downgraded to free, the service-role bypass
+      // (`Allow all for admin` + Postgres's bypassrls on the role)
+      // continues to allow direct inserts — required for support tooling
+      // and the integration-test fixture path.
+      await setOwnerSubscription('free', 'active')
+      await clearShares()
+
+      const { error } = await admin.from('settlement_shared_user').insert({
+        settlement_id: settlementId,
+        shared_user_id: collaborator.id,
+        user_id: owner.id
+      })
+      expect(error).toBeNull()
+
+      const { data: post } = await admin
+        .from('settlement_shared_user')
+        .select('shared_user_id')
+        .eq('settlement_id', settlementId)
+      expect(post ?? []).toEqual([{ shared_user_id: collaborator.id }])
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.66.0",
+      "version": "0.67.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260531000000_settlement_shared_user_paid_gate.sql
+++ b/supabase/migrations/20260531000000_settlement_shared_user_paid_gate.sql
@@ -1,0 +1,53 @@
+--------------------------------------------------------------------------------
+-- Gate `settlement_shared_user` INSERT on `user_can_share()` (Epic E3, Phase
+-- 3.3 — GitHub issue #165).
+--
+-- Replaces the prior `"Allow insert for authenticated"` INSERT policy (last
+-- minted by 20260324185335_fix_shared_user_rls_recursion.sql) with a tighter
+-- predicate that additionally requires the caller to be on a subscription
+-- plan whose `may_share = true` and whose status is `active` or `trialing`.
+-- The new predicate composes three independent checks:
+--
+--   1. `user_can_share()` — paid-tier entitlement (E3.2 helper added by
+--      20260530000000_user_can_share.sql).
+--   2. `is_settlement_owner(settlement_id)` — only the settlement owner may
+--      grant access to it.
+--   3. `user_id = (select auth.uid())` — the grantor column must match the
+--      authenticated user so a forged `user_id` cannot launder the share
+--      through someone else's identity. The `(select auth.uid())` form is
+--      Supabase's recommended initplan idiom (see
+--      https://supabase.com/docs/guides/database/postgres/row-level-security#call-functions-with-select).
+--
+-- Scope
+-- -----
+-- This migration intentionally touches ONLY the INSERT policy. The
+-- "Allow select for owner", "Allow update for owner", "Allow delete for
+-- owner", "Allow select for shared", and "Allow all for admin" policies
+-- minted in 20260220190650_settlement.sql remain unchanged so existing
+-- shares persist for an owner who later downgrades. This is the EC-12
+-- semantic from `docs/settlement-sharing-architecture.md` §9.3:
+--
+--   * Existing collaborator rows stay visible to the original grantor and
+--     to the shared user.
+--   * The grantor can still UPDATE / DELETE rows they already created (i.e.
+--     revoke a share manually).
+--   * Only the creation of new shares is paused while the grantor's
+--     subscription is not in an entitling state.
+--
+-- The admin bypass ("Allow all for admin") is also untouched, so
+-- service-role traffic and the `is_admin()` short-circuit continue to
+-- bypass the new paid gate — required for support tooling and the
+-- integration-test fixture path (`admin.from('settlement_shared_user')...`).
+--
+-- Reference: `docs/settlement-sharing-architecture.md` §9.2 / §9.3 /
+-- Appendix B EC-11, EC-12. Plan: §10 Phase 3 item 3.3. GitHub issue #165.
+--------------------------------------------------------------------------------
+drop policy if exists "Allow insert for authenticated" on settlement_shared_user;
+create policy "Allow insert by paying owner" on settlement_shared_user for
+insert to authenticated with check (
+    user_can_share()
+    and is_settlement_owner(settlement_id)
+    and user_id = (
+      select auth.uid()
+    )
+  );


### PR DESCRIPTION
Closes #165.

## Summary

Replaces the `"Allow insert for authenticated"` policy on `settlement_shared_user` with `"Allow insert by paying owner"`, gating the INSERT path on `user_can_share()` (the E3.2 SECURITY DEFINER helper from PR #238) in addition to the existing owner / `auth.uid()` checks.

This implements **Epic E3 Phase 3.3** — the actual paid-feature gate for settlement sharing. Free users can still _be_ collaborators (read-only of `shared_user_id`), they just can't create new shares; only Lantern Hoard subscribers in an entitling status (`active` or `trialing`) can.

## Migration

`supabase/migrations/20260531000000_settlement_shared_user_paid_gate.sql`:

```sql
drop policy if exists "Allow insert for authenticated" on settlement_shared_user;
create policy "Allow insert by paying owner" on settlement_shared_user for
insert to authenticated with check (
    user_can_share()
    and is_settlement_owner(settlement_id)
    and user_id = (select auth.uid())
);
```

### Policies intentionally left untouched (EC-12)

The `"Allow select for owner"`, `"Allow update for owner"`, `"Allow delete for owner"`, `"Allow select for shared"`, and `"Allow all for admin"` policies minted in `20260220190650_settlement.sql` are **not** modified, so:

- Existing shares persist for an owner who downgrades.
- The original grantor can still SELECT / UPDATE / DELETE rows they previously created — including manually revoking a stale share.
- Only the **creation** of new shares is paused while the grantor's subscription is non-entitling.
- The `service_role` / `is_admin()` bypass survives, which is required for Stripe webhooks, support tooling, and the integration-test fixture path.

This matches [`docs/settlement-sharing-architecture.md`](docs/settlement-sharing-architecture.md) §9.2 / §9.3 and Appendix B EC-12.

## Tests

`__tests__/integration/rls/settlement-shared.test.ts` — 8 cases covering the full acceptance matrix:

| Case | Expected |
| ---- | -------- |
| Lantern Hoard + `active`             | INSERT succeeds |
| Lantern Hoard + `trialing`           | INSERT succeeds |
| free + `active` (seeded state)       | RLS denial (PGRST / 42501) |
| Lantern Hoard + `past_due`           | RLS denial |
| `lantern` + `active` (no may_share)  | RLS denial |
| `user_id` spoof (paid owner sets `user_id = stranger.id`) | RLS denial |
| EC-12: paid → share → cancel → existing row visible + DELETE works + new share denied | All three sub-checks pass |
| `service_role` bypass with free owner | INSERT succeeds |

```
✓ __tests__/integration/rls/settlement-shared.test.ts (8 tests) 778ms
```

Full integration suite: **773 passed / 3 skipped (35 files)** — no regressions.

## Dependencies

- Built on the `user_can_share()` helper from PR #238 (E3.2 / issue #174).
- Unblocks **E3.10** (UI gate for share-creation button) and **E3.12** (Stripe-webhook coverage for the cancellation path).

## Out of scope

- Stripe wiring (E3.4–E3.7).
- UI: the "Light another lantern" button / "subscribe to share" upsell prompt referenced in §9.2 / EC-11.

## Version

`0.66.0` → `0.67.0` (minor — RLS policy change with new tier semantics). `package.json` and `package-lock.json` both bumped.

## References

- Issue: #165
- Architecture: `docs/settlement-sharing-architecture.md` §9.2, §9.3, §10 Phase 3 item 3.3, Appendix B EC-11 / EC-12
- Predecessor PR: #238 (E3.2 — `user_can_share()` helper)
