### PR TITLE
feat(billing): add Stripe webhook handler (#171)

### DIFF
--- a/__tests__/app/api/billing/webhook/route.test.ts
+++ b/__tests__/app/api/billing/webhook/route.test.ts
@@ -1,0 +1,632 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Stub `server-only`. Its real module body throws when loaded outside the
+// React Server Component bundle, which would block Vitest from importing the
+// route under test.
+vi.mock('server-only', () => ({}))
+
+// Hoisted mocks must be declared before any imports that wire them up.
+const { mockAdminFrom, mockCreateAdminClient } = vi.hoisted(() => ({
+  mockAdminFrom: vi.fn(),
+  mockCreateAdminClient: vi.fn()
+}))
+
+const { mockSubscriptionsRetrieve, mockWebhooksConstructEvent, MockStripe } =
+  vi.hoisted(() => {
+    const subscriptionsRetrieve = vi.fn()
+    const webhooksConstructEvent = vi.fn()
+    class Stripe {
+      subscriptions = { retrieve: subscriptionsRetrieve }
+      webhooks = { constructEvent: webhooksConstructEvent }
+    }
+    return {
+      mockSubscriptionsRetrieve: subscriptionsRetrieve,
+      mockWebhooksConstructEvent: webhooksConstructEvent,
+      MockStripe: Stripe
+    }
+  })
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: mockCreateAdminClient
+}))
+
+vi.mock('stripe', () => ({
+  default: MockStripe
+}))
+
+import { NextRequest } from 'next/server'
+
+const { POST } = await import('@/app/api/billing/webhook/route')
+
+/**
+ * Build A Webhook Request
+ *
+ * Stripe webhook requests carry a raw JSON body and a `stripe-signature`
+ * header. The route reads the body via `request.text()` and the signature
+ * via `request.headers.get('stripe-signature')`; the body content itself is
+ * irrelevant because `constructEvent` is mocked.
+ */
+function buildRequest(options?: { body?: string; signature?: string | null }) {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json'
+  }
+
+  const signature =
+    options?.signature === undefined ? 't=1,v1=sig' : options.signature
+
+  if (signature !== null) headers['stripe-signature'] = signature
+
+  return new NextRequest('https://archivist.test/api/billing/webhook', {
+    method: 'POST',
+    headers,
+    body: options?.body ?? '{}'
+  })
+}
+
+/**
+ * Subscription Item Fixture
+ *
+ * Captures the shape the route reads off `subscription.items.data[0]` —
+ * `price.id` (drives `plan_id`) and `current_period_end` (Unix seconds, as
+ * Stripe ships it).
+ */
+function buildSubscriptionItem(options: {
+  priceId: string
+  currentPeriodEnd: number
+}) {
+  return {
+    id: 'si_test',
+    price: { id: options.priceId },
+    current_period_end: options.currentPeriodEnd
+  }
+}
+
+/**
+ * Build A Stripe Subscription Fixture
+ */
+function buildSubscription(options: {
+  id?: string
+  customer?: string | null
+  status?: string
+  priceId?: string
+  currentPeriodEnd?: number
+  userId?: string | null
+}) {
+  return {
+    id: options.id ?? 'sub_test',
+    customer: options.customer ?? 'cus_test',
+    status: options.status ?? 'active',
+    metadata:
+      options.userId === null ? {} : { user_id: options.userId ?? 'user-1' },
+    items: {
+      data: [
+        buildSubscriptionItem({
+          priceId: options.priceId ?? 'price_lantern',
+          currentPeriodEnd: options.currentPeriodEnd ?? 1_900_000_000
+        })
+      ]
+    }
+  }
+}
+
+/**
+ * Wire The Admin Client
+ *
+ * The webhook calls three different shapes against `user_subscription`:
+ *   - `.update(...).eq('user_id', ...)` — used by the update/delete handlers.
+ *   - `.upsert(...)` — used by the checkout-completed handler.
+ *   - `.select('user_id').eq('stripe_customer_id', ...).maybeSingle()` — used
+ *     when subscription metadata is missing.
+ *
+ * Returning all three matchers from `from('user_subscription')` lets a single
+ * mock cover every event handler.
+ */
+function setupAdmin(options?: {
+  upsertError?: { message: string } | null
+  updateError?: { message: string } | null
+  lookupUserId?: string | null
+  lookupError?: { message: string } | null
+}) {
+  const upsert = vi
+    .fn()
+    .mockResolvedValue({ error: options?.upsertError ?? null })
+  const updateEq = vi
+    .fn()
+    .mockResolvedValue({ error: options?.updateError ?? null })
+  const update = vi.fn().mockReturnValue({ eq: updateEq })
+  const maybeSingle = vi.fn().mockResolvedValue({
+    data: options?.lookupUserId ? { user_id: options.lookupUserId } : null,
+    error: options?.lookupError ?? null
+  })
+  const lookupEq = vi.fn().mockReturnValue({ maybeSingle })
+  const select = vi.fn().mockReturnValue({ eq: lookupEq })
+
+  mockAdminFrom.mockReturnValue({ upsert, update, select })
+  mockCreateAdminClient.mockReturnValue({ from: mockAdminFrom })
+
+  return { upsert, update, updateEq, select, lookupEq, maybeSingle }
+}
+
+describe('POST /api/billing/webhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.STRIPE_SECRET_KEY = 'sk_test_123'
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test'
+    process.env.STRIPE_PRICE_ID_LANTERN = 'price_lantern'
+    process.env.STRIPE_PRICE_ID_LANTERN_HOARD = 'price_lantern_hoard'
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://127.0.0.1:54321'
+    process.env.SUPABASE_SECRET_KEY = 'service-role-key'
+  })
+
+  it('returns 400 when the stripe-signature header is missing', async () => {
+    setupAdmin()
+
+    const response = await POST(buildRequest({ signature: null }))
+    const json = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(json.error).toBe('Invalid Signature')
+    expect(mockWebhooksConstructEvent).not.toHaveBeenCalled()
+    expect(mockCreateAdminClient).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when STRIPE_WEBHOOK_SECRET is not configured', async () => {
+    delete process.env.STRIPE_WEBHOOK_SECRET
+    setupAdmin()
+
+    const response = await POST(buildRequest())
+
+    expect(response.status).toBe(400)
+    expect(mockWebhooksConstructEvent).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when signature verification throws', async () => {
+    setupAdmin()
+    mockWebhooksConstructEvent.mockImplementation(() => {
+      throw new Error('Bad signature')
+    })
+
+    const response = await POST(buildRequest())
+    const json = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(json.error).toBe('Invalid Signature')
+    expect(mockCreateAdminClient).not.toHaveBeenCalled()
+  })
+
+  describe('checkout.session.completed', () => {
+    it('upserts an active lantern subscription using metadata.user_id', async () => {
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test',
+            metadata: { user_id: 'user-1' },
+            client_reference_id: null,
+            subscription: 'sub_test'
+          }
+        }
+      })
+      mockSubscriptionsRetrieve.mockResolvedValue(
+        buildSubscription({
+          customer: 'cus_test',
+          priceId: 'price_lantern',
+          currentPeriodEnd: 1_900_000_000
+        })
+      )
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(mockSubscriptionsRetrieve).toHaveBeenCalledWith('sub_test')
+      expect(mockAdminFrom).toHaveBeenCalledWith('user_subscription')
+      expect(admin.upsert).toHaveBeenCalledTimes(1)
+
+      const [payload, options] = admin.upsert.mock.calls[0]
+      expect(payload).toMatchObject({
+        user_id: 'user-1',
+        plan_id: 'lantern',
+        status: 'active',
+        stripe_customer_id: 'cus_test',
+        stripe_subscription_id: 'sub_test'
+      })
+      expect(payload.current_period_end).toBe(
+        new Date(1_900_000_000 * 1000).toISOString()
+      )
+      expect(options).toEqual({ onConflict: 'user_id' })
+    })
+
+    it('falls back to client_reference_id when metadata is absent', async () => {
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test',
+            metadata: {},
+            client_reference_id: 'user-fallback',
+            subscription: 'sub_test'
+          }
+        }
+      })
+      mockSubscriptionsRetrieve.mockResolvedValue(
+        buildSubscription({ priceId: 'price_lantern' })
+      )
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      const payload = admin.upsert.mock.calls[0][0]
+      expect(payload.user_id).toBe('user-fallback')
+    })
+
+    it('writes plan_id = "lantern_hoard" when the session price matches the hoard env', async () => {
+      // The user clarified that subscription handlers must cope with plan
+      // alternation. checkout.session.completed therefore derives plan_id
+      // from the price rather than hardcoding "lantern" — a subscriber who
+      // chooses Lantern Hoard at checkout should land on that tier directly.
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test',
+            metadata: { user_id: 'user-1' },
+            client_reference_id: null,
+            subscription: 'sub_test'
+          }
+        }
+      })
+      mockSubscriptionsRetrieve.mockResolvedValue(
+        buildSubscription({ priceId: 'price_lantern_hoard' })
+      )
+
+      await POST(buildRequest())
+
+      expect(admin.upsert.mock.calls[0][0].plan_id).toBe('lantern_hoard')
+    })
+
+    it('skips the write and returns 200 when user_id cannot be resolved', async () => {
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test',
+            metadata: {},
+            client_reference_id: null,
+            subscription: 'sub_test'
+          }
+        }
+      })
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(mockSubscriptionsRetrieve).not.toHaveBeenCalled()
+      expect(admin.upsert).not.toHaveBeenCalled()
+    })
+
+    it('skips the write when the session has no subscription id', async () => {
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test',
+            metadata: { user_id: 'user-1' },
+            client_reference_id: null,
+            subscription: null
+          }
+        }
+      })
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(mockSubscriptionsRetrieve).not.toHaveBeenCalled()
+      expect(admin.upsert).not.toHaveBeenCalled()
+    })
+
+    it('skips the write when the subscription price is not a configured plan', async () => {
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test',
+            metadata: { user_id: 'user-1' },
+            subscription: 'sub_test'
+          }
+        }
+      })
+      mockSubscriptionsRetrieve.mockResolvedValue(
+        buildSubscription({ priceId: 'price_unknown' })
+      )
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(admin.upsert).not.toHaveBeenCalled()
+    })
+
+    it('returns 500 when retrieving the subscription from Stripe fails', async () => {
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test',
+            metadata: { user_id: 'user-1' },
+            subscription: 'sub_test'
+          }
+        }
+      })
+      mockSubscriptionsRetrieve.mockRejectedValue(new Error('Stripe down'))
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(500)
+      expect(admin.upsert).not.toHaveBeenCalled()
+    })
+
+    it('returns 500 when the upsert fails', async () => {
+      const admin = setupAdmin({ upsertError: { message: 'fk violation' } })
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'checkout.session.completed',
+        data: {
+          object: {
+            id: 'cs_test',
+            metadata: { user_id: 'user-1' },
+            subscription: 'sub_test'
+          }
+        }
+      })
+      mockSubscriptionsRetrieve.mockResolvedValue(
+        buildSubscription({ priceId: 'price_lantern' })
+      )
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(500)
+      expect(admin.upsert).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('customer.subscription.updated', () => {
+    it('updates status and current_period_end on a normal renewal', async () => {
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'customer.subscription.updated',
+        data: {
+          object: buildSubscription({
+            id: 'sub_test',
+            status: 'active',
+            priceId: 'price_lantern',
+            currentPeriodEnd: 1_950_000_000
+          })
+        }
+      })
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(admin.update).toHaveBeenCalledTimes(1)
+      const updatePayload = admin.update.mock.calls[0][0]
+      expect(updatePayload).toMatchObject({
+        plan_id: 'lantern',
+        status: 'active',
+        stripe_subscription_id: 'sub_test'
+      })
+      expect(updatePayload.current_period_end).toBe(
+        new Date(1_950_000_000 * 1000).toISOString()
+      )
+      expect(admin.updateEq).toHaveBeenCalledWith('user_id', 'user-1')
+      expect(admin.upsert).not.toHaveBeenCalled()
+    })
+
+    it('switches plan_id when the active price moves between Lantern and Lantern Hoard', async () => {
+      // The Customer Portal lets subscribers alternate between paid tiers.
+      // Each switch arrives as a customer.subscription.updated event with a
+      // new price; the webhook must re-derive plan_id so the column doesn't
+      // drift.
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'customer.subscription.updated',
+        data: {
+          object: buildSubscription({
+            priceId: 'price_lantern_hoard',
+            status: 'active'
+          })
+        }
+      })
+
+      await POST(buildRequest())
+
+      expect(admin.update.mock.calls[0][0].plan_id).toBe('lantern_hoard')
+    })
+
+    it('maps each documented Stripe status to its column value', async () => {
+      const cases: Array<[string, string]> = [
+        ['active', 'active'],
+        ['trialing', 'trialing'],
+        ['past_due', 'past_due'],
+        ['canceled', 'canceled'],
+        ['incomplete', 'incomplete']
+      ]
+
+      for (const [stripeStatus, expected] of cases) {
+        const admin = setupAdmin()
+        mockWebhooksConstructEvent.mockReturnValue({
+          type: 'customer.subscription.updated',
+          data: {
+            object: buildSubscription({
+              status: stripeStatus,
+              priceId: 'price_lantern'
+            })
+          }
+        })
+
+        await POST(buildRequest())
+
+        expect(admin.update.mock.calls[0][0].status).toBe(expected)
+      }
+    })
+
+    it('skips the write for unmapped Stripe statuses', async () => {
+      // `paused`, `unpaid`, and `incomplete_expired` are valid Stripe states
+      // with no representation in our schema's CHECK constraint. Skip the
+      // write rather than emit a value the DB would reject.
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'customer.subscription.updated',
+        data: { object: buildSubscription({ status: 'paused' }) }
+      })
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(admin.update).not.toHaveBeenCalled()
+    })
+
+    it('resolves user_id via stripe_customer_id when metadata is absent', async () => {
+      const admin = setupAdmin({ lookupUserId: 'user-by-customer' })
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'customer.subscription.updated',
+        data: {
+          object: buildSubscription({
+            userId: null,
+            customer: 'cus_known',
+            priceId: 'price_lantern'
+          })
+        }
+      })
+
+      await POST(buildRequest())
+
+      expect(admin.select).toHaveBeenCalledWith('user_id')
+      expect(admin.lookupEq).toHaveBeenCalledWith(
+        'stripe_customer_id',
+        'cus_known'
+      )
+      expect(admin.updateEq).toHaveBeenCalledWith('user_id', 'user-by-customer')
+    })
+
+    it('skips the write when no user_id can be resolved', async () => {
+      const admin = setupAdmin({ lookupUserId: null })
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'customer.subscription.updated',
+        data: {
+          object: buildSubscription({
+            userId: null,
+            customer: 'cus_unknown'
+          })
+        }
+      })
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(admin.update).not.toHaveBeenCalled()
+    })
+
+    it('skips the write when the active price is not a configured plan', async () => {
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'customer.subscription.updated',
+        data: { object: buildSubscription({ priceId: 'price_unknown' }) }
+      })
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(admin.update).not.toHaveBeenCalled()
+    })
+
+    it('returns 500 when the update fails', async () => {
+      const admin = setupAdmin({ updateError: { message: 'rls denied' } })
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'customer.subscription.updated',
+        data: { object: buildSubscription({ priceId: 'price_lantern' }) }
+      })
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(500)
+      expect(admin.update).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('customer.subscription.deleted', () => {
+    it('flips the row back to free / canceled', async () => {
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'customer.subscription.deleted',
+        data: { object: buildSubscription({ status: 'canceled' }) }
+      })
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(admin.update).toHaveBeenCalledTimes(1)
+      const payload = admin.update.mock.calls[0][0]
+      expect(payload).toMatchObject({
+        plan_id: 'free',
+        status: 'canceled'
+      })
+      expect(admin.updateEq).toHaveBeenCalledWith('user_id', 'user-1')
+    })
+
+    it('resolves user_id via stripe_customer_id when metadata is absent', async () => {
+      const admin = setupAdmin({ lookupUserId: 'user-by-customer' })
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'customer.subscription.deleted',
+        data: {
+          object: buildSubscription({
+            userId: null,
+            customer: 'cus_known'
+          })
+        }
+      })
+
+      await POST(buildRequest())
+
+      expect(admin.updateEq).toHaveBeenCalledWith('user_id', 'user-by-customer')
+    })
+
+    it('skips the write when no user_id can be resolved', async () => {
+      const admin = setupAdmin({ lookupUserId: null })
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'customer.subscription.deleted',
+        data: {
+          object: buildSubscription({
+            userId: null,
+            customer: 'cus_unknown'
+          })
+        }
+      })
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(admin.update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unhandled events', () => {
+    it('acknowledges unrelated event types with 200 and writes nothing', async () => {
+      const admin = setupAdmin()
+      mockWebhooksConstructEvent.mockReturnValue({
+        type: 'invoice.paid',
+        data: { object: { id: 'in_test' } }
+      })
+
+      const response = await POST(buildRequest())
+
+      expect(response.status).toBe(200)
+      expect(admin.upsert).not.toHaveBeenCalled()
+      expect(admin.update).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -1,0 +1,434 @@
+import 'server-only'
+
+import { STRIPE_API_VERSION } from '@/lib/common'
+import { Database } from '@/lib/database.types'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { BillingPlanId } from '@/schemas/billing-checkout-input'
+import { SupabaseClient } from '@supabase/supabase-js'
+import { NextResponse, type NextRequest } from 'next/server'
+import Stripe from 'stripe'
+
+/**
+ * Force Node Runtime
+ *
+ * The Stripe Node SDK is not compatible with the Edge runtime, and the
+ * signature-verification helper needs Node's `crypto` module. Pinning to
+ * `nodejs` also gives the handler access to `process.env.STRIPE_*` and the
+ * Supabase service-role key.
+ */
+export const runtime = 'nodejs'
+
+type AdminClient = SupabaseClient<Database>
+
+/**
+ * Subscription Status Value
+ *
+ * The set of values the `user_subscription.status` column accepts. Kept in
+ * sync with the CHECK constraint in migration `20260527000001`.
+ */
+type SubscriptionStatusValue =
+  | 'active'
+  | 'trialing'
+  | 'past_due'
+  | 'canceled'
+  | 'incomplete'
+
+/**
+ * Subscription Status Map
+ *
+ * Translates Stripe's `Subscription.Status` enum to the values our column
+ * accepts. Statuses outside this set (`incomplete_expired`, `paused`,
+ * `unpaid`) are valid in Stripe but have no representation in our schema, so
+ * we skip the write rather than emit an unknown value the DB would reject.
+ */
+const SUBSCRIPTION_STATUS_MAP: Partial<
+  Record<Stripe.Subscription.Status, SubscriptionStatusValue>
+> = {
+  active: 'active',
+  trialing: 'trialing',
+  past_due: 'past_due',
+  canceled: 'canceled',
+  incomplete: 'incomplete'
+}
+
+/**
+ * Resolve Plan From Price ID
+ *
+ * Inverse of the checkout route's `BillingPlanId` → price ID mapping. Reads
+ * the same `STRIPE_PRICE_ID_*` env vars so a single set of price IDs
+ * configures both routes. Returns null when the price doesn't match any
+ * known paid plan — for example, a future tier added on the Stripe Dashboard
+ * before the app is wired to support it.
+ *
+ * @param priceId Stripe Price ID
+ * @returns Billing Plan ID Or Null
+ */
+function resolvePlanFromPriceId(priceId: string): BillingPlanId | null {
+  if (priceId === process.env.STRIPE_PRICE_ID_LANTERN)
+    return BillingPlanId.LANTERN
+
+  if (priceId === process.env.STRIPE_PRICE_ID_LANTERN_HOARD)
+    return BillingPlanId.LANTERN_HOARD
+
+  return null
+}
+
+/**
+ * Extract Subscription Current Period End
+ *
+ * In Stripe API version `2025-04-30.basil` and later, `current_period_end`
+ * moved off the Subscription object and onto each Subscription Item (because
+ * a single subscription may carry items on different billing cycles). For
+ * our single-line subscriptions the first item's value is the source of
+ * truth.
+ *
+ * Returns the value as an ISO timestamp suitable for the `timestamptz`
+ * column, or null when the subscription unexpectedly has no items.
+ *
+ * @param subscription Stripe Subscription
+ * @returns ISO Timestamp Or Null
+ */
+function extractCurrentPeriodEnd(
+  subscription: Stripe.Subscription
+): string | null {
+  const item = subscription.items?.data?.[0]
+
+  if (!item?.current_period_end) return null
+
+  return new Date(item.current_period_end * 1000).toISOString()
+}
+
+/**
+ * Extract Relation ID
+ *
+ * Stripe relations are typed as `string | T | null` so callers can opt into
+ * expansion. The webhook treats unexpanded string IDs as the canonical form
+ * but tolerates expanded objects for the same field.
+ *
+ * @param value Stripe Relation
+ * @returns Resolved ID Or Null
+ */
+function extractRelationId(
+  value: string | { id: string } | null | undefined
+): string | null {
+  if (!value) return null
+
+  return typeof value === 'string' ? value : value.id
+}
+
+/**
+ * Resolve User ID From Stripe Customer
+ *
+ * Subscription events do not always carry the `user_id` metadata set by the
+ * checkout route — `customer.subscription.updated` events triggered from the
+ * Customer Portal can omit it, and `stripe trigger` fixtures never set it
+ * unless explicitly overridden. In those cases we fall back to looking the
+ * row up by `stripe_customer_id`, which the checkout route always persists.
+ *
+ * @param admin Service-Role Supabase Client
+ * @param customerId Stripe Customer ID
+ * @returns Supabase User ID Or Null
+ */
+async function resolveUserIdFromCustomer(
+  admin: AdminClient,
+  customerId: string
+): Promise<string | null> {
+  const { data, error } = await admin
+    .from('user_subscription')
+    .select('user_id')
+    .eq('stripe_customer_id', customerId)
+    .maybeSingle()
+
+  if (error) throw error
+
+  return data?.user_id ?? null
+}
+
+/**
+ * Handle Checkout Session Completed
+ *
+ * Provisions a paid subscription row when a Checkout session finalizes.
+ * Resolves the caller via `metadata.user_id` (set by the checkout route's
+ * `subscription_data` block, and reproducible by `stripe trigger` with
+ * `--override "metadata[user_id]=…"`) with a fallback to
+ * `client_reference_id` (also set by the checkout route).
+ *
+ * Retrieves the Subscription so we can capture the price (drives `plan_id`)
+ * and per-item `current_period_end`. The upsert is keyed on `user_id`,
+ * making redelivery from Stripe idempotent.
+ *
+ * @param session Stripe Checkout Session
+ * @param stripe Stripe Client
+ * @param admin Service-Role Supabase Client
+ */
+async function handleCheckoutSessionCompleted(
+  session: Stripe.Checkout.Session,
+  stripe: Stripe,
+  admin: AdminClient
+): Promise<void> {
+  const userId = session.metadata?.user_id ?? session.client_reference_id
+
+  if (!userId) {
+    console.warn(
+      'Stripe Webhook Skip: checkout.session.completed missing user_id',
+      session.id
+    )
+
+    return
+  }
+
+  const subscriptionId = extractRelationId(session.subscription)
+
+  if (!subscriptionId) {
+    console.warn(
+      'Stripe Webhook Skip: checkout.session.completed missing subscription',
+      session.id
+    )
+
+    return
+  }
+
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId)
+
+  const priceId = subscription.items.data[0]?.price?.id ?? null
+  const planId = priceId ? resolvePlanFromPriceId(priceId) : null
+
+  if (!planId) {
+    console.warn(
+      'Stripe Webhook Skip: checkout.session.completed unknown price',
+      subscription.id,
+      priceId
+    )
+
+    return
+  }
+
+  const customerId = extractRelationId(subscription.customer)
+
+  const { error } = await admin.from('user_subscription').upsert(
+    {
+      user_id: userId,
+      plan_id: planId,
+      status: 'active',
+      current_period_end: extractCurrentPeriodEnd(subscription),
+      stripe_customer_id: customerId,
+      stripe_subscription_id: subscription.id,
+      updated_at: new Date().toISOString()
+    },
+    { onConflict: 'user_id' }
+  )
+
+  if (error) throw error
+}
+
+/**
+ * Handle Subscription Updated
+ *
+ * Reflects in-flight subscription changes back into `user_subscription`.
+ * Covers three flavors of update:
+ *
+ *   - **Status transitions** — renewals, failed payments, reactivations
+ *     after past-due. Maps Stripe's status to the column's accepted values.
+ *   - **Plan switches** — the Customer Portal lets subscribers move between
+ *     Lantern and Lantern Hoard, which arrives as a `subscription.updated`
+ *     event with a new price. We re-derive `plan_id` from the active price
+ *     on every update so the column doesn't drift after a switch.
+ *   - **Period renewals** — `current_period_end` advances each billing
+ *     cycle.
+ *
+ * Falls back to a `stripe_customer_id` lookup when the subscription's
+ * `metadata.user_id` is unset (Customer Portal-initiated updates can drop
+ * the metadata that the original Checkout flow set).
+ *
+ * @param subscription Stripe Subscription
+ * @param admin Service-Role Supabase Client
+ */
+async function handleSubscriptionUpdated(
+  subscription: Stripe.Subscription,
+  admin: AdminClient
+): Promise<void> {
+  const status = SUBSCRIPTION_STATUS_MAP[subscription.status]
+
+  if (!status) {
+    console.warn(
+      'Stripe Webhook Skip: customer.subscription.updated unmapped status',
+      subscription.id,
+      subscription.status
+    )
+
+    return
+  }
+
+  const customerId = extractRelationId(subscription.customer)
+  let userId: string | null = subscription.metadata?.user_id ?? null
+
+  if (!userId && customerId)
+    userId = await resolveUserIdFromCustomer(admin, customerId)
+
+  if (!userId) {
+    console.warn(
+      'Stripe Webhook Skip: customer.subscription.updated unable to resolve user',
+      subscription.id
+    )
+
+    return
+  }
+
+  const priceId = subscription.items.data[0]?.price?.id ?? null
+  const planId = priceId ? resolvePlanFromPriceId(priceId) : null
+
+  if (!planId) {
+    console.warn(
+      'Stripe Webhook Skip: customer.subscription.updated unknown price',
+      subscription.id,
+      priceId
+    )
+
+    return
+  }
+
+  const { error } = await admin
+    .from('user_subscription')
+    .update({
+      plan_id: planId,
+      status,
+      current_period_end: extractCurrentPeriodEnd(subscription),
+      stripe_subscription_id: subscription.id,
+      updated_at: new Date().toISOString()
+    })
+    .eq('user_id', userId)
+
+  if (error) throw error
+}
+
+/**
+ * Handle Subscription Deleted
+ *
+ * Restores the caller to the free tier. Cancellation may arrive from the
+ * Customer Portal, a Dashboard action, or end-of-cycle expiry — all of
+ * which surface as `customer.subscription.deleted`. We keep the historical
+ * `stripe_customer_id` and `stripe_subscription_id` so audits and future
+ * re-subscribes have continuity, and only flip the columns the issue
+ * scoping document calls out: `plan_id` → `'free'`, `status` → `'canceled'`.
+ *
+ * @param subscription Stripe Subscription
+ * @param admin Service-Role Supabase Client
+ */
+async function handleSubscriptionDeleted(
+  subscription: Stripe.Subscription,
+  admin: AdminClient
+): Promise<void> {
+  const customerId = extractRelationId(subscription.customer)
+  let userId: string | null = subscription.metadata?.user_id ?? null
+
+  if (!userId && customerId)
+    userId = await resolveUserIdFromCustomer(admin, customerId)
+
+  if (!userId) {
+    console.warn(
+      'Stripe Webhook Skip: customer.subscription.deleted unable to resolve user',
+      subscription.id
+    )
+
+    return
+  }
+
+  const { error } = await admin
+    .from('user_subscription')
+    .update({
+      plan_id: 'free',
+      status: 'canceled',
+      updated_at: new Date().toISOString()
+    })
+    .eq('user_id', userId)
+
+  if (error) throw error
+}
+
+/**
+ * Stripe Webhook Handler
+ *
+ * POST handler for `/api/billing/webhook`. Stripe POSTs subscription
+ * lifecycle events here; we verify the signature against
+ * `STRIPE_WEBHOOK_SECRET` and translate the event into the appropriate write
+ * against `user_subscription` using the service-role admin client (the
+ * webhook is unauthenticated by design — only Stripe can produce a valid
+ * signature).
+ *
+ * Handled events:
+ *   - `checkout.session.completed` — upgrade to the purchased plan.
+ *   - `customer.subscription.updated` — sync status, period, and plan (the
+ *     Customer Portal can switch between Lantern and Lantern Hoard).
+ *   - `customer.subscription.deleted` — return to the free tier.
+ *
+ * Behavior:
+ *   - 400 when the `stripe-signature` header is absent, the
+ *     `STRIPE_WEBHOOK_SECRET` env var is unset, or the signature fails to
+ *     verify.
+ *   - 200 on every successfully processed event. Events outside the handled
+ *     set are acknowledged silently so Stripe does not retry them.
+ *   - 500 on DB / Stripe-API failures during processing so Stripe's retry
+ *     queue picks them up.
+ *
+ * @param request Next Request
+ * @returns Empty JSON Response With The Appropriate Status
+ */
+export async function POST(request: NextRequest) {
+  const signature = request.headers.get('stripe-signature')
+  const secret = process.env.STRIPE_WEBHOOK_SECRET
+
+  if (!signature || !secret) {
+    console.error(
+      'Stripe Webhook Signature Error: missing signature header or webhook secret'
+    )
+
+    return NextResponse.json({ error: 'Invalid Signature' }, { status: 400 })
+  }
+
+  // The raw body MUST be read as text — JSON parsing would normalize the
+  // payload and invalidate the signature. Next.js App Router does not buffer
+  // the body for us, so `request.text()` returns the bytes Stripe signed.
+  const rawBody = await request.text()
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+    apiVersion: STRIPE_API_VERSION
+  })
+
+  let event: Stripe.Event
+
+  try {
+    event = stripe.webhooks.constructEvent(rawBody, signature, secret)
+  } catch (error) {
+    console.error('Stripe Webhook Signature Error:', error)
+
+    return NextResponse.json({ error: 'Invalid Signature' }, { status: 400 })
+  }
+
+  try {
+    const admin = createAdminClient()
+
+    switch (event.type) {
+      case 'checkout.session.completed':
+        await handleCheckoutSessionCompleted(event.data.object, stripe, admin)
+        break
+
+      case 'customer.subscription.updated':
+        await handleSubscriptionUpdated(event.data.object, admin)
+        break
+
+      case 'customer.subscription.deleted':
+        await handleSubscriptionDeleted(event.data.object, admin)
+        break
+
+      default:
+        // Acknowledged but not handled. Stripe does not retry on 2xx.
+        break
+    }
+  } catch (error) {
+    console.error('Stripe Webhook Handler Error:', event.type, error)
+
+    return NextResponse.json({ error: 'Webhook Error' }, { status: 500 })
+  }
+
+  return NextResponse.json({ received: true }, { status: 200 })
+}

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -164,10 +164,10 @@ Developers → Webhooks → **Add endpoint**:
   - `customer.subscription.updated`
   - `customer.subscription.deleted`
 - **API version:** leave the webhook endpoint at the account default. The
-  checkout route pins its own request version (`2026-04-22.dahlia`) in code so
-  the contract does not depend on Dashboard state. When intentionally upgrading,
-  update the `STRIPE_API_VERSION` constant in
-  `app/api/billing/checkout/route.ts` and this doc together.
+  checkout, portal, and webhook routes pin their own request version
+  (`2026-04-22.dahlia`) in code so the contract does not depend on Dashboard
+  state. When intentionally upgrading, update the `STRIPE_API_VERSION` constant
+  in `lib/common.ts` and this doc together.
 - Save the endpoint. Reveal the **Signing secret** (starts with `whsec_`) — this
   is the value you paste into `STRIPE_WEBHOOK_SECRET`.
 
@@ -238,10 +238,14 @@ internet.
    `STRIPE_WEBHOOK_SECRET` in `.env.local`** and restart `npm run dev` so the
    handler picks it up. This secret is distinct from the dashboard webhook's
    signing secret and is valid only while `stripe listen` is running.
-1. To replay events for development, use `stripe trigger`, e.g.:
+1. To replay events for development, use `stripe trigger`. The webhook resolves
+   the target user via `metadata.user_id` first, with a fallback to the row
+   keyed by `stripe_customer_id`. For synthetic events, pass an `--override` so
+   the metadata reaches the handler:
 
    ```bash
-   stripe trigger checkout.session.completed
+   stripe trigger checkout.session.completed \
+     --override "checkout_session:metadata[user_id]=<supabase-user-id>"
    stripe trigger customer.subscription.updated
    stripe trigger customer.subscription.deleted
    ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.70.0",
+      "version": "0.71.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
Closes #171 (E3.7 — Stripe webhook handler).

## What

Adds `POST /api/billing/webhook` so subscription lifecycle events from Stripe finally write through to `user_subscription`. With this in place, the checkout/portal trilogy is wired end-to-end: checkout opens the upsell, the portal lets subscribers self-manage, and the webhook is what actually moves the row.

## Handled events

| Event | Behavior |
| --- | --- |
| `checkout.session.completed` | Upsert keyed on `user_id`. Sets `plan_id` (derived from the active price, not hardcoded), `status='active'`, `current_period_end`, `stripe_customer_id`, `stripe_subscription_id`. |
| `customer.subscription.updated` | Update by `user_id`. Re-derives `plan_id` on every event so a Customer-Portal plan switch between Lantern and Lantern Hoard does not leave the column stale. Maps `active`/`trialing`/`past_due`/`canceled`/`incomplete` to the values the CHECK constraint accepts; skips writes for `paused`/`unpaid`/`incomplete_expired`. |
| `customer.subscription.deleted` | Update by `user_id`. Sets `plan_id='free'`, `status='canceled'`. Keeps `stripe_customer_id` and `stripe_subscription_id` for audit continuity. |
| All others | Acknowledged with 200, no write. Stripe does not retry on 2xx. |

## Why derive `plan_id` from price (issue scope note)

The issue body says "single tier only at this stage" and to hardcode `plan_id='lantern'` for `checkout.session.completed`. While reviewing, the user clarified that subscription updates must handle alternating between tiers — which is what `docs/stripe-setup.md` §7 already smoke-tests (Lantern → Customer Portal switch → Lantern Hoard). To keep `checkout.session.completed` and `customer.subscription.updated` consistent and avoid an asymmetric "first checkout pins you to Lantern even if you bought Lantern Hoard" bug, both handlers read the active price ID and map it via `STRIPE_PRICE_ID_LANTERN` / `STRIPE_PRICE_ID_LANTERN_HOARD`. Unknown prices are skipped with a logged warning.

## Security / robustness

- **Signature verification** — raw body read via `request.text()` (JSON parsing would invalidate the signature), then `stripe.webhooks.constructEvent`. 400 on missing header, missing `STRIPE_WEBHOOK_SECRET`, or verification failure. `createAdminClient` is never reached on signature failure.
- **Service-role admin client** for all writes (the webhook is unauthenticated by design — RLS would block service-role writes otherwise).
- **Idempotent** — `checkout.session.completed` uses `upsert` keyed on `user_id`; the update/delete handlers are naturally idempotent for the same payload.
- **User-ID resolution** — sessions prefer `metadata.user_id` (matches `stripe trigger --override`) with fallback to `client_reference_id`. Subscriptions prefer `metadata.user_id` with fallback to a `stripe_customer_id` lookup against `user_subscription` (covers Customer-Portal-initiated events that drop the original Checkout metadata).
- **5xx on transient errors** — DB / Stripe-API failures bubble to a generic 500 so Stripe's retry queue picks them up. Unrecoverable cases (unknown user, unknown price, unmapped status) log + 200 to avoid pile-up.

## API-version note

`current_period_end` was moved off `Subscription` onto each `SubscriptionItem` in Stripe API `2025-04-30.basil`. Our pinned version is `2026-04-22.dahlia`, so the route reads `subscription.items.data[0].current_period_end` (Unix seconds → ISO timestamp for the `timestamptz` column). Verified against `node_modules/stripe/esm/resources/SubscriptionItems.d.ts:50`.

## Files

- `app/api/billing/webhook/route.ts` (new, 434 lines) — server-only, `runtime = 'nodejs'`.
- `__tests__/app/api/billing/webhook/route.test.ts` (new, 23 tests) — signature failures, all three event handlers (including plan switching and status mapping), `metadata.user_id` → `client_reference_id` → customer-id fallback chain, unknown-price skips, DB-error propagation.
- `docs/stripe-setup.md` — corrects a stale pointer (`STRIPE_API_VERSION` lives in `lib/common.ts` now, not `app/api/billing/checkout/route.ts`) and documents the `--override "checkout_session:metadata[user_id]=…"` flag the issue acceptance criteria require for local `stripe trigger`.
- `package.json` / `package-lock.json` — `0.70.0` → `0.71.0`.

## Acceptance checklist

- [x] Server-only with `runtime = 'nodejs'`.
- [x] Raw body via `req.text()`.
- [x] Signature verified via `stripe.webhooks.constructEvent(rawBody, sigHeader, STRIPE_WEBHOOK_SECRET)`.
- [x] `checkout.session.completed` → upsert with paid plan, `status='active'`, `current_period_end`.
- [x] `customer.subscription.updated` → status + period + plan re-derivation.
- [x] `customer.subscription.deleted` → `status='canceled'`, `plan_id='free'`.
- [x] Service-role admin Supabase client.
- [x] Idempotent via `upsert` keyed on `user_id`.
- [x] 200 on processed event, 400 on signature failure.

## Local verification

```bash
npx vitest run __tests__/app/api/billing __tests__/lib/stripe.test.ts --coverage=false
# 4 files, 59 tests, all passing
```

End-to-end smoke test per `docs/stripe-setup.md` §7 (`stripe trigger checkout.session.completed --override "checkout_session:metadata[user_id]=<uuid>"` etc.) is the next step on the merged branch — it requires the live Stripe test-mode account that this PR's CI cannot exercise.

## Dependencies

- Builds on #241 (checkout, merged) and #242 (portal, merged).
- Unblocks E3.10 / E3.11 / E3.12 (DAL plan-gating, settings UI, status surfacing).
