### PR TITLE
feat(billing): add user_subscription DAL helpers (#167)

### DIFF
--- a/__tests__/lib/dal/user-subscription.test.ts
+++ b/__tests__/lib/dal/user-subscription.test.ts
@@ -200,17 +200,16 @@ describe('getUserSubscription', () => {
     expect(result?.can_share).toBe(false)
   })
 
-  it('does not query user_can_share when there is no subscription row', async () => {
-    // Skipping the RPC keeps brand-new (unprovisioned) accounts from
-    // hitting the database for an answer that is unambiguously `false`.
+  it('still issues the user_can_share RPC in parallel and ignores its result when the row is missing', async () => {
+    // Both reads run in parallel (Promise.all), so the RPC is already in
+    // flight by the time we discover the row is missing. We assert it was
+    // wired up so a future refactor to sequential reads gets caught — but
+    // the helper short-circuits to null without consuming the result.
     configureSubscriptionMock({ subscriptionRow: null })
 
     const result = await getUserSubscription()
 
     expect(result).toBeNull()
-    // Both reads were issued in parallel, but the RPC outcome is discarded
-    // when the row is missing. We still verify the RPC was wired up so
-    // tests catch accidental sequential refactors.
     expect(mockSupabase.rpc).toHaveBeenCalledWith('user_can_share')
   })
 })

--- a/__tests__/lib/dal/user-subscription.test.ts
+++ b/__tests__/lib/dal/user-subscription.test.ts
@@ -1,0 +1,353 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the Supabase client module so `getUserId` (imported transitively from
+// `@/lib/dal/user`) resolves against this fake client.
+const mockSupabase = {
+  auth: {
+    getUser: vi.fn(),
+    signOut: vi.fn()
+  },
+  from: vi.fn(),
+  rpc: vi.fn()
+}
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabase
+}))
+
+// Import after mocking so the module picks up the mock.
+const { getUserSubscription, startCheckout, openPortal } =
+  await import('@/lib/dal/user-subscription')
+const { BillingPlanId } = await import('@/schemas/billing-checkout-input')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Wire The Supabase Mock For `getUserSubscription`
+ *
+ * Stubs `auth.getUser`, the `from('user_subscription')` chain, and the
+ * `user_can_share` RPC so each test can dial in the exact behavior under
+ * inspection.
+ */
+function configureSubscriptionMock(opts: {
+  user?: { id: string } | null
+  authError?: { message: string } | null
+  subscriptionRow?: {
+    plan_id: string
+    status: string
+    current_period_end: string | null
+  } | null
+  subscriptionError?: { message: string } | null
+  canShare?: boolean
+  rpcError?: { message: string } | null
+}) {
+  const {
+    user = { id: 'user-1' },
+    authError = null,
+    subscriptionRow = null,
+    subscriptionError = null,
+    canShare = false,
+    rpcError = null
+  } = opts
+
+  mockSupabase.auth.getUser.mockResolvedValue({
+    data: { user },
+    error: authError
+  })
+
+  const mockMaybeSingle = vi.fn().mockResolvedValue({
+    data: subscriptionRow,
+    error: subscriptionError
+  })
+  const mockEq = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle })
+  const mockSelect = vi.fn().mockReturnValue({ eq: mockEq })
+  mockSupabase.from.mockReturnValue({ select: mockSelect })
+
+  mockSupabase.rpc.mockResolvedValue({ data: canShare, error: rpcError })
+
+  return { mockMaybeSingle, mockEq, mockSelect }
+}
+
+describe('getUserSubscription', () => {
+  it('returns null when the user has no user_subscription row yet', async () => {
+    configureSubscriptionMock({ subscriptionRow: null })
+
+    const result = await getUserSubscription()
+
+    expect(result).toBeNull()
+    expect(mockSupabase.from).toHaveBeenCalledWith('user_subscription')
+  })
+
+  it('returns the free-plan row with can_share = false', async () => {
+    const { mockSelect, mockEq, mockMaybeSingle } = configureSubscriptionMock({
+      subscriptionRow: {
+        plan_id: 'free',
+        status: 'active',
+        current_period_end: null
+      },
+      canShare: false
+    })
+
+    const result = await getUserSubscription()
+
+    expect(mockSelect).toHaveBeenCalledWith(
+      'plan_id, status, current_period_end'
+    )
+    expect(mockEq).toHaveBeenCalledWith('user_id', 'user-1')
+    expect(mockMaybeSingle).toHaveBeenCalledOnce()
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('user_can_share')
+    expect(result).toEqual({
+      plan_id: 'free',
+      status: 'active',
+      current_period_end: null,
+      can_share: false
+    })
+  })
+
+  it('returns can_share = true for an active lantern_hoard subscription', async () => {
+    configureSubscriptionMock({
+      subscriptionRow: {
+        plan_id: 'lantern_hoard',
+        status: 'active',
+        current_period_end: '2027-01-01T00:00:00Z'
+      },
+      canShare: true
+    })
+
+    const result = await getUserSubscription()
+
+    expect(result).toEqual({
+      plan_id: 'lantern_hoard',
+      status: 'active',
+      current_period_end: '2027-01-01T00:00:00Z',
+      can_share: true
+    })
+  })
+
+  it('returns can_share = false for a canceled lantern subscription', async () => {
+    // `user_can_share` is what decides — `status = canceled` makes the RPC
+    // resolve false even though the row still exists. This mirrors the
+    // §9.3 "existing shares persist; no new shares" behavior.
+    configureSubscriptionMock({
+      subscriptionRow: {
+        plan_id: 'lantern',
+        status: 'canceled',
+        current_period_end: '2027-01-01T00:00:00Z'
+      },
+      canShare: false
+    })
+
+    const result = await getUserSubscription()
+
+    expect(result).toEqual({
+      plan_id: 'lantern',
+      status: 'canceled',
+      current_period_end: '2027-01-01T00:00:00Z',
+      can_share: false
+    })
+  })
+
+  it('throws Not Authenticated when no user is present', async () => {
+    configureSubscriptionMock({ user: null })
+
+    await expect(getUserSubscription()).rejects.toThrow('Not Authenticated')
+    expect(mockSupabase.from).not.toHaveBeenCalled()
+    expect(mockSupabase.rpc).not.toHaveBeenCalled()
+  })
+
+  it('throws when the subscription query fails', async () => {
+    configureSubscriptionMock({
+      subscriptionError: { message: 'connection refused' }
+    })
+
+    await expect(getUserSubscription()).rejects.toThrow(
+      'Error Fetching User Subscription: connection refused'
+    )
+  })
+
+  it('throws when the user_can_share RPC fails', async () => {
+    configureSubscriptionMock({
+      subscriptionRow: {
+        plan_id: 'lantern',
+        status: 'active',
+        current_period_end: '2027-01-01T00:00:00Z'
+      },
+      rpcError: { message: 'rpc unavailable' }
+    })
+
+    await expect(getUserSubscription()).rejects.toThrow(
+      'Error Checking Share Entitlement: rpc unavailable'
+    )
+  })
+
+  it('treats a non-boolean RPC payload as not entitled', async () => {
+    // Defense in depth: even if the RPC returns null/undefined, the gate
+    // must default to closed.
+    configureSubscriptionMock({
+      subscriptionRow: {
+        plan_id: 'lantern_hoard',
+        status: 'active',
+        current_period_end: '2027-01-01T00:00:00Z'
+      },
+      canShare: null as unknown as boolean
+    })
+
+    const result = await getUserSubscription()
+
+    expect(result?.can_share).toBe(false)
+  })
+
+  it('does not query user_can_share when there is no subscription row', async () => {
+    // Skipping the RPC keeps brand-new (unprovisioned) accounts from
+    // hitting the database for an answer that is unambiguously `false`.
+    configureSubscriptionMock({ subscriptionRow: null })
+
+    const result = await getUserSubscription()
+
+    expect(result).toBeNull()
+    // Both reads were issued in parallel, but the RPC outcome is discarded
+    // when the row is missing. We still verify the RPC was wired up so
+    // tests catch accidental sequential refactors.
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('user_can_share')
+  })
+})
+
+describe('startCheckout', () => {
+  it('POSTs the planId to /api/billing/checkout and returns the URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://checkout.stripe.com/c/pay/cs_test' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const url = await startCheckout(BillingPlanId.LANTERN_HOARD)
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/billing/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ planId: 'lantern_hoard' })
+    })
+    expect(url).toBe('https://checkout.stripe.com/c/pay/cs_test')
+  })
+
+  it('forwards the lantern plan id alongside lantern_hoard', async () => {
+    // Regression guard: the route accepts both paid tiers; the DAL must
+    // forward the caller's selection verbatim.
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://checkout.stripe.com/c/pay/cs_test' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await startCheckout(BillingPlanId.LANTERN)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/billing/checkout',
+      expect.objectContaining({
+        body: JSON.stringify({ planId: 'lantern' })
+      })
+    )
+  })
+
+  it('throws with the route error message on non-OK responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      statusText: 'Unauthorized',
+      json: async () => ({ error: 'Not Authenticated' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(startCheckout(BillingPlanId.LANTERN)).rejects.toThrow(
+      'Error Starting Checkout: Not Authenticated'
+    )
+  })
+
+  it('falls back to statusText when the error body is not JSON', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      statusText: 'Bad Gateway',
+      status: 502,
+      json: async () => {
+        throw new Error('not json')
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(startCheckout(BillingPlanId.LANTERN)).rejects.toThrow(
+      'Error Starting Checkout: Bad Gateway'
+    )
+  })
+
+  it('throws when the response body is missing the URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({})
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(startCheckout(BillingPlanId.LANTERN)).rejects.toThrow(
+      'Error Starting Checkout: missing session URL'
+    )
+  })
+})
+
+describe('openPortal', () => {
+  it('POSTs to /api/billing/portal and returns the URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://billing.stripe.com/p/session/bps_x' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const url = await openPortal()
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/billing/portal', {
+      method: 'POST'
+    })
+    expect(url).toBe('https://billing.stripe.com/p/session/bps_x')
+  })
+
+  it('throws with the route error message on non-OK responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      statusText: 'Bad Request',
+      json: async () => ({ error: 'No Subscription' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(openPortal()).rejects.toThrow(
+      'Error Opening Portal: No Subscription'
+    )
+  })
+
+  it('falls back to a generic message when the error body and statusText are empty', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      statusText: '',
+      status: 500,
+      json: async () => {
+        throw new Error('not json')
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(openPortal()).rejects.toThrow(
+      'Error Opening Portal: Request failed (500)'
+    )
+  })
+
+  it('throws when the response body is missing the URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({})
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(openPortal()).rejects.toThrow(
+      'Error Opening Portal: missing session URL'
+    )
+  })
+})

--- a/contexts/local-context.tsx
+++ b/contexts/local-context.tsx
@@ -1182,8 +1182,12 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
   /**
    * Fetch User Subscription Data
    *
-   * Mirrors the user-settings effect. Failures reset to `null` so
-   * `canShare` falls back to `false` rather than a stale `true`.
+   * Mirrors the user-settings effect. The cleanup callback clears
+   * `userSubscription` whenever `isAuthenticated` transitions (or the
+   * provider unmounts) so paid-gating state can never survive a logout or
+   * user-switch in memory — `canShare` always falls back to `false` until
+   * the next fetch resolves. Failures inside the fetch likewise reset to
+   * `null` so a stale `true` cannot leak across an error.
    */
   useEffect(() => {
     console.debug('Fetching User Subscription Data')
@@ -1213,6 +1217,11 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
 
     return () => {
       isCancelled = true
+      // Clear the cached subscription on auth-flip (true → false) or
+      // unmount. Calling `setState` from the cleanup callback is the
+      // documented safe pattern — the synchronous-setState-in-effect-body
+      // lint rule targets the initial render path, not teardown.
+      setUserSubscriptionState(null)
     }
   }, [isAuthenticated])
 

--- a/contexts/local-context.tsx
+++ b/contexts/local-context.tsx
@@ -12,6 +12,7 @@ import { getSettlementPhase } from '@/lib/dal/settlement-phase'
 import { getShowdown } from '@/lib/dal/showdown'
 import { getSurvivor, getSurvivors } from '@/lib/dal/survivor'
 import { getSettlementForUser, getUserSettings } from '@/lib/dal/user'
+import { getUserSubscription } from '@/lib/dal/user-subscription'
 import { TabType } from '@/lib/enums'
 import { ERROR_MESSAGE } from '@/lib/messages'
 import { createClient } from '@/lib/supabase/client'
@@ -27,7 +28,8 @@ import {
   SurvivorDetail,
   SurvivorsStateSetter,
   SurvivorStateSetter,
-  UserSettingsDetail
+  UserSettingsDetail,
+  UserSubscriptionDetail
 } from '@/lib/types'
 import { saveToLocalStorage } from '@/lib/utils'
 import {
@@ -187,6 +189,28 @@ interface LocalContextType {
   setUserSettings: (settings: UserSettingsDetail | null) => void
 
   /**
+   * User Subscription
+   *
+   * Cached result of `getUserSubscription`. `null` while the initial fetch
+   * is in flight or when the caller has no `user_subscription` row yet
+   * (e.g. a brand-new user racing the sign-up trigger). Consumers should
+   * read `canShare` rather than re-deriving from `plan_id` so the gate
+   * tracks the Postgres `user_can_share()` predicate that RLS already
+   * enforces.
+   */
+  userSubscription: UserSubscriptionDetail | null
+  /** Set User Subscription */
+  setUserSubscription: (subscription: UserSubscriptionDetail | null) => void
+  /**
+   * Whether The User May Create New Shares
+   *
+   * Convenience derivation of `userSubscription?.can_share`. `false`
+   * whenever the subscription is missing, on the free plan, or in a
+   * non-entitling status (`past_due`, `canceled`, `incomplete`).
+   */
+  canShare: boolean
+
+  /**
    * Settlement List
    *
    * Cached result of `getSettlementForUser`. Refreshed automatically when
@@ -276,6 +300,12 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
   // User Settings
   const [userSettings, setUserSettingsState] =
     useState<UserSettingsDetail | null>(null)
+
+  // User Subscription — paid-feature gating snapshot. Refreshed alongside
+  // user settings whenever authentication transitions to true. `canShare`
+  // is derived from this in the memoized context value.
+  const [userSubscription, setUserSubscriptionState] =
+    useState<UserSubscriptionDetail | null>(null)
 
   const [isCreatingNewHunt, setIsCreatingNewHunt] = useState<boolean>(false)
   const [isCreatingNewSettlement, setIsCreatingNewSettlement] =
@@ -1150,6 +1180,43 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
   }, [isAuthenticated])
 
   /**
+   * Fetch User Subscription Data
+   *
+   * Mirrors the user-settings effect. Failures reset to `null` so
+   * `canShare` falls back to `false` rather than a stale `true`.
+   */
+  useEffect(() => {
+    console.debug('Fetching User Subscription Data')
+
+    let isCancelled = false
+
+    if (!isAuthenticated)
+      return () => {
+        isCancelled = true
+      }
+
+    getUserSubscription()
+      .then((subscription) => {
+        if (isCancelled) return
+
+        console.debug('User Subscription:', subscription)
+
+        setUserSubscriptionState(subscription)
+      })
+      .catch((err: unknown) => {
+        if (isCancelled) return
+
+        console.error('User Subscription Fetch Error:', err)
+
+        setUserSubscriptionState(null)
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [isAuthenticated])
+
+  /**
    * Set Selected Hunt
    *
    * @param huntOrUpdater Selected Hunt or functional updater receiving the
@@ -1456,6 +1523,18 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
   }, [])
 
   /**
+   * Set User Subscription
+   *
+   * @param subscription User Subscription
+   */
+  const setUserSubscription = useCallback(
+    (subscription: UserSubscriptionDetail | null) => {
+      setUserSubscriptionState(subscription)
+    },
+    []
+  )
+
+  /**
    * Update Local State
    *
    * @param next Updated Local Data
@@ -1522,6 +1601,10 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
       userSettings,
       setUserSettings,
 
+      userSubscription,
+      setUserSubscription,
+      canShare: userSubscription?.can_share === true,
+
       settlementList,
       isSettlementListLoading
     }),
@@ -1548,6 +1631,7 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
       survivors,
       local,
       userSettings,
+      userSubscription,
       settlementList,
       isSettlementListLoading,
       setSelectedHunt,
@@ -1564,6 +1648,7 @@ export function LocalProvider({ children }: LocalProviderProps): ReactElement {
       setSelectedSurvivorId,
       setSelectedTab,
       setUserSettings,
+      setUserSubscription,
       updateLocal
     ]
   )

--- a/lib/dal/user-subscription.ts
+++ b/lib/dal/user-subscription.ts
@@ -1,0 +1,145 @@
+import { getUserId } from '@/lib/dal/user'
+import { createClient } from '@/lib/supabase/client'
+import { UserSubscriptionDetail } from '@/lib/types'
+import { BillingPlanId } from '@/schemas/billing-checkout-input'
+
+/**
+ * Get User Subscription
+ *
+ * Fetches the authenticated user's row from `user_subscription` and resolves
+ * the share-entitlement flag via the `user_can_share()` RPC. Returning
+ * `can_share` from the server keeps the paid-feature gating decision in
+ * Postgres — the same predicate the RLS policy on
+ * `settlement_shared_user.INSERT` consults — so the UI and the database can
+ * never disagree about who may share.
+ *
+ * The two reads are issued in parallel: the `user_subscription` row carries
+ * plan/status/period metadata for display, and the RPC carries the boolean
+ * entitlement. A `null` return indicates the caller has no subscription row
+ * yet (e.g. a brand-new user racing the sign-up trigger that seeds the
+ * default `free` row).
+ *
+ * @returns User Subscription Detail, or null when no subscription row exists
+ * for the authenticated user.
+ * @throws If the caller is not authenticated, or either underlying query
+ * fails.
+ */
+export async function getUserSubscription(): Promise<UserSubscriptionDetail | null> {
+  const userId = await getUserId()
+  const supabase = createClient()
+
+  const [subscriptionResult, canShareResult] = await Promise.all([
+    supabase
+      .from('user_subscription')
+      .select('plan_id, status, current_period_end')
+      .eq('user_id', userId)
+      .maybeSingle(),
+    supabase.rpc('user_can_share')
+  ])
+
+  if (subscriptionResult.error)
+    throw new Error(
+      `Error Fetching User Subscription: ${subscriptionResult.error.message}`
+    )
+
+  if (!subscriptionResult.data) return null
+
+  if (canShareResult.error)
+    throw new Error(
+      `Error Checking Share Entitlement: ${canShareResult.error.message}`
+    )
+
+  return {
+    plan_id: subscriptionResult.data.plan_id,
+    status: subscriptionResult.data.status,
+    current_period_end: subscriptionResult.data.current_period_end,
+    can_share: canShareResult.data === true
+  }
+}
+
+/**
+ * Start Stripe Checkout
+ *
+ * POSTs to `/api/billing/checkout` to create a Stripe-hosted Checkout
+ * session for the specified paid plan and returns the hosted URL the caller
+ * should redirect the browser to. The app deliberately does not implement
+ * its own billing surface — plan selection happens on Stripe Checkout.
+ *
+ * Multiple paid tiers (`lantern`, `lantern_hoard`) are validated server-side
+ * by `BillingCheckoutInputSchema`; the DAL just forwards the user's
+ * selection so call sites do not have to hand-roll the fetch.
+ *
+ * @param planId Target paid subscription plan (`free` is not a valid
+ * Checkout target — downgrades flow through the Customer Portal).
+ * @returns Stripe Checkout session URL.
+ * @throws If the request fails or the response body is malformed.
+ */
+export async function startCheckout(planId: BillingPlanId): Promise<string> {
+  const response = await fetch('/api/billing/checkout', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ planId })
+  })
+
+  if (!response.ok) {
+    const message = await extractErrorMessage(response)
+
+    throw new Error(`Error Starting Checkout: ${message}`)
+  }
+
+  const body = (await response.json()) as { url?: string }
+
+  if (!body.url) throw new Error('Error Starting Checkout: missing session URL')
+
+  return body.url
+}
+
+/**
+ * Open Stripe Customer Portal
+ *
+ * POSTs to `/api/billing/portal` to create a Stripe-hosted Customer Portal
+ * session for the authenticated user and returns the hosted URL the caller
+ * should redirect the browser to. All subscription self-service (payment
+ * method, invoices, plan switch, cancel) happens on Stripe's hosted UI; the
+ * app intentionally does not implement its own billing surface.
+ *
+ * @returns Stripe Customer Portal session URL.
+ * @throws If the request fails or the response body is malformed.
+ */
+export async function openPortal(): Promise<string> {
+  const response = await fetch('/api/billing/portal', { method: 'POST' })
+
+  if (!response.ok) {
+    const message = await extractErrorMessage(response)
+
+    throw new Error(`Error Opening Portal: ${message}`)
+  }
+
+  const body = (await response.json()) as { url?: string }
+
+  if (!body.url) throw new Error('Error Opening Portal: missing session URL')
+
+  return body.url
+}
+
+/**
+ * Extract Error Message
+ *
+ * Pulls a human-readable message out of an error JSON body returned by the
+ * billing routes. Falls back to the HTTP status text when the body cannot
+ * be parsed (e.g. an upstream proxy returned text/html).
+ *
+ * @param response Non-OK Fetch Response.
+ * @returns Error Message.
+ */
+async function extractErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: string }
+
+    if (body.error) return body.error
+  } catch {
+    // Body was not valid JSON — fall through to statusText.
+  }
+
+  return response.statusText || `Request failed (${response.status})`
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1624,6 +1624,33 @@ export type UserSettingsDetail = Omit<
 >
 
 /**
+ * User Subscription Detail
+ *
+ * Client-side projection of the authenticated user's row in
+ * `user_subscription`, combined with the `user_can_share()` entitlement
+ * flag. Returned by `getUserSubscription()` in
+ * `lib/dal/user-subscription.ts` and surfaced on `LocalContext` so any
+ * component can read the active plan and share entitlement without
+ * re-querying. The same Postgres predicate that decides `can_share` here
+ * also gates RLS on `settlement_shared_user.INSERT`.
+ */
+export interface UserSubscriptionDetail {
+  /** Active Plan ID */
+  plan_id: 'free' | 'lantern' | 'lantern_hoard'
+  /** Subscription Status (e.g. `active`, `past_due`, `canceled`) */
+  status: string
+  /** Current Period End (ISO timestamp; null on the free plan) */
+  current_period_end: string | null
+  /**
+   * Whether The User May Create New Shares
+   *
+   * Mirrors the `user_can_share()` Postgres predicate consulted by RLS on
+   * `settlement_shared_user.INSERT`.
+   */
+  can_share: boolean
+}
+
+/**
  * Wanderer Detail
  *
  * Used throughout the app to represent the currently selected wanderer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.71.0",
+      "version": "0.72.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
Closes #167.

## Summary

Adds the client-side data-access layer that closes out the E3 billing trilogy. Three previously merged PRs (#241 Checkout, #242 Portal, #243 Webhook) wrote to `user_subscription`; this PR exposes a typed read path and thin fetch wrappers so the rest of the app can:

- read the caller's plan / status / period without hand-rolling the Supabase query,
- ask Postgres "may this user share?" in one call,
- redirect into Stripe Checkout for any paid tier (`lantern`, `lantern_hoard`), and
- redirect into the Stripe Customer Portal for self-service.

All payment / subscription UI stays on Stripe-hosted pages — the app intentionally ships no embedded billing surface.

## What changed

### New: `lib/dal/user-subscription.ts`

- **`getUserSubscription(): Promise<UserSubscriptionDetail | null>`** — issues two parallel reads: a `SELECT plan_id, status, current_period_end FROM user_subscription` (gated by the "Allow select own" RLS policy) and `supabase.rpc('user_can_share')`. Returns `null` when no row exists (brand-new user racing the sign-up trigger). Resolving `can_share` via the RPC means the UI's gate tracks the same SECURITY DEFINER predicate that RLS enforces on `settlement_shared_user.INSERT` — single source of truth for the paid-feature decision.
- **`startCheckout(planId: BillingPlanId): Promise<string>`** — POSTs `{ planId }` to `/api/billing/checkout` and returns the hosted Stripe URL. The `planId` parameter (intentional addition vs. the issue's bare signature) honors the "account for multiple subscription tiers" requirement; the route's existing `BillingCheckoutInputSchema` validates the value server-side.
- **`openPortal(): Promise<string>`** — POSTs to `/api/billing/portal` and returns the Customer Portal URL.
- Shared private `extractErrorMessage(response)` parses `body.error`, falls back to `statusText`, and finally to `Request failed (${status})` so non-JSON proxy errors still surface readable text.

### New: `UserSubscriptionDetail` interface in `lib/types.ts`

`{ plan_id, status, current_period_end, can_share }`. Documented as the client-side projection of `user_subscription` + the `user_can_share()` entitlement.

### `LocalContext` wiring

- New top-level fields `userSubscription`, `setUserSubscription`, and a derived `canShare` (mirrors `userSettings`'s pattern — server-derived state, deliberately NOT persisted to the localStorage `local` slice so a stale `true` never survives sign-out).
- New `useEffect` mirrors the existing user-settings fetch effect: fires on `isAuthenticated === true`, resets to `null` on failure so `canShare` falls back closed.

### Version bump

`0.71.0` → `0.72.0` in `package.json` and `package-lock.json`.

## Design notes

- **Parallel reads.** The SELECT and the RPC are independent — `Promise.all` saves a round trip.
- **`can_share` from the server, not the client.** Could be derived from `(status === 'active' || status === 'trialing') && plan.may_share`, but that would duplicate Postgres logic in TS and drift the moment a new plan ships. The RPC is the canonical answer.
- **`startCheckout` takes a `planId`.** The issue body said `startCheckout(): Promise`, but with two paid tiers already seeded (`lantern`, `lantern_hoard`) and the user's instruction to "account for the multiple subscription tiers", the parameter is required.
- **`canShare` exposed at top level on `LocalContext`, not inside `local`.** The issue mentions `local.canShare`, but the existing `local` slice is the localStorage-persisted shape (selected IDs, tab, disableToasts). Subscription state must not survive offline; it lives alongside `userSettings` instead.

## Departures from issue body

| Issue text | Implementation | Reason |
|---|---|---|
| `startCheckout(): Promise` | `startCheckout(planId: BillingPlanId): Promise<string>` | Two paid tiers exist; route requires `planId` |
| `local.canShare` | `useLocal().canShare` (top-level field) | Subscription is server state, not persisted |

## Tests

`__tests__/lib/dal/user-subscription.test.ts` — 18 cases:

- `getUserSubscription`: null when no row; free/active mapped correctly; lantern_hoard/active with `can_share: true`; lantern/canceled with `can_share: false`; throws on unauthenticated, SELECT error, RPC error; defends against a non-boolean RPC payload (defaults closed); does not require the RPC outcome when the row is missing.
- `startCheckout`: POSTs `{ planId: 'lantern_hoard' }`; forwards `{ planId: 'lantern' }`; throws `Error Starting Checkout: …` with route error body; falls back to `statusText` on non-JSON; throws on missing URL.
- `openPortal`: POSTs to `/api/billing/portal`; throws `Error Opening Portal: …` on non-OK; falls back to `Request failed (${status})` when both body and statusText are empty; throws on missing URL.

Full sweep (`user-subscription`, `user`, billing routes, stripe helper) — 104/104 pass.

## Out of scope

Per the issue: rendering the subscription state in settings UI is left to E3.10. This PR only ships the DAL + context wiring.