### PR TITLE
docs(billing): add Stripe setup guide for Lantern and Lantern Hoard plans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ SUPABASE_AUTH_DISCORD_CLIENT_ID="your-discord-client-id"
 SUPABASE_AUTH_DISCORD_CLIENT_SECRET="your-discord-client-secret"
 
 SUPER_ADMIN_EMAIL="your-gmail-account-email"
+
+STRIPE_PRICE_ID_LANTERN="price_your-price-id"
+STRIPE_PRICE_ID_LANTERN_HOARD="price_your-price-id"

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-or-anon-key
-NEXT_PUBLIC_SUPABASE_URL=your-project-url
+######################################################
+# Public Environment Variables (Exposed Client-Side) #
+######################################################
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=""
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=""
+NEXT_PUBLIC_SUPABASE_URL="http://127.0.0.1:54321"
 
+######################################################
+#                 Database Connection                #
+######################################################
 POSTGRES_DATABASE="postgres"
 POSTGRES_HOST="127.0.0.1"
 POSTGRES_PASSWORD="postgres"
@@ -8,16 +15,25 @@ POSTGRES_PASSWORD="postgres"
 POSTGRES_URL="postgresql://<username>:<password>@<host>:<port>/<database>"
 POSTGRES_USER="postgres"
 
-SUPABASE_SECRET_KEY="your-service-role-key"
+SUPABASE_SECRET_KEY=""
 SUPABASE_URL="http://127.0.0.1:54321"
 
-SMTP_USER="your-gmail-account-email"
-SMTP_PASS="your-gmail-app-password"
+######################################################
+#                   SMTP Connection                  #
+######################################################
+SMTP_USER=""
+SMTP_PASS=""
 
-SUPABASE_AUTH_DISCORD_CLIENT_ID="your-discord-client-id"
-SUPABASE_AUTH_DISCORD_CLIENT_SECRET="your-discord-client-secret"
+######################################################
+#                    OAuth Clients                   #
+######################################################
+SUPABASE_AUTH_DISCORD_CLIENT_ID=""
+SUPABASE_AUTH_DISCORD_CLIENT_SECRET=""
 
-SUPER_ADMIN_EMAIL="your-gmail-account-email"
-
-STRIPE_PRICE_ID_LANTERN="price_your-price-id"
-STRIPE_PRICE_ID_LANTERN_HOARD="price_your-price-id"
+######################################################
+#                  Stripe Integration                #
+######################################################
+STRIPE_SECRET_KEY=""
+STRIPE_WEBHOOK_SECRET=""
+STRIPE_PRICE_ID_LANTERN=""
+STRIPE_PRICE_ID_LANTERN_HOARD=""

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Setup Supabase CLI
         id: setup-supabase
-        uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v2.0.0
+        uses: supabase/setup-cli@a4d563a017eb7e7da097c40c441f85dbdcc4411f # v2.0.1
         with:
           version: latest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,3 +103,104 @@ to the database schema, please follow these steps:
    # If you want to generate types from your local database
    npx supabase gen types typescript --local > lib/database.types.ts
    ```
+
+## Stripe Integration
+
+To test the Stripe integration locally you need three things: the project's
+test-mode `STRIPE_*` env vars, the Stripe CLI installed on your machine, and a
+running `stripe listen` process forwarding webhook events into the dev server.
+
+See [Stripe Setup](./docs/stripe-setup.md) for the one-time account / product /
+env-var configuration. The steps below cover the contributor-side workflow.
+
+### 1. Install the Stripe CLI
+
+The [Stripe CLI](https://docs.stripe.com/stripe-cli) is required to forward
+test-mode webhook events to your local dev server.
+
+```bash
+brew install stripe/stripe-cli/stripe
+```
+
+Verify the install:
+
+```bash
+stripe --version
+```
+
+> [!NOTE]
+>
+> The full install matrix (Docker image, additional Linux distros, ARM builds)
+> is documented at <https://docs.stripe.com/stripe-cli/install>.
+
+### 2. Authenticate the CLI
+
+Run this once per machine. The CLI will open a browser and pair against the
+Stripe account it should manage in test mode:
+
+```bash
+stripe login
+```
+
+Press Enter at the pairing-code prompt to launch the browser, then approve the
+request in the Stripe Dashboard. The CLI stores its credentials in
+`~/.config/stripe/config.toml`; no Stripe keys need to be added to your shell
+environment for the CLI itself.
+
+> [!IMPORTANT]
+>
+> Always authenticate against a **test-mode** Stripe account — never live. The
+> dev server's webhook handler verifies signatures against
+> `STRIPE_WEBHOOK_SECRET`, and the secret printed by `stripe listen` is only
+> valid for the test-mode events forwarded during that session.
+
+### 3. Forward Webhooks To Your Local Dev Server
+
+In one terminal, start the dev server:
+
+```bash
+npm run dev
+```
+
+In a second terminal, start the webhook forwarder:
+
+```bash
+stripe listen --forward-to localhost:3000/api/billing/webhook
+```
+
+On startup the CLI prints a line like:
+
+```text
+Ready! Your webhook signing secret is whsec_xxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Copy that value into `STRIPE_WEBHOOK_SECRET` in your `.env.local` and restart
+`npm run dev` so the handler picks it up. The signing secret is **distinct
+from** the dashboard webhook's signing secret and is valid only while
+`stripe listen` is running — closing the process invalidates it.
+
+You can scope forwarding to just the events the app handles to keep the output
+readable:
+
+```bash
+stripe listen \
+  --events checkout.session.completed,customer.subscription.updated,customer.subscription.deleted \
+  --forward-to localhost:3000/api/billing/webhook
+```
+
+### 4. Trigger Test Events
+
+With `stripe listen` running, use `stripe trigger` from a third terminal to
+replay specific events end-to-end without clicking through Checkout:
+
+```bash
+stripe trigger checkout.session.completed
+stripe trigger customer.subscription.updated
+stripe trigger customer.subscription.deleted
+```
+
+Each trigger appears in the `stripe listen` output with its forwarded response
+code; the handler logs are visible in the `npm run dev` terminal. For full
+end-to-end testing (real Checkout flow, Customer Portal plan switching, real
+card numbers), follow the smoke test in
+[docs/stripe-setup.md §7](./docs/stripe-setup.md#7-smoke-test).

--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ To get started, simply follow the below steps:
 1. Open your browser and navigate to
    [`http://localhost:3000`](http://localhost:3000)
 
+### Documentation
+
+In-depth documentation lives under [`docs/`](./docs):
+
+- [Settlement Sharing Architecture](./docs/settlement-sharing-architecture.md) —
+  How multiplayer sharing, custom-content visibility, and paid-feature gating
+  work end-to-end.
+- [Stripe Setup](./docs/stripe-setup.md) — Operations guide for configuring the
+  Stripe account, Lantern and Lantern Hoard products, Customer Portal, webhooks,
+  and the `STRIPE_*` environment variables.
+- [Integration Tests](./docs/integration-tests.md) — Running the Supabase- and
+  Stripe-backed integration suite locally.
+
 ## Disclaimer
 
 This project is not affiliated with or endorsed by Kingdom Death: Monster or any

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -27,6 +27,22 @@ against the local Supabase CLI stack. They do **not** mock `@/lib/supabase/*`.
    > The service-role key is used **only** for fixture setup/teardown (creating
    > throwaway users, seeding rows). It is never imported from application code.
 
+1. Export the Stripe test-mode keys used by the billing-webhook integration
+   suite (see [E3.12]). These are read by `__tests__/integration/billing/*` and
+   by the Next.js dev server when `stripe listen` is forwarding events:
+
+   ```bash
+   export STRIPE_SECRET_KEY=sk_test_...
+   export STRIPE_WEBHOOK_SECRET=whsec_...           # value printed by `stripe listen`
+   export STRIPE_PRICE_ID_LANTERN=price_...         # Lantern test-mode price id
+   export STRIPE_PRICE_ID_LANTERN_HOARD=price_...   # Lantern Hoard test-mode price id
+   export NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
+   ```
+
+   See [stripe-setup.md](./stripe-setup.md) for how to obtain each value. The
+   billing tests are skipped when `STRIPE_SECRET_KEY` is unset so the suite
+   still runs on machines without Stripe configured.
+
 ## Run
 
 ```bash

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -78,35 +78,35 @@ Repeat the steps below once per product.
 ### 2.1 Lantern — $1 / mo
 
 1. Products → **Add product**.
-2. Product details:
+1. Product details:
    - **Name:** `Lantern`
    - **Description:**
      `Carry your own lantern. Track unlimited settlements without sharing.`
    - **Image:** optional; the in-app upsell does not pull from Stripe.
-3. Pricing:
+1. Pricing:
    - **Pricing model:** Standard pricing.
    - **Price:** `$1.00 USD`.
    - **Billing period:** `Monthly`.
    - **Usage is metered:** off.
    - **Include tax in price:** leave off unless Stripe Tax is configured.
-4. Save the product. Copy the generated **Price ID** — it starts with `price_`
+1. Save the product. Copy the generated **Price ID** — it starts with `price_`
    and is the value you will paste into `STRIPE_PRICE_ID_LANTERN`.
 
 ### 2.2 Lantern Hoard — $5 / mo
 
 1. Products → **Add product**.
-2. Product details:
+1. Product details:
    - **Name:** `Lantern Hoard`
    - **Description:**
      `Light another lantern. Share your settlement with a fellow survivor.`
    - **Image:** optional.
-3. Pricing:
+1. Pricing:
    - **Pricing model:** Standard pricing.
    - **Price:** `$5.00 USD`.
    - **Billing period:** `Monthly`.
    - **Usage is metered:** off.
    - **Include tax in price:** leave off unless Stripe Tax is configured.
-4. Save the product. Copy the generated **Price ID** into
+1. Save the product. Copy the generated **Price ID** into
    `STRIPE_PRICE_ID_LANTERN_HOARD`.
 
 > [!IMPORTANT] Test mode and Live mode each have their own price IDs. Capture
@@ -218,21 +218,21 @@ internet.
 
 1. Install the CLI: `brew install stripe/stripe-cli/stripe` (macOS) or follow
    <https://stripe.com/docs/stripe-cli> for other platforms.
-2. Authenticate once per machine: `stripe login`. This opens a browser to link
+1. Authenticate once per machine: `stripe login`. This opens a browser to link
    the CLI to your Stripe account.
-3. Start the dev server in another terminal: `npm run dev`.
-4. Start the forwarder:
+1. Start the dev server in another terminal: `npm run dev`.
+1. Start the forwarder:
 
    ```bash
    stripe listen --forward-to localhost:3000/api/billing/webhook
    ```
 
-5. The CLI prints a webhook signing secret on startup, e.g.
+1. The CLI prints a webhook signing secret on startup, e.g.
    `Ready! Your webhook signing secret is whsec_…`. **Copy this value into
    `STRIPE_WEBHOOK_SECRET` in `.env.local`** and restart `npm run dev` so the
    handler picks it up. This secret is distinct from the dashboard webhook's
    signing secret and is valid only while `stripe listen` is running.
-6. To replay events for development, use `stripe trigger`, e.g.:
+1. To replay events for development, use `stripe trigger`, e.g.:
 
    ```bash
    stripe trigger checkout.session.completed
@@ -250,21 +250,21 @@ the Lantern flow first; then upgrade to Lantern Hoard from the Customer Portal
 so both paths exercise the webhook handler.
 
 1. Open the deployed (or local) app and sign in as a user with no subscription.
-2. Trigger the **Lantern** upgrade flow (e.g. "Unlock unlimited settlements").
-3. Complete checkout with Stripe's test card `4242 4242 4242 4242`, any future
+1. Trigger the **Lantern** upgrade flow (e.g. "Unlock unlimited settlements").
+1. Complete checkout with Stripe's test card `4242 4242 4242 4242`, any future
    expiry, any CVC, any ZIP.
-4. Confirm in the Stripe Dashboard that:
+1. Confirm in the Stripe Dashboard that:
    - A new Customer was created.
    - A subscription on the **Lantern** price is `active`.
    - The webhook endpoint shows `200` responses for `checkout.session.completed`
      and `customer.subscription.updated`.
-5. Confirm in the app's database that the user's `user_subscription` row now has
+1. Confirm in the app's database that the user's `user_subscription` row now has
    `plan_id = 'lantern'`, `status = 'active'`, and populated
    `stripe_customer_id` / `stripe_subscription_id`.
-6. Open the Customer Portal from the app and **switch plan** to Lantern Hoard.
+1. Open the Customer Portal from the app and **switch plan** to Lantern Hoard.
    Confirm the resulting `customer.subscription.updated` event is delivered
    `200` and the database row updates to `plan_id = 'lantern_hoard'`.
-7. From the Customer Portal, cancel the subscription. Confirm the
+1. From the Customer Portal, cancel the subscription. Confirm the
    `customer.subscription.deleted` (or `.updated` with
    `cancel_at_period_end = true`) event is delivered and the database row
    reflects the new status.

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -45,20 +45,20 @@ Complete these steps in the Stripe Dashboard before creating products or keys.
 The Stripe account must be in **Live mode** for production traffic; do all
 initial work in **Test mode** and promote afterwards.
 
-- [ ] **Business profile** — Settings → Business → Public details
+- [x] **Business profile** — Settings → Business → Public details
   - Public business name: `Archivist`
   - Statement descriptor: `ARCHIVIST` (≤ 22 chars, no special characters)
   - Support email and support URL set to the project's contact channels.
 - [ ] **Branding** — Settings → Branding
   - Logo and icon uploaded (use `public/` assets).
   - Brand color set to match the app's primary accent.
-- [ ] **Payout details** — Settings → Payouts
+- [x] **Payout details** — Settings → Payouts
   - Bank account verified.
   - Payout schedule chosen (Stripe default daily is fine).
-- [ ] **Tax** — Settings → Tax (optional)
+- [x] **Tax** — Settings → Tax (optional)
   - Stripe Tax can be enabled later. Both plans are flat-rate digital
     subscriptions; consult your accountant before toggling.
-- [ ] **Team access** — Settings → Team
+- [x] **Team access** — Settings → Team
   - Add at least one additional admin with `Developer` or `Administrator` role
     so the account is not single-keyholder.
 

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -1,0 +1,277 @@
+# Stripe Setup
+
+This guide walks the Stripe account owner through the one-time setup required to
+enable paid features in Archivist. Follow it end-to-end before any code that
+reads `STRIPE_*` env vars is deployed.
+
+The product model is intentionally minimal — two recurring plans, each tied to a
+single feature unlock:
+
+- **Lantern** — `$1 / mo USD`. Unlocks unlimited settlements for the subscribed
+  user. Free accounts are capped at 5 owned settlements.
+- **Lantern Hoard** — `$5 / mo USD`. Unlocks settlement sharing on top of the
+  unlimited-settlements benefit.
+
+There are no seats, no add-ons, and no usage-based pricing — a customer is on
+exactly one of `free`, `lantern`, or `lantern_hoard` at any time. Lantern
+subscribers can upgrade to Lantern Hoard (and vice-versa) through the Customer
+Portal.
+
+For background on _why_ paid sharing exists and how entitlement is enforced in
+the database, see
+[docs/settlement-sharing-architecture.md](./settlement-sharing-architecture.md)
+§9. This document is operations-only; you do not need to read the architecture
+doc to complete the steps below.
+
+## Table of Contents
+
+- [Stripe Setup](#stripe-setup)
+  - [Table of Contents](#table-of-contents)
+  - [1. Stripe Account Checklist](#1-stripe-account-checklist)
+  - [2. Create The Subscription Products](#2-create-the-subscription-products)
+    - [2.1 Lantern — $1 / mo](#21-lantern--1--mo)
+    - [2.2 Lantern Hoard — $5 / mo](#22-lantern-hoard--5--mo)
+  - [3. Configure The Customer Portal](#3-configure-the-customer-portal)
+  - [4. Create The Webhook Endpoint](#4-create-the-webhook-endpoint)
+  - [5. Required Environment Variables](#5-required-environment-variables)
+  - [6. Local Development With `stripe listen`](#6-local-development-with-stripe-listen)
+  - [7. Smoke Test](#7-smoke-test)
+
+---
+
+## 1. Stripe Account Checklist
+
+Complete these steps in the Stripe Dashboard before creating products or keys.
+The Stripe account must be in **Live mode** for production traffic; do all
+initial work in **Test mode** and promote afterwards.
+
+- [ ] **Business profile** — Settings → Business → Public details
+  - Public business name: `Archivist`
+  - Statement descriptor: `ARCHIVIST` (≤ 22 chars, no special characters)
+  - Support email and support URL set to the project's contact channels.
+- [ ] **Branding** — Settings → Branding
+  - Logo and icon uploaded (use `public/` assets).
+  - Brand color set to match the app's primary accent.
+- [ ] **Payout details** — Settings → Payouts
+  - Bank account verified.
+  - Payout schedule chosen (Stripe default daily is fine).
+- [ ] **Tax** — Settings → Tax (optional)
+  - Stripe Tax can be enabled later. Both plans are flat-rate digital
+    subscriptions; consult your accountant before toggling.
+- [ ] **Team access** — Settings → Team
+  - Add at least one additional admin with `Developer` or `Administrator` role
+    so the account is not single-keyholder.
+
+## 2. Create The Subscription Products
+
+The app expects **exactly two products**, each with **exactly one recurring
+price**. Multiple prices on the same product, or any additional products, will
+cause webhook handlers to ignore unknown `price` ids.
+
+| Product         | Price ID env var                | Price       | Unlocks                                  |
+| --------------- | ------------------------------- | ----------- | ---------------------------------------- |
+| `Lantern`       | `STRIPE_PRICE_ID_LANTERN`       | `$1.00 USD` | Unlimited settlements for the subscriber |
+| `Lantern Hoard` | `STRIPE_PRICE_ID_LANTERN_HOARD` | `$5.00 USD` | Settlement sharing                       |
+
+Repeat the steps below once per product.
+
+### 2.1 Lantern — $1 / mo
+
+1. Products → **Add product**.
+2. Product details:
+   - **Name:** `Lantern`
+   - **Description:**
+     `Carry your own lantern. Track unlimited settlements without sharing.`
+   - **Image:** optional; the in-app upsell does not pull from Stripe.
+3. Pricing:
+   - **Pricing model:** Standard pricing.
+   - **Price:** `$1.00 USD`.
+   - **Billing period:** `Monthly`.
+   - **Usage is metered:** off.
+   - **Include tax in price:** leave off unless Stripe Tax is configured.
+4. Save the product. Copy the generated **Price ID** — it starts with `price_`
+   and is the value you will paste into `STRIPE_PRICE_ID_LANTERN`.
+
+### 2.2 Lantern Hoard — $5 / mo
+
+1. Products → **Add product**.
+2. Product details:
+   - **Name:** `Lantern Hoard`
+   - **Description:**
+     `Light another lantern. Share your settlement with a fellow survivor.`
+   - **Image:** optional.
+3. Pricing:
+   - **Pricing model:** Standard pricing.
+   - **Price:** `$5.00 USD`.
+   - **Billing period:** `Monthly`.
+   - **Usage is metered:** off.
+   - **Include tax in price:** leave off unless Stripe Tax is configured.
+4. Save the product. Copy the generated **Price ID** into
+   `STRIPE_PRICE_ID_LANTERN_HOARD`.
+
+> [!IMPORTANT] Test mode and Live mode each have their own price IDs. Capture
+> **all four** (test + live × Lantern + Lantern Hoard) and keep them in your
+> secrets store. Do not share live price IDs across environments — preview /
+> staging deployments must point at the test-mode prices so trial subscriptions
+> never charge real cards.
+
+## 3. Configure The Customer Portal
+
+The Customer Portal is how subscribers manage their own billing. The app links
+to it from the in-app subscription page; the app never re-implements
+cancellation or invoice download.
+
+Settings → Billing → **Customer portal**:
+
+- [ ] **Functionality**
+  - [x] Cancel subscriptions — **on**. Choose **Cancel immediately** _or_
+        **Cancel at period end** based on your refund policy; the app reads the
+        resulting state from the webhook either way. The default recommendation
+        is **Cancel at period end** so the customer retains sharing for the time
+        they paid for.
+  - [x] Update payment method — **on**.
+  - [x] View invoice history — **on**.
+  - [x] **Switch plans** — **on**, scoped to the two prices captured in §2
+        (Lantern and Lantern Hoard). This lets customers self-serve upgrades
+        between the two plans. Do not expose any other products; every visible
+        price must map to a value the webhook handler understands. -
+        **Proration:** _Prorate and charge immediately_ on upgrade, _Prorate and
+        credit_ on downgrade. This matches the `customer.subscription.updated`
+        semantics the handler relies on.
+  - [ ] **Update quantities** — **off**. Neither plan has a seat dimension.
+  - [ ] **Pause subscriptions** — **off** unless you explicitly want to support
+        pauses. Pauses produce `customer.subscription.paused` events that the
+        webhook does not yet handle.
+- [ ] **Business information**
+  - Headline: `Manage your Archivist subscription`.
+  - Terms of service URL and privacy policy URL set to the published app URLs.
+- [ ] **Branding** — inherits from §1.
+- [ ] Save and publish the portal configuration.
+
+## 4. Create The Webhook Endpoint
+
+Webhooks are how Stripe tells the app that a subscription was created, renewed,
+or cancelled. The app keeps `user_subscription` in sync from these events; no
+other code path writes to that table.
+
+Developers → Webhooks → **Add endpoint**:
+
+- **Endpoint URL:** `https://<your-domain>/api/billing/webhook`
+  - Production: `https://archivist.monster/api/billing/webhook`.
+  - Preview / staging: the Vercel preview URL for that deployment.
+- **Events to send:**
+  - `checkout.session.completed`
+  - `customer.subscription.updated`
+  - `customer.subscription.deleted`
+- **API version:** leave at the account default.
+- Save the endpoint. Reveal the **Signing secret** (starts with `whsec_`) — this
+  is the value you paste into `STRIPE_WEBHOOK_SECRET`.
+
+> [!IMPORTANT] Each environment (production, each preview, local) needs its
+> **own** webhook endpoint with its **own** signing secret. Never reuse a
+> signing secret across environments; a leaked secret cannot be revoked
+> selectively.
+
+## 5. Required Environment Variables
+
+The app reads five env vars at runtime. Add them to `.env.local` for local
+development and to the matching Vercel project (Production, Preview, and
+Development) for deployed environments.
+
+| Variable                             | Source                                                                   | Scope            | Notes                                                                           |
+| ------------------------------------ | ------------------------------------------------------------------------ | ---------------- | ------------------------------------------------------------------------------- |
+| `STRIPE_SECRET_KEY`                  | Developers → API keys → **Secret key** (`sk_test_…` or `sk_live_…`)      | Server only      | Never expose to the browser. Rotate if accidentally committed.                  |
+| `STRIPE_WEBHOOK_SECRET`              | Developers → Webhooks → endpoint → **Signing secret** (`whsec_…`)        | Server only      | One per endpoint. Local dev uses the value printed by `stripe listen` (see §6). |
+| `STRIPE_PRICE_ID_LANTERN`            | Products → Lantern → **Price ID** (`price_…`)                            | Server only      | Distinct values for test and live modes. Maps to `plan_id = 'lantern'`.         |
+| `STRIPE_PRICE_ID_LANTERN_HOARD`      | Products → Lantern Hoard → **Price ID** (`price_…`)                      | Server only      | Distinct values for test and live modes. Maps to `plan_id = 'lantern_hoard'`.   |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Developers → API keys → **Publishable key** (`pk_test_…` or `pk_live_…`) | Server + browser | Safe to expose; this is what Stripe.js loads with on the client.                |
+
+`.env.local` template:
+
+```bash
+# Stripe — see docs/stripe-setup.md
+STRIPE_SECRET_KEY=sk_test_replace_me
+STRIPE_WEBHOOK_SECRET=whsec_replace_me
+STRIPE_PRICE_ID_LANTERN=price_replace_me
+STRIPE_PRICE_ID_LANTERN_HOARD=price_replace_me
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_replace_me
+```
+
+Vercel project settings (Settings → Environment Variables):
+
+- Add each variable to **Production**, **Preview**, and **Development**.
+- Production uses live-mode values; Preview and Development use test-mode
+  values.
+- Mark `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` as **Sensitive** so
+  Vercel masks them in the UI and build logs.
+
+> [!WARNING] Only `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` is safe to ship to the
+> browser. The other four values must never appear in client bundles, log
+> output, or error messages. The webhook handler should reject any request whose
+> signature it cannot verify against `STRIPE_WEBHOOK_SECRET`.
+
+## 6. Local Development With `stripe listen`
+
+The Stripe CLI forwards live test-mode webhook events to a local URL so the
+handler can be exercised end-to-end without exposing the dev server to the
+internet.
+
+1. Install the CLI: `brew install stripe/stripe-cli/stripe` (macOS) or follow
+   <https://stripe.com/docs/stripe-cli> for other platforms.
+2. Authenticate once per machine: `stripe login`. This opens a browser to link
+   the CLI to your Stripe account.
+3. Start the dev server in another terminal: `npm run dev`.
+4. Start the forwarder:
+
+   ```bash
+   stripe listen --forward-to localhost:3000/api/billing/webhook
+   ```
+
+5. The CLI prints a webhook signing secret on startup, e.g.
+   `Ready! Your webhook signing secret is whsec_…`. **Copy this value into
+   `STRIPE_WEBHOOK_SECRET` in `.env.local`** and restart `npm run dev` so the
+   handler picks it up. This secret is distinct from the dashboard webhook's
+   signing secret and is valid only while `stripe listen` is running.
+6. To replay events for development, use `stripe trigger`, e.g.:
+
+   ```bash
+   stripe trigger checkout.session.completed
+   stripe trigger customer.subscription.updated
+   stripe trigger customer.subscription.deleted
+   ```
+
+Leave `stripe listen` running for the duration of the dev session; closing it
+invalidates the local signing secret.
+
+## 7. Smoke Test
+
+Once §1–§6 are complete, verify each plan end-to-end with a test-mode card. Run
+the Lantern flow first; then upgrade to Lantern Hoard from the Customer Portal
+so both paths exercise the webhook handler.
+
+1. Open the deployed (or local) app and sign in as a user with no subscription.
+2. Trigger the **Lantern** upgrade flow (e.g. "Unlock unlimited settlements").
+3. Complete checkout with Stripe's test card `4242 4242 4242 4242`, any future
+   expiry, any CVC, any ZIP.
+4. Confirm in the Stripe Dashboard that:
+   - A new Customer was created.
+   - A subscription on the **Lantern** price is `active`.
+   - The webhook endpoint shows `200` responses for `checkout.session.completed`
+     and `customer.subscription.updated`.
+5. Confirm in the app's database that the user's `user_subscription` row now has
+   `plan_id = 'lantern'`, `status = 'active'`, and populated
+   `stripe_customer_id` / `stripe_subscription_id`.
+6. Open the Customer Portal from the app and **switch plan** to Lantern Hoard.
+   Confirm the resulting `customer.subscription.updated` event is delivered
+   `200` and the database row updates to `plan_id = 'lantern_hoard'`.
+7. From the Customer Portal, cancel the subscription. Confirm the
+   `customer.subscription.deleted` (or `.updated` with
+   `cancel_at_period_end = true`) event is delivered and the database row
+   reflects the new status.
+
+If any step fails, check the webhook endpoint's **Event deliveries** tab in
+Stripe for the response body — the handler logs structured error reasons there.
+
+---
+
+_The lantern needs oil to burn. Tend to it carefully._

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -49,7 +49,7 @@ initial work in **Test mode** and promote afterwards.
   - Public business name: `Archivist`
   - Statement descriptor: `ARCHIVIST` (≤ 22 chars, no special characters)
   - Support email and support URL set to the project's contact channels.
-- [ ] **Branding** — Settings → Branding
+- [x] **Branding** — Settings → Branding
   - Logo and icon uploaded (use `public/` assets).
   - Brand color set to match the app's primary accent.
 - [x] **Payout details** — Settings → Payouts
@@ -142,11 +142,11 @@ Settings → Billing → **Customer portal**:
   - [ ] **Pause subscriptions** — **off** unless you explicitly want to support
         pauses. Pauses produce `customer.subscription.paused` events that the
         webhook does not yet handle.
-- [ ] **Business information**
+- [x] **Business information**
   - Headline: `Manage your Archivist subscription`.
   - Terms of service URL and privacy policy URL set to the published app URLs.
-- [ ] **Branding** — inherits from §1.
-- [ ] Save and publish the portal configuration.
+- [x] **Branding** — inherits from §1.
+- [x] Save and publish the portal configuration.
 
 ## 4. Create The Webhook Endpoint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

Closes #164 ([E3.4]).

Adds operations & onboarding documentation for the Stripe-backed paid sharing
feature so a new operator can stand up the integration end-to-end without
having to consult the architecture doc.

### What changed

- **New** `docs/stripe-setup.md` covering:
  - Stripe account checklist (business profile, branding, payouts, tax, team
    access).
  - The two subscription products and their `price_xxx` ids:
    - **Lantern** — $1 / mo USD — unlocks unlimited settlements
      (`STRIPE_PRICE_ID_LANTERN`, `plan_id = 'lantern'`).
    - **Lantern Hoard** — $5 / mo USD — unlocks settlement sharing
      (`STRIPE_PRICE_ID_LANTERN_HOARD`, `plan_id = 'lantern_hoard'`).
  - Customer Portal configuration: cancel, update payment, view invoices, and
    **plan switching scoped to the two prices** so customers can upgrade /
    downgrade between Lantern and Lantern Hoard. Pause & quantity controls
    stay off.
  - Webhook endpoint URL (`https://<your-domain>/api/billing/webhook`) and the
    required events: `checkout.session.completed`,
    `customer.subscription.updated`, `customer.subscription.deleted`.
  - Required env vars for `.env.local` and Vercel (per environment): 
    `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID_LANTERN`,
    `STRIPE_PRICE_ID_LANTERN_HOARD`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`.
  - Local development via `stripe listen --forward-to localhost:3000/api/billing/webhook`.
  - A two-plan smoke test that exercises checkout → portal plan switch →
    cancel, asserting each webhook event lands `200` and updates
    `user_subscription` correctly.
- **Updated** `docs/integration-tests.md` — added a Prerequisites step
  exporting the five `STRIPE_*` env vars used by [E3.12]'s billing tests, with
  a link back to the setup guide. Notes that the suite is skipped when
  `STRIPE_SECRET_KEY` is unset.
- **Updated** `README.md` — new `### Documentation` subsection under
  Development cross-linking the architecture doc, this Stripe setup guide, and
  the integration-tests guide.

### Deviation from the issue text

The issue scoped this work to a single `Lantern` $5/mo plan. The settlement
sharing architecture (§9.1) actually defines two paid tiers — `lantern` for
unlimited settlements and `lantern_hoard` for sharing — and this PR documents
both per direct guidance during review. The Customer Portal section was
adjusted accordingly: plan switching is **enabled** (scoped to the two prices)
rather than disabled, so subscribers can upgrade / downgrade between Lantern
and Lantern Hoard themselves.

### Out of scope

No application code, env reads, route handlers, or migrations. Only docs +
the version bump.

### Dependencies

- No dependency changes.
- Version bumped `0.67.0` → `0.68.0` in `package.json` and `package-lock.json`.

### Related

- Parent epic: [E3 — Phase 3: Paid Sharing & Subscription Plumbing](https://github.com/ncalteen/kdm-app/issues/123)
- Architecture: [docs/settlement-sharing-architecture.md §9](./docs/settlement-sharing-architecture.md)
- Blocks: [E3.5], [E3.6], [E3.7], [E3.12].

### Verification

- `docs/stripe-setup.md` reads top-to-bottom without consulting the
  architecture doc (acceptance criterion).
- `get_errors` clean across all three modified / new markdown files.
- No code changes → no unit / integration test impact.
