### PR TITLE
test(rls): paid-sharing matrix (#172) + subscription provisioning coverage (#173)

### DIFF
--- a/__tests__/integration/rls/paid-sharing.test.ts
+++ b/__tests__/integration/rls/paid-sharing.test.ts
@@ -1,0 +1,388 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Paid-Sharing Entitlement Matrix (E3.12)
+ *
+ * Integration test matrix for the paid-sharing entitlement layer added in
+ * Epic E3 — Phase 3 (`docs/settlement-sharing-architecture.md` §9.1 / §9.3
+ * and Appendix B EC-11, EC-12). Mirrors the cases enumerated in GitHub
+ * issue #172:
+ *
+ *   1. Free user attempts to INSERT into `settlement_shared_user` → RLS
+ *      denies (EC-11).
+ *   2. Lantern Hoard / active user INSERTs → success.
+ *   3. Lantern Hoard / active user shares with two free invitees; both can
+ *      collaborate fully on the paid-shared settlement (EC-11/EC-12 — the
+ *      entitlement attaches to the GRANTOR, not the grantee).
+ *   4. Owner downgrades to canceled; the existing share row persists and
+ *      the invitee still has full collaboration access, but the owner
+ *      cannot create a NEW share to a third party (EC-12).
+ *   5. Past-due owner: INSERT denied — `past_due` is intentionally outside
+ *      the `user_can_share()` status whitelist (`active`, `trialing`).
+ *   6. Trialing owner: INSERT allowed — locks in the second member of the
+ *      `user_can_share()` status whitelist alongside `active`.
+ *
+ * This file is the high-level matrix that ties EC-11 and EC-12 together
+ * end-to-end. The lower-level policy regression for the same migration
+ * lives in `settlement-shared.test.ts` (E3.3 / #165), and the
+ * SECURITY DEFINER predicate by itself is exercised in
+ * `user-can-share.test.ts` (E3.2 / #174). The overlap is intentional:
+ * the per-cell matrix here is the canonical home for the paywall
+ * acceptance criteria in #172, and it cross-checks both lower-level
+ * suites by composing the predicate, the INSERT policy, and the
+ * collaborator-SELECT/INSERT contract in a single flow.
+ *
+ * Why the `admin` (service-role) client seeds `user_subscription`
+ * --------------------------------------------------------------
+ * The `user_subscription` table is provisioned with two RLS policies
+ * (see `20260527000001_user_subscription.sql`):
+ *
+ *   * `"Allow select own"` — authenticated callers may read their own row.
+ *   * `"Allow all for admin"` — only `is_admin()` callers may write.
+ *
+ * Writes are intentionally reserved for the future Stripe webhook handler
+ * (which runs under `service_role`) and for admin operators. There is no
+ * authenticated-user INSERT/UPDATE path on the table. The integration
+ * test fixture therefore mutates rows through the `admin` client, which
+ * holds the service-role key, bypasses RLS, and matches the exact
+ * codepath the production webhook will use. The `setUserSubscription`
+ * helper below documents this contract at its single call site.
+ */
+describe('RLS: paid-sharing matrix (E3.12)', () => {
+  let owner: TestUser
+  let invitee1: TestUser
+  let invitee2: TestUser
+  let stranger: TestUser
+  let settlementId: string
+
+  beforeAll(async () => {
+    // Four users:
+    //   - owner    — flipped between subscription cells per case
+    //   - invitee1 — stays on the default `free` / `active` seed; the
+    //                invitee's plan is irrelevant to `user_can_share()`
+    //                because the predicate is evaluated against the
+    //                grantor (`auth.uid()`), not the grantee.
+    //   - invitee2 — second free invitee for case 3 (two-invitee
+    //                collaboration evidence).
+    //   - stranger — never shared with; used as the target of the
+    //                "new INSERT denied after downgrade" assertion in
+    //                case 4.
+    owner = await createTestUser()
+    invitee1 = await createTestUser()
+    invitee2 = await createTestUser()
+    stranger = await createTestUser()
+    settlementId = await seedSettlement(owner.id, 'E3.12 Paid-Sharing Matrix')
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(invitee1.id)
+    await deleteTestUser(invitee2.id)
+    await deleteTestUser(stranger.id)
+  })
+
+  /**
+   * Set User Subscription
+   *
+   * Drives an arbitrary test user into the requested entitlement cell.
+   *
+   * Uses the service-role `admin` client because the `user_subscription`
+   * table's write policies (`Allow all for admin` only) intentionally
+   * reserve INSERT/UPDATE/DELETE for the Stripe webhook handler and
+   * admin operators — there is no authenticated-user write path. See
+   * the file-level JSDoc above for the full rationale.
+   *
+   * @param userId User ID
+   * @param planId Subscription Plan ID
+   * @param status User Subscription Status
+   */
+  async function setUserSubscription(
+    userId: string,
+    planId: 'free' | 'lantern' | 'lantern_hoard',
+    status: 'active' | 'past_due' | 'canceled' | 'trialing' | 'incomplete'
+  ): Promise<void> {
+    const { error } = await admin
+      .from('user_subscription')
+      .update({ plan_id: planId, status })
+      .eq('user_id', userId)
+    expect(error).toBeNull()
+  }
+
+  /**
+   * Clear Shares
+   *
+   * Wipes every `settlement_shared_user` row for the fixture settlement
+   * so each case starts from a known-empty state. Uses `admin` so the
+   * cleanup is independent of whatever subscription state the previous
+   * case left the owner in (a canceled owner cannot, in general, delete
+   * other people's shares — but the admin bypass survives the paid gate).
+   */
+  async function clearShares(): Promise<void> {
+    const { error } = await admin
+      .from('settlement_shared_user')
+      .delete()
+      .eq('settlement_id', settlementId)
+    expect(error).toBeNull()
+  }
+
+  it('case 1 — free owner: INSERT into settlement_shared_user is denied (EC-11)', async () => {
+    // `createTestUser` already seeds `free` / `active`, but assert the
+    // entitlement cell explicitly so the test is not coupled to fixture
+    // defaults.
+    await setUserSubscription(owner.id, 'free', 'active')
+    await clearShares()
+
+    const { data, error } = await owner.client
+      .from('settlement_shared_user')
+      .insert({
+        settlement_id: settlementId,
+        shared_user_id: invitee1.id,
+        user_id: owner.id
+      })
+      .select('shared_user_id')
+
+    expect(data ?? []).toEqual([])
+    expect(error).not.toBeNull()
+    // PostgREST surfaces an RLS check-clause failure as either `42501`
+    // (newer Postgres) or a `PGRST` prefix code. Either is acceptable —
+    // both signal the same RLS denial.
+    expect(error?.code).toMatch(/PGRST|42501/)
+
+    // Defense-in-depth: confirm no row was created server-side.
+    const { data: post } = await admin
+      .from('settlement_shared_user')
+      .select('shared_user_id')
+      .eq('settlement_id', settlementId)
+    expect(post ?? []).toEqual([])
+  })
+
+  it('case 2 — lantern_hoard + active owner: INSERT succeeds', async () => {
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await clearShares()
+
+    const { data, error } = await owner.client
+      .from('settlement_shared_user')
+      .insert({
+        settlement_id: settlementId,
+        shared_user_id: invitee1.id,
+        user_id: owner.id
+      })
+      .select('settlement_id, shared_user_id, user_id')
+      .single()
+
+    expect(error).toBeNull()
+    expect(data?.settlement_id).toBe(settlementId)
+    expect(data?.shared_user_id).toBe(invitee1.id)
+    expect(data?.user_id).toBe(owner.id)
+  })
+
+  it('case 3 — two free invitees can collaborate fully on a paid-shared settlement (EC-11/EC-12)', async () => {
+    // Paid owner shares with TWO free invitees. The entitlement gates
+    // share CREATION (grantor side), not consumption (grantee side), so
+    // both invitees — despite being on the default free plan — must be
+    // able to exercise the full collaborator contract on the settlement.
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await clearShares()
+
+    // Sanity-check the assumed invitee state: both are still on `free`.
+    // If a previous case mutated them (none should), this would surface
+    // the cross-test bleed loudly.
+    for (const invitee of [invitee1, invitee2]) {
+      const { data: sub } = await admin
+        .from('user_subscription')
+        .select('plan_id, status')
+        .eq('user_id', invitee.id)
+        .single<{ plan_id: string; status: string }>()
+      expect(sub?.plan_id).toBe('free')
+    }
+
+    // Owner grants both invitees in a single round-trip — verifies the
+    // policy fires correctly for back-to-back inserts and not just for
+    // the first.
+    const { error: shareErr } = await owner.client
+      .from('settlement_shared_user')
+      .insert([
+        {
+          settlement_id: settlementId,
+          shared_user_id: invitee1.id,
+          user_id: owner.id
+        },
+        {
+          settlement_id: settlementId,
+          shared_user_id: invitee2.id,
+          user_id: owner.id
+        }
+      ])
+    expect(shareErr).toBeNull()
+
+    // Both invitees can now SELECT the settlement row (the "Allow select
+    // for shared" policy on `settlement` reads through
+    // `settlement_shared_user`).
+    for (const invitee of [invitee1, invitee2]) {
+      const { data: sel, error: selErr } = await invitee.client
+        .from('settlement')
+        .select('id, settlement_name')
+        .eq('id', settlementId)
+        .single()
+      expect(selErr).toBeNull()
+      expect(sel?.id).toBe(settlementId)
+    }
+
+    // Each invitee can INSERT into a settlement-scoped child table.
+    // `settlement_timeline_year.year_number` is unique per settlement
+    // and constrained to `0..50` by a CHECK; the two invitees pick
+    // distinct in-range slots (the seeded settlement has no timeline
+    // rows of its own).
+    const insertedRowIds: string[] = []
+    const invitees = [invitee1, invitee2]
+    const yearSlots = [11, 12]
+    for (let i = 0; i < invitees.length; i++) {
+      const invitee = invitees[i]
+      const { data: ins, error: insErr } = await invitee.client
+        .from('settlement_timeline_year')
+        .insert({
+          settlement_id: settlementId,
+          year_number: yearSlots[i]
+        })
+        .select('id')
+        .single<{ id: string }>()
+      expect(insErr).toBeNull()
+      expect(ins?.id).toBeTruthy()
+      insertedRowIds.push(ins!.id)
+    }
+
+    // And each invitee can UPDATE the row they just inserted — proves
+    // the full SELECT + INSERT + UPDATE contract on a child row that
+    // their entitlement does NOT directly cover.
+    for (let i = 0; i < invitees.length; i++) {
+      const { data: upd, error: updErr } = await invitees[i].client
+        .from('settlement_timeline_year')
+        .update({ completed: true })
+        .eq('id', insertedRowIds[i])
+        .select('id, completed')
+        .single()
+      expect(updErr).toBeNull()
+      expect(upd?.completed).toBe(true)
+    }
+
+    // Cleanup so the next case starts from a clean settlement_timeline_year.
+    const { error: cleanupErr } = await admin
+      .from('settlement_timeline_year')
+      .delete()
+      .in('id', insertedRowIds)
+    expect(cleanupErr).toBeNull()
+  })
+
+  it('case 4 — owner downgrades to canceled: existing share persists, new INSERT denied (EC-12)', async () => {
+    // 1. Paid owner seeds a share to invitee1.
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await clearShares()
+    const { error: seedErr } = await owner.client
+      .from('settlement_shared_user')
+      .insert({
+        settlement_id: settlementId,
+        shared_user_id: invitee1.id,
+        user_id: owner.id
+      })
+    expect(seedErr).toBeNull()
+
+    // 2. Owner cancels. The "Allow insert by paying owner" policy now
+    //    rejects new grants, but the SELECT / UPDATE / DELETE policies
+    //    minted in 20260220190650_settlement.sql are untouched, so the
+    //    existing row remains intact for both sides.
+    await setUserSubscription(owner.id, 'lantern_hoard', 'canceled')
+
+    // 3a. The existing share row is still visible to the owner.
+    const { data: ownerView, error: ownerViewErr } = await owner.client
+      .from('settlement_shared_user')
+      .select('shared_user_id, user_id')
+      .eq('settlement_id', settlementId)
+    expect(ownerViewErr).toBeNull()
+    expect(ownerView ?? []).toEqual([
+      { shared_user_id: invitee1.id, user_id: owner.id }
+    ])
+
+    // 3b. The invitee can still SELECT the settlement — their access
+    //     was minted before the downgrade and the canceled owner has
+    //     not had it revoked. This is the EC-12 contract.
+    const { data: inviteeView, error: inviteeViewErr } = await invitee1.client
+      .from('settlement')
+      .select('id')
+      .eq('id', settlementId)
+      .single()
+    expect(inviteeViewErr).toBeNull()
+    expect(inviteeView?.id).toBe(settlementId)
+
+    // 3c. But the owner can NO LONGER create a new share. Pick the
+    //     stranger as the target so this assertion is independent of
+    //     the existing invitee1 grant.
+    const { data: newShare, error: newShareErr } = await owner.client
+      .from('settlement_shared_user')
+      .insert({
+        settlement_id: settlementId,
+        shared_user_id: stranger.id,
+        user_id: owner.id
+      })
+      .select('shared_user_id')
+    expect(newShare ?? []).toEqual([])
+    expect(newShareErr).not.toBeNull()
+    expect(newShareErr?.code).toMatch(/PGRST|42501/)
+
+    // 3d. Defense-in-depth: confirm the share table holds exactly the
+    //     original row — no stranger grant leaked through.
+    const { data: final } = await admin
+      .from('settlement_shared_user')
+      .select('shared_user_id')
+      .eq('settlement_id', settlementId)
+    expect(final ?? []).toEqual([{ shared_user_id: invitee1.id }])
+  })
+
+  it('case 5 — past_due owner: INSERT denied (status whitelist excludes past_due)', async () => {
+    // `past_due` is intentionally outside the `user_can_share()`
+    // whitelist (which only accepts `active` and `trialing`). The
+    // grantor's plan still has `may_share = true`, so this pins the
+    // policy to the status check specifically.
+    await setUserSubscription(owner.id, 'lantern_hoard', 'past_due')
+    await clearShares()
+
+    const { data, error } = await owner.client
+      .from('settlement_shared_user')
+      .insert({
+        settlement_id: settlementId,
+        shared_user_id: invitee1.id,
+        user_id: owner.id
+      })
+      .select('shared_user_id')
+
+    expect(data ?? []).toEqual([])
+    expect(error).not.toBeNull()
+    expect(error?.code).toMatch(/PGRST|42501/)
+  })
+
+  it('case 6 — trialing owner: INSERT allowed (second member of the status whitelist)', async () => {
+    // Locks in the second whitelisted status (`trialing`) against the
+    // policy as a regression target separate from `active`.
+    await setUserSubscription(owner.id, 'lantern_hoard', 'trialing')
+    await clearShares()
+
+    const { data, error } = await owner.client
+      .from('settlement_shared_user')
+      .insert({
+        settlement_id: settlementId,
+        shared_user_id: invitee1.id,
+        user_id: owner.id
+      })
+      .select('shared_user_id')
+      .single()
+
+    expect(error).toBeNull()
+    expect(data?.shared_user_id).toBe(invitee1.id)
+  })
+})

--- a/__tests__/integration/rls/subscription-provisioning.test.ts
+++ b/__tests__/integration/rls/subscription-provisioning.test.ts
@@ -1,0 +1,263 @@
+import { admin } from '@/__tests__/integration/helpers/supabase'
+import type { User } from '@supabase/supabase-js'
+import { afterEach, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Default-Row Provisioning of `free` Subscription on New Sign-Up
+ *
+ * Integration coverage for Epic E3.13 (GitHub issue #173). Verifies the
+ * `user_subscription` provisioning paths that ship in
+ * `20260527000001_user_subscription.sql`:
+ *
+ *   1. Email sign-up — the `initialize_user_settings(p_user_id, p_username)`
+ *      RPC (called by the sign-up form after `signUp()` resolves) seeds a
+ *      `free` / `active` row.
+ *   2. OAuth sign-up — the `on_auth_user_created_oauth` trigger delegates
+ *      to `provision_user_settings_for_oauth(p_user_id)`, which seeds the
+ *      same row. The trigger's wrapper (`handle_new_oauth_user`) is
+ *      authored to call this helper, so testing the helper directly is
+ *      equivalent to testing the trigger's contract without forging
+ *      `auth.users` rows.
+ *   3. Idempotency — both RPCs are wrapped in `on conflict do nothing`
+ *      so re-invocations and OAuth-then-email race scenarios are
+ *      harmless.
+ *   4. Backfill — re-running the migration's backfill SQL produces a row
+ *      for any pre-existing user that lacks one (mirroring the block at
+ *      the bottom of `20260527000001_user_subscription.sql`).
+ *
+ * Why this file does NOT use `createTestUser`
+ * -------------------------------------------
+ * The shared `createTestUser` helper manually seeds both `user_settings`
+ * and `user_subscription` rows so downstream RLS tests can rely on a
+ * known starting state. That manual seed would mask the production
+ * provisioning paths under test here, so this file creates its
+ * `auth.users` row via the GoTrue admin endpoint directly and then
+ * inspects the database for the resulting subscription row.
+ *
+ * GoTrue's admin `createUser` records `provider = 'email'` on the
+ * inserted row, which the OAuth trigger
+ * (`handle_new_oauth_user`) explicitly short-circuits. So the test
+ * users created here never trigger any auto-provisioning of their own —
+ * provisioning happens only when the production RPC under test is
+ * invoked.
+ */
+describe('RLS: subscription provisioning on sign-up (E3.13)', () => {
+  // Track every test-created user so a single afterEach can tear them down
+  // even when an assertion mid-test throws. `deleteUser` cascades to
+  // `user_settings` and `user_subscription` via the FK chain.
+  const provisionedUserIds: string[] = []
+
+  afterEach(async () => {
+    while (provisionedUserIds.length > 0) {
+      const id = provisionedUserIds.pop()!
+      await admin.auth.admin.deleteUser(id)
+    }
+  })
+
+  /**
+   * Create Bare Auth User
+   *
+   * Mints an `auth.users` row via GoTrue admin and returns the User
+   * record. Performs NO `user_settings` or `user_subscription` seeding —
+   * the OAuth trigger short-circuits for `provider = 'email'` (which is
+   * what GoTrue's admin path emits), so the database stays in the exact
+   * state a fresh email sign-up sees right after `signUp()` resolves and
+   * before the sign-up form calls `initialize_user_settings`.
+   *
+   * @returns Auth User
+   */
+  async function createBareAuthUser(): Promise<User> {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const { data, error } = await admin.auth.admin.createUser({
+      email: `prov-${suffix}@test.local`,
+      password: `password-${suffix}`,
+      email_confirm: true
+    })
+    if (error || !data.user)
+      throw new Error(`createUser failed: ${error?.message}`)
+    provisionedUserIds.push(data.user.id)
+    return data.user
+  }
+
+  it('email path — initialize_user_settings seeds free/active subscription', async () => {
+    const user = await createBareAuthUser()
+
+    // Confirm the OAuth trigger did NOT pre-seed (it short-circuits for
+    // provider='email'). This is the exact pre-condition the production
+    // sign-up flow sees right after signUp() resolves.
+    const { data: before } = await admin
+      .from('user_subscription')
+      .select('user_id')
+      .eq('user_id', user.id)
+    expect(before ?? []).toEqual([])
+
+    // Production codepath: the sign-up form calls this RPC with the
+    // username the user typed in. The function is SECURITY DEFINER, so
+    // the admin client is used only as a transport — the function body
+    // would behave identically when called by the anon client.
+    const { error: rpcErr } = await admin.rpc('initialize_user_settings', {
+      p_user_id: user.id,
+      p_username: `prov_${user.id.slice(0, 8)}`
+    })
+    expect(rpcErr).toBeNull()
+
+    const { data: after, error: afterErr } = await admin
+      .from('user_subscription')
+      .select('user_id, plan_id, status')
+      .eq('user_id', user.id)
+      .single()
+    expect(afterErr).toBeNull()
+    expect(after?.plan_id).toBe('free')
+    expect(after?.status).toBe('active')
+  })
+
+  it('oauth path — provision_user_settings_for_oauth seeds free/active subscription', async () => {
+    const user = await createBareAuthUser()
+
+    const { data: before } = await admin
+      .from('user_subscription')
+      .select('user_id')
+      .eq('user_id', user.id)
+    expect(before ?? []).toEqual([])
+
+    // The OAuth trigger (`handle_new_oauth_user`) is a thin wrapper that
+    // delegates to this helper for every non-email provider. Calling it
+    // directly tests the helper's contract — which is what the trigger
+    // body actually executes — without having to forge an auth.users
+    // row with `provider = 'discord'`. EXECUTE on this function is
+    // restricted to service_role per
+    // `20260508000000_user_settings_avatar_url.sql`, which is exactly
+    // what the admin client holds.
+    const { error: rpcErr } = await admin.rpc(
+      'provision_user_settings_for_oauth',
+      { p_user_id: user.id }
+    )
+    expect(rpcErr).toBeNull()
+
+    const { data: after, error: afterErr } = await admin
+      .from('user_subscription')
+      .select('user_id, plan_id, status')
+      .eq('user_id', user.id)
+      .single()
+    expect(afterErr).toBeNull()
+    expect(after?.plan_id).toBe('free')
+    expect(after?.status).toBe('active')
+  })
+
+  it('email path is idempotent — re-invocation is a no-op', async () => {
+    const user = await createBareAuthUser()
+
+    // First call seeds the row.
+    await admin.rpc('initialize_user_settings', {
+      p_user_id: user.id,
+      p_username: `prov_${user.id.slice(0, 8)}`
+    })
+
+    // Mutate the row out of band so we can detect any overwrite by the
+    // second call. The `on conflict do nothing` clause should leave
+    // this in place.
+    const { error: mutateErr } = await admin
+      .from('user_subscription')
+      .update({ plan_id: 'lantern_hoard', status: 'active' })
+      .eq('user_id', user.id)
+    expect(mutateErr).toBeNull()
+
+    // Re-call: must not clobber the upgraded plan.
+    const { error: secondErr } = await admin.rpc('initialize_user_settings', {
+      p_user_id: user.id,
+      p_username: `prov_${user.id.slice(0, 8)}`
+    })
+    expect(secondErr).toBeNull()
+
+    const { data: rows } = await admin
+      .from('user_subscription')
+      .select('user_id, plan_id')
+      .eq('user_id', user.id)
+    expect(rows).toHaveLength(1)
+    expect(rows?.[0].plan_id).toBe('lantern_hoard')
+  })
+
+  it('oauth path is idempotent — re-invocation is a no-op', async () => {
+    const user = await createBareAuthUser()
+
+    await admin.rpc('provision_user_settings_for_oauth', { p_user_id: user.id })
+
+    const { error: mutateErr } = await admin
+      .from('user_subscription')
+      .update({ plan_id: 'lantern', status: 'trialing' })
+      .eq('user_id', user.id)
+    expect(mutateErr).toBeNull()
+
+    const { error: secondErr } = await admin.rpc(
+      'provision_user_settings_for_oauth',
+      { p_user_id: user.id }
+    )
+    expect(secondErr).toBeNull()
+
+    const { data: rows } = await admin
+      .from('user_subscription')
+      .select('user_id, plan_id, status')
+      .eq('user_id', user.id)
+    expect(rows).toHaveLength(1)
+    expect(rows?.[0].plan_id).toBe('lantern')
+    expect(rows?.[0].status).toBe('trialing')
+  })
+
+  it('backfill — a pre-existing user without a subscription row is recovered to free', async () => {
+    // Simulate the state any pre-E3.1 user was in immediately before the
+    // backfill ran: an `auth.users` row with NO matching
+    // `user_subscription` row. (Our `createBareAuthUser` already produces
+    // exactly this state because the OAuth trigger short-circuits on
+    // `provider = 'email'`.)
+    const user = await createBareAuthUser()
+
+    const { data: before } = await admin
+      .from('user_subscription')
+      .select('user_id')
+      .eq('user_id', user.id)
+    expect(before ?? []).toEqual([])
+
+    // Mirror the backfill block at the bottom of
+    // `20260527000001_user_subscription.sql`. Scoped to the test user via
+    // an `eq` filter so it cannot interfere with other concurrent tests.
+    const { error: backfillErr } = await admin
+      .from('user_subscription')
+      .upsert(
+        { user_id: user.id, plan_id: 'free' },
+        { onConflict: 'user_id', ignoreDuplicates: true }
+      )
+    expect(backfillErr).toBeNull()
+
+    const { data: after, error: afterErr } = await admin
+      .from('user_subscription')
+      .select('user_id, plan_id, status')
+      .eq('user_id', user.id)
+      .single()
+    expect(afterErr).toBeNull()
+    expect(after?.plan_id).toBe('free')
+    expect(after?.status).toBe('active')
+
+    // Re-running the backfill must be a no-op (idempotency). Mutate the
+    // row first to a non-default state; the backfill should not clobber
+    // it.
+    await admin
+      .from('user_subscription')
+      .update({ plan_id: 'lantern_hoard' })
+      .eq('user_id', user.id)
+
+    const { error: secondErr } = await admin
+      .from('user_subscription')
+      .upsert(
+        { user_id: user.id, plan_id: 'free' },
+        { onConflict: 'user_id', ignoreDuplicates: true }
+      )
+    expect(secondErr).toBeNull()
+
+    const { data: post } = await admin
+      .from('user_subscription')
+      .select('plan_id')
+      .eq('user_id', user.id)
+      .single()
+    expect(post?.plan_id).toBe('lantern_hoard')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.78.0",
+      "version": "0.78.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
Closes #172. Closes #173.

## Summary

Adds the integration-test coverage that closes out **E3.12** (paid-sharing
RLS matrix) and the remaining acceptance item for **E3.13** (default-row
provisioning of `free` subscription on new sign-up). No app code, no
migrations, no schema changes — both deliverables are test-only.

### #172 — `__tests__/integration/rls/paid-sharing.test.ts` (new)

High-level matrix that ties EC-11 and EC-12 together end-to-end against
the live local Supabase stack. Mirrors the six cases enumerated in the
issue:

| # | Cell | Expected |
| - | ---- | -------- |
| 1 | `free` owner | `INSERT settlement_shared_user` → RLS denied (EC-11) |
| 2 | `lantern_hoard` + `active` | INSERT succeeds |
| 3 | `lantern_hoard` + `active` shares to **two** `free` invitees | Both can `SELECT` the settlement and INSERT/UPDATE a `settlement_timeline_year` row (entitlement attaches to the grantor only) |
| 4 | Owner downgrades to `canceled` after a share exists | Existing share persists, invitee retains access, new INSERT to a third party is RLS-denied (EC-12) |
| 5 | `past_due` owner | INSERT denied (status whitelist excludes `past_due`) |
| 6 | `trialing` owner | INSERT allowed (second whitelisted status) |

Includes a local `setUserSubscription(userId, planId, status)` helper that
routes writes through the service-role `admin` client. The file-level
JSDoc explicitly documents why the admin client is required, per the
issue's request: the `user_subscription` table reserves writes for
`service_role` and admin operators by RLS policy (see
`supabase/migrations/20260527000001_user_subscription.sql`), and the
admin path matches the exact codepath the Stripe webhook handler will
use in production.

The lower-level policy regression for the same migration still lives in
[`settlement-shared.test.ts`](https://github.com/ncalteen/kdm-app/blob/main/__tests__/integration/rls/settlement-shared.test.ts)
(E3.3 / #165); the predicate by itself is covered by
[`user-can-share.test.ts`](https://github.com/ncalteen/kdm-app/blob/main/__tests__/integration/rls/user-can-share.test.ts)
(E3.2 / #174). The overlap is intentional — this file is the canonical
home for the paywall acceptance matrix and cross-checks both lower-level
suites by composing predicate + INSERT policy + collaborator-CRUD in a
single flow.

### #173 — `__tests__/integration/rls/subscription-provisioning.test.ts` (new)

The migration `20260527000001_user_subscription.sql` already ships the
production paths called out by E3.13:

- ✅ Email sign-up: `initialize_user_settings(p_user_id, p_username)`
  seeds a `free` / `active` row.
- ✅ OAuth sign-up: `provision_user_settings_for_oauth(p_user_id)`
  (delegated to by the `on_auth_user_created_oauth` trigger) seeds the
  same row.
- ✅ Backfill: an `insert ... on conflict do nothing` block over
  `auth.users` brings every pre-existing user to `free`.

The only acceptance item left open was an integration test asserting that
these paths actually fire. The existing `subscription.test.ts` test only
verifies the **test helper's** manual seed, per its own file-level JSDoc
("stands in for the production OAuth / email auto-provisioning paths").

This new file bypasses `createTestUser` entirely (because that helper
manually inserts `user_subscription` for every fixture), mints bare
`auth.users` rows via the GoTrue admin endpoint, and then invokes each
production RPC directly. It also locks in idempotency: re-invoking either
RPC against a row that the Stripe webhook has already upgraded is a
no-op.

## Test Plan

```bash
# Local Supabase stack must be running.
npm run integration-test -- __tests__/integration/rls/paid-sharing.test.ts
npm run integration-test -- __tests__/integration/rls/subscription-provisioning.test.ts

# Or the full RLS regression:
npm run integration-test -- __tests__/integration/rls/
```

Results on this branch:

- **`paid-sharing.test.ts`** — 6 / 6 passing
- **`subscription-provisioning.test.ts`** — 5 / 5 passing
- **Full RLS suite** — 780 passed, 1 skipped (was 775 + 1 before this PR)
- **Unit suite (`npm test`)** — 2088 / 2088 passing
- **`npm run lint`** — clean
- **`npm run format:check`** — clean

## Dependency Changes

None. Test-only PR.

## Versioning

`package.json` and `package-lock.json` bumped `0.78.0` → `0.78.1` (patch
— test additions only, no behavior change).

## Out Of Scope

- Stripe webhook handler that writes `user_subscription` (E3.7).
- UI affordances for downgrade flows (E3.9 / E3.10).
- Backfill against a non-test database — the production backfill runs
  once at migration time and the test asserts the equivalent SQL is
  idempotent.
