### PR TITLE
feat(billing): add Stripe Customer Portal session route (#175)

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -130,6 +130,8 @@ REPORTERS_MARKDOWN_TYPE: advanced
 # Additional list of secured environment variables to hide when calling linters.
 # SECURED_ENV_VARIABLES: []
 
+SECURITY_SUGGESTIONS: false
+
 # Displays elapsed time in reports
 SHOW_ELAPSED_TIME: true
 

--- a/__tests__/app/api/billing/checkout/route.test.ts
+++ b/__tests__/app/api/billing/checkout/route.test.ts
@@ -391,4 +391,32 @@ describe('POST /api/billing/checkout', () => {
     const args = mockCheckoutSessionsCreate.mock.calls[0][0]
     expect(args.success_url).toMatch(/^https:\/\/archivist\.test\//)
   })
+
+  it('fails closed with a 500 in production when NEXT_PUBLIC_SITE_URL is malformed', async () => {
+    // PR #242 review comment r3262472051: production must not silently
+    // degrade to the Host-derived request URL when the canonical origin is
+    // malformed. Verify the helper's throw is caught by the route's outer
+    // try/catch and surfaces as a generic 500 — Stripe must NOT be called.
+    const originalNodeEnv = process.env.NODE_ENV
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = 'production'
+    process.env.NEXT_PUBLIC_SITE_URL = 'https//archivist.monster'
+
+    try {
+      setupAuth({
+        user: { id: 'user-1', email: 'a@b.test' },
+        subscription: { stripe_customer_id: 'cus_existing' }
+      })
+      setupAdminWriter()
+
+      const response = await POST(buildRequest({ planId: 'lantern' }))
+      const json = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(json.error).toMatch(/darkness/i)
+      expect(mockCheckoutSessionsCreate).not.toHaveBeenCalled()
+    } finally {
+      ;(process.env as Record<string, string | undefined>).NODE_ENV =
+        originalNodeEnv
+    }
+  })
 })

--- a/__tests__/app/api/billing/portal/route.test.ts
+++ b/__tests__/app/api/billing/portal/route.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Stub `server-only`. Its real module body throws when loaded outside the
+// React Server Component bundle, which would block Vitest from importing the
+// route under test.
+vi.mock('server-only', () => ({}))
+
+// Hoisted mocks must be declared before any imports that wire them up.
+const { mockGetUser, mockCreateClient } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockCreateClient: vi.fn()
+}))
+
+const { mockAdminFrom, mockCreateAdminClient } = vi.hoisted(() => ({
+  mockAdminFrom: vi.fn(),
+  mockCreateAdminClient: vi.fn()
+}))
+
+const { mockBillingPortalSessionsCreate, MockStripe } = vi.hoisted(() => {
+  const portalSessionsCreate = vi.fn()
+  class Stripe {
+    billingPortal = { sessions: { create: portalSessionsCreate } }
+  }
+  return {
+    mockBillingPortalSessionsCreate: portalSessionsCreate,
+    MockStripe: Stripe
+  }
+})
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: mockCreateClient
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: mockCreateAdminClient
+}))
+
+vi.mock('stripe', () => ({
+  default: MockStripe
+}))
+
+import { NextRequest } from 'next/server'
+
+const { POST } = await import('@/app/api/billing/portal/route')
+
+/**
+ * Build a NextRequest with an optional JSON body that the route can call
+ * `.json()` on. The portal route does not actually read a body, but tests
+ * still need a real `NextRequest` for header handling.
+ */
+function buildRequest(headers: Record<string, string> = {}) {
+  return new NextRequest('https://archivist.test/api/billing/portal', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers }
+  })
+}
+
+/**
+ * Wire the user-scoped Supabase client mock with the supplied auth state.
+ */
+function setupAuth(options: {
+  user: { id: string; email: string | null } | null
+  authError?: { message: string } | null
+}) {
+  mockGetUser.mockResolvedValue({
+    data: { user: options.user },
+    error: options.authError ?? null
+  })
+
+  mockCreateClient.mockResolvedValue({
+    auth: { getUser: mockGetUser }
+  })
+}
+
+/**
+ * Wire the service-role admin Supabase client to capture reads against
+ * `user_subscription` and return the supplied row + error state.
+ */
+function setupAdminLookup(options: {
+  subscription?: { stripe_customer_id: string | null } | null
+  subscriptionError?: { message: string } | null
+}) {
+  const maybeSingle = vi.fn().mockResolvedValue({
+    data: options.subscription ?? null,
+    error: options.subscriptionError ?? null
+  })
+  const eq = vi.fn().mockReturnValue({ maybeSingle })
+  const select = vi.fn().mockReturnValue({ eq })
+  mockAdminFrom.mockReturnValue({ select })
+  mockCreateAdminClient.mockReturnValue({ from: mockAdminFrom })
+
+  return { select, eq, maybeSingle }
+}
+
+describe('POST /api/billing/portal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.STRIPE_SECRET_KEY = 'sk_test_123'
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://127.0.0.1:54321'
+    process.env.SUPABASE_SECRET_KEY = 'service-role-key'
+    delete process.env.NEXT_PUBLIC_SITE_URL
+  })
+
+  it('returns 401 when the caller is not authenticated', async () => {
+    setupAuth({ user: null })
+
+    const response = await POST(buildRequest())
+    const json = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(json.error).toBe('Not Authenticated')
+    expect(mockCreateAdminClient).not.toHaveBeenCalled()
+    expect(mockBillingPortalSessionsCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when supabase reports an auth error', async () => {
+    setupAuth({ user: null, authError: { message: 'JWT expired' } })
+
+    const response = await POST(buildRequest())
+
+    expect(response.status).toBe(401)
+    expect(mockCreateAdminClient).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 "No Subscription" when the user has no user_subscription row', async () => {
+    // A missing row means the caller has never had a subscription provisioned
+    // (and therefore no Stripe customer). The portal has nothing to manage,
+    // so 400 is the correct user-state response.
+    setupAuth({ user: { id: 'user-1', email: 'a@b.test' } })
+    setupAdminLookup({ subscription: null })
+
+    const response = await POST(buildRequest())
+    const json = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(json.error).toBe('No Subscription')
+    expect(mockBillingPortalSessionsCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 "No Subscription" when stripe_customer_id is null', async () => {
+    // The default `free` row exists for every signed-up user but has no
+    // Stripe customer until first checkout. Returning 400 here surfaces the
+    // upsell path instead of trapping the user with a 500.
+    setupAuth({ user: { id: 'user-1', email: 'a@b.test' } })
+    setupAdminLookup({ subscription: { stripe_customer_id: null } })
+
+    const response = await POST(buildRequest())
+    const json = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(json.error).toBe('No Subscription')
+    expect(mockBillingPortalSessionsCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when the subscription lookup fails', async () => {
+    setupAuth({ user: { id: 'user-1', email: 'a@b.test' } })
+    setupAdminLookup({ subscriptionError: { message: 'rls denied' } })
+
+    const response = await POST(buildRequest())
+    const json = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(json.error).toMatch(/darkness/i)
+    expect(mockBillingPortalSessionsCreate).not.toHaveBeenCalled()
+  })
+
+  it('creates a portal session and returns the URL for an existing subscriber', async () => {
+    setupAuth({ user: { id: 'user-1', email: 'survivor@kdm.test' } })
+    const { select, eq } = setupAdminLookup({
+      subscription: { stripe_customer_id: 'cus_existing' }
+    })
+    mockBillingPortalSessionsCreate.mockResolvedValue({
+      url: 'https://billing.stripe.test/p/session/bps_test_123'
+    })
+
+    const response = await POST(buildRequest())
+    const json = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(json.url).toBe('https://billing.stripe.test/p/session/bps_test_123')
+
+    // Confirm we read via the service-role admin client and scoped by user.
+    expect(mockCreateAdminClient).toHaveBeenCalledTimes(1)
+    expect(mockAdminFrom).toHaveBeenCalledWith('user_subscription')
+    expect(select).toHaveBeenCalledWith('stripe_customer_id')
+    expect(eq).toHaveBeenCalledWith('user_id', 'user-1')
+
+    expect(mockBillingPortalSessionsCreate).toHaveBeenCalledTimes(1)
+    const args = mockBillingPortalSessionsCreate.mock.calls[0][0]
+    expect(args.customer).toBe('cus_existing')
+    expect(args.return_url).toBe('https://archivist.test/settings/subscription')
+  })
+
+  it('returns 500 when Stripe rejects the portal session creation request', async () => {
+    setupAuth({ user: { id: 'user-1', email: 'a@b.test' } })
+    setupAdminLookup({
+      subscription: { stripe_customer_id: 'cus_existing' }
+    })
+    mockBillingPortalSessionsCreate.mockRejectedValue(new Error('Stripe down'))
+
+    const response = await POST(buildRequest())
+    const json = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(json.error).toMatch(/darkness/i)
+  })
+
+  it('returns 500 when Stripe returns a session without a URL', async () => {
+    setupAuth({ user: { id: 'user-1', email: 'a@b.test' } })
+    setupAdminLookup({
+      subscription: { stripe_customer_id: 'cus_existing' }
+    })
+    mockBillingPortalSessionsCreate.mockResolvedValue({ url: null })
+
+    const response = await POST(buildRequest())
+
+    expect(response.status).toBe(500)
+  })
+
+  it('uses NEXT_PUBLIC_SITE_URL as the canonical return origin when set', async () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://archivist.example.com'
+
+    setupAuth({ user: { id: 'user-1', email: 'a@b.test' } })
+    setupAdminLookup({
+      subscription: { stripe_customer_id: 'cus_existing' }
+    })
+    mockBillingPortalSessionsCreate.mockResolvedValue({
+      url: 'https://billing.stripe.test/p/session'
+    })
+
+    await POST(buildRequest())
+
+    const args = mockBillingPortalSessionsCreate.mock.calls[0][0]
+    expect(args.return_url).toBe(
+      'https://archivist.example.com/settings/subscription'
+    )
+  })
+
+  it('ignores spoofed x-forwarded-host header and falls back to request URL', async () => {
+    // Open-redirect class of bugs: a spoofed forwarded-host header must NOT
+    // influence the portal return URL. Only NEXT_PUBLIC_SITE_URL or the
+    // request URL parsed from the Host header are allowed.
+    setupAuth({ user: { id: 'user-1', email: 'a@b.test' } })
+    setupAdminLookup({
+      subscription: { stripe_customer_id: 'cus_existing' }
+    })
+    mockBillingPortalSessionsCreate.mockResolvedValue({
+      url: 'https://billing.stripe.test/p/session'
+    })
+
+    await POST(
+      buildRequest({
+        'x-forwarded-host': 'evil.example.com',
+        'x-forwarded-proto': 'https'
+      })
+    )
+
+    const args = mockBillingPortalSessionsCreate.mock.calls[0][0]
+    expect(args.return_url).toMatch(/^https:\/\/archivist\.test\//)
+    expect(args.return_url).not.toContain('evil.example.com')
+  })
+
+  it('falls back to the request URL when NEXT_PUBLIC_SITE_URL is malformed', async () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'not-a-url'
+
+    setupAuth({ user: { id: 'user-1', email: 'a@b.test' } })
+    setupAdminLookup({
+      subscription: { stripe_customer_id: 'cus_existing' }
+    })
+    mockBillingPortalSessionsCreate.mockResolvedValue({
+      url: 'https://billing.stripe.test/p/session'
+    })
+
+    await POST(buildRequest())
+
+    const args = mockBillingPortalSessionsCreate.mock.calls[0][0]
+    expect(args.return_url).toMatch(/^https:\/\/archivist\.test\//)
+  })
+})

--- a/__tests__/app/api/billing/portal/route.test.ts
+++ b/__tests__/app/api/billing/portal/route.test.ts
@@ -276,4 +276,31 @@ describe('POST /api/billing/portal', () => {
     const args = mockBillingPortalSessionsCreate.mock.calls[0][0]
     expect(args.return_url).toMatch(/^https:\/\/archivist\.test\//)
   })
+
+  it('fails closed with a 500 in production when NEXT_PUBLIC_SITE_URL is malformed', async () => {
+    // PR #242 review comment r3262472051: production must not silently
+    // degrade to the Host-derived request URL when the canonical origin is
+    // malformed. Verify the helper's throw is caught by the route's outer
+    // try/catch and surfaces as a generic 500 — Stripe must NOT be called.
+    const originalNodeEnv = process.env.NODE_ENV
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = 'production'
+    process.env.NEXT_PUBLIC_SITE_URL = 'https//archivist.monster'
+
+    try {
+      setupAuth({ user: { id: 'user-1', email: 'a@b.test' } })
+      setupAdminLookup({
+        subscription: { stripe_customer_id: 'cus_existing' }
+      })
+
+      const response = await POST(buildRequest())
+      const json = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(json.error).toMatch(/darkness/i)
+      expect(mockBillingPortalSessionsCreate).not.toHaveBeenCalled()
+    } finally {
+      ;(process.env as Record<string, string | undefined>).NODE_ENV =
+        originalNodeEnv
+    }
+  })
 })

--- a/__tests__/lib/stripe.test.ts
+++ b/__tests__/lib/stripe.test.ts
@@ -1,0 +1,89 @@
+import { resolveOrigin } from '@/lib/stripe'
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Build a `NextRequest` so we can exercise `resolveOrigin` directly.
+ */
+function buildRequest(url = 'https://archivist.test/api/billing/checkout') {
+  return new NextRequest(url, { method: 'POST' })
+}
+
+describe('resolveOrigin', () => {
+  // Snapshot + restore environment between tests. `NODE_ENV` is read-only in
+  // TS, so we cast through a temporary record to mutate it.
+  const originalSiteUrl = process.env.NEXT_PUBLIC_SITE_URL
+  const originalNodeEnv = process.env.NODE_ENV
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_SITE_URL
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = 'test'
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_SITE_URL = originalSiteUrl
+    ;(process.env as Record<string, string | undefined>).NODE_ENV =
+      originalNodeEnv
+    vi.restoreAllMocks()
+  })
+
+  it('returns the configured origin when NEXT_PUBLIC_SITE_URL is well-formed', () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://archivist.example.com'
+
+    expect(resolveOrigin(buildRequest())).toBe('https://archivist.example.com')
+  })
+
+  it('strips paths/queries from a configured URL, returning only the origin', () => {
+    process.env.NEXT_PUBLIC_SITE_URL =
+      'https://archivist.example.com/some/path?with=query'
+
+    expect(resolveOrigin(buildRequest())).toBe('https://archivist.example.com')
+  })
+
+  it('falls back to the request URL in non-production when NEXT_PUBLIC_SITE_URL is unset', () => {
+    expect(resolveOrigin(buildRequest('https://archivist.test/x'))).toBe(
+      'https://archivist.test'
+    )
+  })
+
+  it('falls back to the request URL in non-production when NEXT_PUBLIC_SITE_URL is malformed', () => {
+    process.env.NEXT_PUBLIC_SITE_URL = 'not-a-url'
+
+    expect(resolveOrigin(buildRequest('https://archivist.test/x'))).toBe(
+      'https://archivist.test'
+    )
+  })
+
+  it('fails closed (throws) in production when NEXT_PUBLIC_SITE_URL is unset', () => {
+    // Reviewer feedback (PR #242 review comment r3262472051): production must
+    // not silently degrade to the Host-derived request URL. A missing
+    // canonical origin in production is a deploy-time misconfiguration, not a
+    // user-facing failure mode — surface it loudly instead of leaking an
+    // attacker-influenceable redirect.
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = 'production'
+
+    expect(() => resolveOrigin(buildRequest())).toThrowError(
+      /NEXT_PUBLIC_SITE_URL is not set/
+    )
+  })
+
+  it('fails closed (throws) in production when NEXT_PUBLIC_SITE_URL is malformed', () => {
+    // A typo like `https//archivist.monster` (missing colon) must not fall
+    // through to the Host header — that would reintroduce the open-redirect
+    // class this helper is documented to prevent.
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = 'production'
+    process.env.NEXT_PUBLIC_SITE_URL = 'https//archivist.monster'
+
+    expect(() => resolveOrigin(buildRequest())).toThrowError(
+      /NEXT_PUBLIC_SITE_URL is malformed/
+    )
+  })
+
+  it('honors a well-formed NEXT_PUBLIC_SITE_URL in production', () => {
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = 'production'
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://archivist.monster'
+
+    expect(resolveOrigin(buildRequest())).toBe('https://archivist.monster')
+  })
+})

--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -1,6 +1,8 @@
 import 'server-only'
 
+import { STRIPE_API_VERSION } from '@/lib/common'
 import { ERROR_MESSAGE } from '@/lib/messages'
+import { resolveOrigin } from '@/lib/stripe'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import {
@@ -44,51 +46,6 @@ function resolvePriceId(planId: BillingPlanId): string {
 
   return priceId
 }
-
-/**
- * Resolve Origin For Redirects
- *
- * Stripe Checkout requires absolute `success_url` and `cancel_url`. To
- * eliminate the open-redirect class of bugs where an attacker spoofs `Host` or
- * `x-forwarded-host` to redirect a paying user to an attacker-controlled domain
- * after checkout (carrying `session_id`), production deployments MUST set
- * `NEXT_PUBLIC_SITE_URL` to the canonical site origin. When set, that value is
- * the sole source of truth.
- *
- * For local development the env var can be omitted and the route falls back to
- * the request's parsed URL. The fallback is intentionally limited to
- * `request.url` (parsed from `Host`); forwarded-host headers are NOT honored.
- *
- * @param request Next Request
- * @returns Origin Including Scheme
- */
-function resolveOrigin(request: NextRequest): string {
-  const configured = process.env.NEXT_PUBLIC_SITE_URL
-
-  if (configured) {
-    try {
-      return new URL(configured).origin
-    } catch {
-      // Malformed env var — fall through to request-derived origin so a typo
-      // doesn't produce an unbreakable 500.
-      console.error(
-        'Stripe Checkout Origin Error: malformed NEXT_PUBLIC_SITE_URL',
-        configured
-      )
-    }
-  }
-
-  return new URL(request.url).origin
-}
-
-/**
- * Stripe API Version
- *
- * Pinned in code so that the route's contract with Stripe does not silently
- * change when the account's Dashboard-pinned version is rolled. Update this
- * constant + `docs/stripe-setup.md` together when intentionally upgrading.
- */
-const STRIPE_API_VERSION = '2026-04-22.dahlia' as const
 
 /**
  * Create Stripe Checkout Session

--- a/app/api/billing/portal/route.ts
+++ b/app/api/billing/portal/route.ts
@@ -1,0 +1,105 @@
+import 'server-only'
+
+import { STRIPE_API_VERSION } from '@/lib/common'
+import { ERROR_MESSAGE } from '@/lib/messages'
+import { resolveOrigin } from '@/lib/stripe'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import { NextResponse, type NextRequest } from 'next/server'
+import Stripe from 'stripe'
+
+/**
+ * Force Node Runtime
+ *
+ * The Stripe Node SDK is not compatible with the Edge runtime. Pinning to
+ * `nodejs` also gives the handler access to `process.env.STRIPE_*` server-only
+ * secrets and the Supabase service-role key.
+ */
+export const runtime = 'nodejs'
+
+/**
+ * Create Stripe Customer Portal Session
+ *
+ * POST handler for `/api/billing/portal`. Authenticated subscribers receive a
+ * Stripe Customer Portal URL that lets them manage their subscription — update
+ * payment method, view invoices, switch plan, and cancel — without the app
+ * re-implementing any of those flows.
+ *
+ * Behavior:
+ *   - Returns 401 when the caller is not signed in.
+ *   - Reads `user_subscription` via the service-role admin client to bypass
+ *     RLS on the lookup. The "Allow select own" policy would work for the
+ *     happy path but the admin client makes this route consistent with the
+ *     checkout + webhook handlers and avoids surprises if RLS is tightened.
+ *   - Returns 400 ("No Subscription") when the caller has no
+ *     `stripe_customer_id` yet — i.e. has never checked out and therefore has
+ *     nothing to manage in the portal.
+ *   - Creates a `billingPortal.sessions` with a hardened `return_url` and
+ *     returns the URL.
+ *   - Returns 500 on any Stripe / Supabase failure with a generic message.
+ *
+ * @param request Next Request
+ * @returns JSON Response Containing The Portal Session URL
+ */
+export async function POST(request: NextRequest) {
+  // 1. Authenticate the caller. The portal is account-scoped — unauthenticated
+  //    requests must never reach Stripe.
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+    error: authError
+  } = await supabase.auth.getUser()
+
+  if (authError || !user)
+    return NextResponse.json({ error: 'Not Authenticated' }, { status: 401 })
+
+  // 2. Look up the caller's Stripe customer ID. The admin client bypasses RLS
+  //    on `user_subscription` (see migration 20260527000001), matching the
+  //    issue's instruction to use a service-role admin client for the read.
+  const admin = createAdminClient()
+
+  const { data: subscription, error: subscriptionError } = await admin
+    .from('user_subscription')
+    .select('stripe_customer_id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (subscriptionError) {
+    console.error('Stripe Portal Subscription Lookup Error:', subscriptionError)
+
+    return NextResponse.json({ error: ERROR_MESSAGE() }, { status: 500 })
+  }
+
+  // 3. A caller without a `stripe_customer_id` has never checked out and has
+  //    nothing to manage. Surface 400 rather than 500 — this is a legitimate
+  //    user-state error, not a server fault.
+  if (!subscription?.stripe_customer_id)
+    return NextResponse.json({ error: 'No Subscription' }, { status: 400 })
+
+  // 4. Create the portal session.
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+    apiVersion: STRIPE_API_VERSION
+  })
+
+  try {
+    const origin = resolveOrigin(request)
+
+    const session = await stripe.billingPortal.sessions.create({
+      customer: subscription.stripe_customer_id,
+      return_url: `${origin}/settings/subscription`
+    })
+
+    if (!session.url) {
+      console.error('Stripe Portal Session Error: missing session.url')
+
+      return NextResponse.json({ error: ERROR_MESSAGE() }, { status: 500 })
+    }
+
+    return NextResponse.json({ url: session.url })
+  } catch (error) {
+    console.error('Stripe Portal Session Error:', error)
+
+    return NextResponse.json({ error: ERROR_MESSAGE() }, { status: 500 })
+  }
+}

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -51,6 +51,16 @@ export const MARKDOWN_SYNTAX_URL = 'https://www.markdownguide.org/basic-syntax/'
 export const FREE_TIER_SETTLEMENT_LIMIT = 5
 
 /**
+ * Stripe API Version
+ *
+ * Pinned in code so that the route's contract with Stripe does not silently
+ * change when the account's Dashboard-pinned version is rolled. Keep in sync
+ * with the checkout + webhook handlers; update them together when intentionally
+ * upgrading.
+ */
+export const STRIPE_API_VERSION = '2026-04-22.dahlia'
+
+/**
  * Basic Hunt Board Configuration
  */
 export const basicHuntBoard = {

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server'
+
+/**
+ * Resolve Origin For Redirects
+ *
+ * Stripe Checkout requires absolute `success_url` and `cancel_url`. To
+ * eliminate the open-redirect class of bugs where an attacker spoofs `Host` or
+ * `x-forwarded-host` to redirect a paying user to an attacker-controlled domain
+ * after checkout (carrying `session_id`), production deployments MUST set
+ * `NEXT_PUBLIC_SITE_URL` to the canonical site origin. When set, that value is
+ * the sole source of truth.
+ *
+ * For local development the env var can be omitted and the route falls back to
+ * the request's parsed URL. The fallback is intentionally limited to
+ * `request.url` (parsed from `Host`); forwarded-host headers are NOT honored.
+ *
+ * @param request Next Request
+ * @returns Origin Including Scheme
+ */
+export function resolveOrigin(request: NextRequest): string {
+  const configured = process.env.NEXT_PUBLIC_SITE_URL
+
+  if (configured) {
+    try {
+      return new URL(configured).origin
+    } catch {
+      // Malformed env var — fall through to request-derived origin so a typo
+      // doesn't produce an unbreakable 500.
+      console.error(
+        'Stripe Billing Origin Error: malformed NEXT_PUBLIC_SITE_URL',
+        configured
+      )
+    }
+  }
+
+  return new URL(request.url).origin
+}

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -10,27 +10,51 @@ import { NextRequest } from 'next/server'
  * `NEXT_PUBLIC_SITE_URL` to the canonical site origin. When set, that value is
  * the sole source of truth.
  *
- * For local development the env var can be omitted and the route falls back to
- * the request's parsed URL. The fallback is intentionally limited to
- * `request.url` (parsed from `Host`); forwarded-host headers are NOT honored.
+ * Outside production (development and test) the env var can be omitted or
+ * malformed; the helper falls back to the request's parsed URL so local
+ * workflows aren't gated on an env var. The fallback is intentionally limited
+ * to `request.url` (parsed from `Host`); forwarded-host headers are NEVER
+ * honored.
+ *
+ * In production the helper fails closed: a missing or malformed
+ * `NEXT_PUBLIC_SITE_URL` throws rather than silently degrading to the
+ * Host-derived origin. A typo in the canonical URL (e.g. `https//site.com`)
+ * would otherwise reintroduce the exact open-redirect class this helper exists
+ * to prevent. The thrown error is caught by the route's outer try/catch and
+ * surfaces as a generic 500 — no redirect leak.
  *
  * @param request Next Request
  * @returns Origin Including Scheme
+ * @throws Error When `NEXT_PUBLIC_SITE_URL` Is Missing Or Malformed In Production
  */
 export function resolveOrigin(request: NextRequest): string {
   const configured = process.env.NEXT_PUBLIC_SITE_URL
+  const isProduction = process.env.NODE_ENV === 'production'
 
   if (configured) {
     try {
       return new URL(configured).origin
     } catch {
-      // Malformed env var — fall through to request-derived origin so a typo
-      // doesn't produce an unbreakable 500.
       console.error(
         'Stripe Billing Origin Error: malformed NEXT_PUBLIC_SITE_URL',
         configured
       )
+
+      // Fail closed in production. A typo in the canonical origin must not
+      // silently fall through to the attacker-influenceable Host-derived
+      // origin. In dev/test we tolerate the typo so local workflows aren't
+      // wedged by an env-var issue.
+      if (isProduction)
+        throw new Error(
+          'Stripe Billing Origin Error: NEXT_PUBLIC_SITE_URL is malformed; refusing to fall back to request-derived origin in production.'
+        )
     }
+  } else if (isProduction) {
+    // Same fail-closed posture when the canonical origin is missing entirely.
+    // Production must always pin its redirect origin in code.
+    throw new Error(
+      'Stripe Billing Origin Error: NEXT_PUBLIC_SITE_URL is not set; refusing to fall back to request-derived origin in production.'
+    )
   }
 
   return new URL(request.url).origin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.69.0",
+      "version": "0.70.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

Implements [E3.6] — Stripe Customer Portal API route — per issue #175.

Adds `POST /api/billing/portal`, which authenticates the caller, looks up their `stripe_customer_id` from `user_subscription` via a service-role admin client, and returns a Stripe Customer Portal session URL so subscribers can self-manage payment method, invoices, plan switches, and cancellation. The app never re-implements any of those flows; Stripe owns the UI and the webhook handler (E3.5) keeps `user_subscription` in sync.

Lanterns kept lit. Survivors who paid for the season can now tend their own subscription without a steward.

## Changes

- **New** `app/api/billing/portal/route.ts` — server-only handler with `runtime = 'nodejs'`.
  - `401 Not Authenticated` for unauthenticated callers.
  - Reads `user_subscription.stripe_customer_id` via `createAdminClient()` per the issue's instruction to bypass RLS on this lookup.
  - `400 No Subscription` when the caller has no `stripe_customer_id` (free user who has never checked out) — surfaces the upsell path instead of a 500.
  - `500` on Supabase lookup error, Stripe failure, or a session response missing `url`.
  - On success, creates `stripe.billingPortal.sessions.create({ customer, return_url })` and returns `{ url }`.
- **New** `app/api/billing/portal/route.ts` shares an extracted hardened `resolveOrigin` helper (now `lib/stripe.ts`) and the pinned `STRIPE_API_VERSION` constant (now `lib/common.ts`).
- **Refactor** `app/api/billing/checkout/route.ts` to import `STRIPE_API_VERSION` / `resolveOrigin` from the shared locations so both routes stay in lockstep on API version and redirect hardening.
- **New** `lib/stripe.ts` — exports `resolveOrigin(request)`. Defends against open-redirect attacks where a spoofed `x-forwarded-host` could redirect a paying user to an attacker-controlled domain. Only honors `NEXT_PUBLIC_SITE_URL` or the request's parsed `Host`; never forwarded-host headers.
- **Updated** `lib/common.ts` — exports `STRIPE_API_VERSION = '2026-04-22.dahlia'`. Single source of truth across checkout, portal, and (later) webhook.
- **New** `__tests__/app/api/billing/portal/route.test.ts` — 11 unit tests, all passing:
  - 401 paths (no user, auth error).
  - 400 paths (no `user_subscription` row, null `stripe_customer_id`).
  - 500 paths (subscription lookup error, Stripe rejection, session without URL).
  - Happy path asserts admin client used, correct `user_id` scoping, correct `customer` + `return_url`.
  - Origin hardening: `NEXT_PUBLIC_SITE_URL` honored, spoofed `x-forwarded-host` rejected, malformed env falls back to request URL.

## Acceptance Criteria (from #175)

- [x] Authenticated POST returns a portal URL.
- [x] User without a subscription returns 400.
- [x] Uses a service-role admin client for the read.
- [x] `runtime = 'nodejs'`.
- [x] Out of scope (single tier only) — plan switches handled by Stripe's Customer Portal configuration per `docs/stripe-setup.md` §3.

## Notes

- `return_url` points at `/settings/subscription`, matching the checkout route's `success_url` / `cancel_url`. That page lands in E3.7; until then, callers will be redirected to a route that does not yet exist. The portal session itself is still valid.
- The no-subscription response is `"No Subscription"` (title-case) to match the existing `"Not Authenticated"` casing — the issue spec wrote it lowercase; flagging in case you'd prefer the literal.

## Testing

```sh
npx vitest run __tests__/app/api/billing --coverage=false
# Test Files  2 passed (2)
#      Tests  27 passed (27)
```

## Dependencies

- No new runtime dependencies — uses the existing `stripe` package wired up for E3.4.

## Versioning

- Bumped `package.json` + `package-lock.json` from `0.69.0` → `0.70.0` (minor: new feature).

## Related

- Closes #175
- Part of Epic E3 — Phase 3: Paid Sharing & Subscription Plumbing (#123)
- Source of truth: `docs/settlement-sharing-architecture.md` §9.6
- Depends on: #169 (E3.4 — Checkout route), #168 (`user_subscription` table)
- Unblocks: [E3.9] (subscription page UI that calls this route)
