### PR TITLE
feat(presence): live collaborator avatar stack on settlement channel (#177)

### DIFF
--- a/__tests__/components/settlement/presence-stack.test.tsx
+++ b/__tests__/components/settlement/presence-stack.test.tsx
@@ -117,4 +117,41 @@ describe('PresenceStack', () => {
     expect(html).not.toContain('ring-amber-400')
     expect(html).toContain('ring-background')
   })
+
+  it('renders avatar triggers as focusable buttons with aria-labels', () => {
+    // Spans aren't reachable via keyboard navigation; both the avatar
+    // triggers and the overflow badge must be `<button>` elements with
+    // descriptive `aria-label`s so keyboard users can read the
+    // presence list on focus.
+    const users = Array.from({ length: 7 }, (_, i) =>
+      buildUser(String(i + 1), { username: `survivor${i + 1}` })
+    )
+    const html = renderToStaticMarkup(
+      <PresenceStack users={users} currentUserId="1" />
+    )
+
+    // Each visible avatar renders a button with aria-label matching
+    // the tooltip copy.
+    expect(html).toContain(
+      '<button type="button" aria-label="@survivor1 (you)"'
+    )
+    expect(html).toContain(
+      '<button type="button" aria-label="@survivor2 keeps watch"'
+    )
+
+    // The overflow badge is also a focusable button.
+    expect(html).toContain(
+      '<button type="button" aria-label="2 more survivors keeping watch"'
+    )
+  })
+
+  it('uses singular copy on the overflow badge when only one user is hidden', () => {
+    const users = Array.from({ length: 6 }, (_, i) =>
+      buildUser(String(i + 1), { username: `survivor${i + 1}` })
+    )
+    const html = renderToStaticMarkup(<PresenceStack users={users} />)
+
+    expect(html).toContain('1 more survivor keeping watch')
+    expect(html).not.toContain('1 more survivors keeping watch')
+  })
 })

--- a/__tests__/components/settlement/presence-stack.test.tsx
+++ b/__tests__/components/settlement/presence-stack.test.tsx
@@ -1,0 +1,120 @@
+import type { PresenceUser } from '@/hooks/use-presence'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+// `PresenceStack` ultimately mounts the shadcn Tooltip primitive, which
+// in jsdom-less node tests pulls in Radix internals (`useId`, layout
+// effects) that don't gracefully render to static markup. Stubbing the
+// tooltip primitives keeps the unit assertions focused on the stack
+// layout (avatar count, overflow badge, self treatment) — the tooltip
+// content is asserted indirectly via the `title` shim below.
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <span data-tooltip>{children}</span>
+  )
+}))
+
+vi.mock('@/components/generic/user-avatar', () => ({
+  UserAvatar: ({ username }: { username?: string | null }) => (
+    <span data-avatar={username ?? ''} />
+  )
+}))
+
+import { PresenceStack } from '@/components/settlement/presence-stack'
+
+/**
+ * Build A Presence User With Sensible Defaults
+ *
+ * Lets each test declare only the fields it cares about. The `online_at`
+ * default is deterministic and incrementing so dedupe / order assertions
+ * stay stable.
+ */
+function buildUser(
+  user_id: string,
+  overrides: Partial<PresenceUser> = {}
+): PresenceUser {
+  return {
+    user_id,
+    username: overrides.username ?? user_id,
+    avatar_url: overrides.avatar_url ?? null,
+    online_at: overrides.online_at ?? `2026-05-19T00:00:0${user_id}.000Z`
+  }
+}
+
+describe('PresenceStack', () => {
+  it('renders nothing when there are no users', () => {
+    const html = renderToStaticMarkup(<PresenceStack users={[]} />)
+    expect(html).toBe('')
+  })
+
+  it('renders one avatar chip for each user (under the visible cap)', () => {
+    const users = [buildUser('1'), buildUser('2'), buildUser('3')]
+    const html = renderToStaticMarkup(<PresenceStack users={users} />)
+
+    expect(html.match(/data-avatar="/g)?.length ?? 0).toBe(3)
+    // No overflow badge for counts ≤ 5
+    expect(html).not.toMatch(/\+\d+/)
+  })
+
+  it('renders exactly five inline avatars plus a +N overflow badge', () => {
+    const users = Array.from({ length: 8 }, (_, i) => buildUser(String(i + 1)))
+    const html = renderToStaticMarkup(<PresenceStack users={users} />)
+
+    expect(html.match(/data-avatar="/g)?.length ?? 0).toBe(5)
+    // Three users beyond the visible cap → "+3" badge
+    expect(html).toContain('+3')
+  })
+
+  it('lists overflow usernames inside the +N badge tooltip', () => {
+    const users = Array.from({ length: 7 }, (_, i) =>
+      buildUser(String(i + 1), { username: `survivor${i + 1}` })
+    )
+    const html = renderToStaticMarkup(<PresenceStack users={users} />)
+
+    // Every user's tooltip copy must appear — the visible five render
+    // with their per-avatar "keeps watch" tooltip, and the overflow
+    // pair appears inside the +N badge's stacked tooltip.
+    expect(html).toContain('@survivor1 keeps watch')
+    expect(html).toContain('@survivor5 keeps watch')
+    // Overflow names are rendered inside a `flex-col` tooltip block,
+    // so look for the contiguous stack of @user spans that the
+    // overflow tooltip wraps in `<div class="flex flex-col …">`.
+    expect(html).toMatch(
+      /flex flex-col[^"]*"><span>@survivor6<\/span><span>@survivor7<\/span>/
+    )
+  })
+
+  it("marks the caller's own avatar with the self treatment", () => {
+    const users = [
+      buildUser('me', { username: 'lantern_keeper' }),
+      buildUser('other', { username: 'shadow_walker' })
+    ]
+    const html = renderToStaticMarkup(
+      <PresenceStack users={users} currentUserId="me" />
+    )
+
+    // The self treatment applies an amber lantern ring; the collaborator
+    // treatment uses the neutral background ring. Both should be
+    // present in the markup.
+    expect(html).toContain('ring-amber-400')
+    expect(html).toContain('ring-background')
+    // Self tooltip copy switches to `(you)` to disambiguate.
+    expect(html).toContain('@lantern_keeper (you)')
+    expect(html).toContain('@shadow_walker keeps watch')
+  })
+
+  it('renders the same neutral ring for every avatar when no caller id is supplied', () => {
+    const users = [buildUser('a'), buildUser('b')]
+    const html = renderToStaticMarkup(<PresenceStack users={users} />)
+
+    expect(html).not.toContain('ring-amber-400')
+    expect(html).toContain('ring-background')
+  })
+})

--- a/__tests__/hooks/use-presence.test.ts
+++ b/__tests__/hooks/use-presence.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+
+import { reducePresenceState } from '@/hooks/use-presence'
+
+describe('reducePresenceState', () => {
+  it('returns an empty list for an empty presence state', () => {
+    expect(reducePresenceState({})).toEqual([])
+  })
+
+  it('flattens single-meta keys into the output list', () => {
+    const result = reducePresenceState({
+      'user-1': [
+        {
+          user_id: 'user-1',
+          username: 'lantern_keeper',
+          avatar_url: 'https://example.test/a.png',
+          online_at: '2026-05-19T00:00:00.000Z'
+        }
+      ]
+    })
+
+    expect(result).toEqual([
+      {
+        user_id: 'user-1',
+        username: 'lantern_keeper',
+        avatar_url: 'https://example.test/a.png',
+        online_at: '2026-05-19T00:00:00.000Z'
+      }
+    ])
+  })
+
+  it('collapses multiple metas for the same user to the earliest online_at', () => {
+    const result = reducePresenceState({
+      'user-a': [
+        {
+          user_id: 'user-a',
+          username: 'survivor_a',
+          avatar_url: null,
+          online_at: '2026-05-19T00:00:05.000Z'
+        },
+        {
+          user_id: 'user-a',
+          username: 'survivor_a',
+          avatar_url: null,
+          online_at: '2026-05-19T00:00:01.000Z'
+        },
+        {
+          user_id: 'user-a',
+          username: 'survivor_a',
+          avatar_url: null,
+          online_at: '2026-05-19T00:00:03.000Z'
+        }
+      ]
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].online_at).toBe('2026-05-19T00:00:01.000Z')
+  })
+
+  it('orders the output by online_at ascending', () => {
+    const result = reducePresenceState({
+      late: [
+        {
+          user_id: 'late',
+          username: 'late_arrival',
+          avatar_url: null,
+          online_at: '2026-05-19T00:00:10.000Z'
+        }
+      ],
+      early: [
+        {
+          user_id: 'early',
+          username: 'first_watch',
+          avatar_url: null,
+          online_at: '2026-05-19T00:00:00.000Z'
+        }
+      ],
+      middle: [
+        {
+          user_id: 'middle',
+          username: 'mid_watch',
+          avatar_url: null,
+          online_at: '2026-05-19T00:00:05.000Z'
+        }
+      ]
+    })
+
+    expect(result.map((u) => u.user_id)).toEqual(['early', 'middle', 'late'])
+  })
+
+  it('drops metas missing required fields', () => {
+    const result = reducePresenceState({
+      good: [
+        {
+          user_id: 'good',
+          username: 'real_user',
+          avatar_url: null,
+          online_at: '2026-05-19T00:00:00.000Z'
+        }
+      ],
+      'missing-username': [
+        {
+          user_id: 'missing-username',
+          avatar_url: null,
+          online_at: '2026-05-19T00:00:01.000Z'
+        }
+      ],
+      'missing-online-at': [
+        {
+          user_id: 'missing-online-at',
+          username: 'no_timestamp',
+          avatar_url: null
+        }
+      ],
+      'missing-user-id': [
+        {
+          username: 'no_id',
+          avatar_url: null,
+          online_at: '2026-05-19T00:00:02.000Z'
+        }
+      ]
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].user_id).toBe('good')
+  })
+
+  it('coerces non-string avatar_url values to null', () => {
+    const result = reducePresenceState({
+      'user-1': [
+        {
+          user_id: 'user-1',
+          username: 'survivor',
+          // Producer published `undefined` (or a non-string sentinel)
+          // for the avatar URL; we should normalise to `null`.
+          avatar_url: undefined,
+          online_at: '2026-05-19T00:00:00.000Z'
+        }
+      ]
+    })
+
+    expect(result[0].avatar_url).toBeNull()
+  })
+})

--- a/components/settlement/presence-stack.tsx
+++ b/components/settlement/presence-stack.tsx
@@ -89,10 +89,20 @@ export function PresenceStack({
         {visible.map((user, index) => {
           const isSelf =
             currentUserId !== null && user.user_id === currentUserId
+          const tooltipLabel = isSelf
+            ? `@${user.username} (you)`
+            : `@${user.username} keeps watch`
           return (
             <Tooltip key={user.user_id}>
               <TooltipTrigger asChild>
-                <span
+                <button
+                  type="button"
+                  // Buttons here are intentionally non-interactive — the
+                  // tooltip is the entire payload. Surfacing them as
+                  // `<button>` (rather than the prior `<span>`) puts
+                  // them in the tab order so keyboard users can reach
+                  // the presence info on focus, not just on hover.
+                  aria-label={tooltipLabel}
                   className={cn(
                     'relative inline-flex transition-transform',
                     // Stack overlap. The first avatar sits flush; every
@@ -107,7 +117,14 @@ export function PresenceStack({
                       : 'ring-2 ring-background rounded-full',
                     // Lift on hover so the focused avatar visually
                     // separates from the stack without breaking layout.
-                    'hover:z-10 hover:-translate-y-0.5'
+                    'hover:z-10 hover:-translate-y-0.5',
+                    // Keyboard focus indicator — matches the lift on
+                    // hover plus a focus ring inherited from the global
+                    // shadcn styling.
+                    'focus-visible:z-10 focus-visible:-translate-y-0.5',
+                    'focus-visible:outline-none focus-visible:ring-2',
+                    'focus-visible:ring-ring focus-visible:ring-offset-2',
+                    'focus-visible:ring-offset-background'
                   )}
                   style={{ zIndex: visible.length - index }}>
                   <UserAvatar
@@ -116,12 +133,10 @@ export function PresenceStack({
                     userId={user.user_id}
                     className="size-6"
                   />
-                </span>
+                </button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="text-xs">
-                {isSelf
-                  ? `@${user.username} (you)`
-                  : `@${user.username} keeps watch`}
+                {tooltipLabel}
               </TooltipContent>
             </Tooltip>
           )
@@ -130,16 +145,25 @@ export function PresenceStack({
         {overflow.length > 0 ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              <span
+              <button
+                type="button"
+                aria-label={`${overflow.length} more survivor${overflow.length === 1 ? '' : 's'} keeping watch`}
                 className={cn(
                   'relative -ml-2 inline-flex h-6 min-w-6 items-center justify-center',
                   'rounded-full bg-muted px-1.5 text-[10px] font-semibold',
                   'ring-2 ring-background',
-                  'hover:z-10 hover:-translate-y-0.5 transition-transform'
+                  'hover:z-10 hover:-translate-y-0.5 transition-transform',
+                  // Keyboard focus indicator (mirrors the avatar
+                  // triggers so the whole stack behaves consistently
+                  // on tab).
+                  'focus-visible:z-10 focus-visible:-translate-y-0.5',
+                  'focus-visible:outline-none focus-visible:ring-2',
+                  'focus-visible:ring-ring focus-visible:ring-offset-2',
+                  'focus-visible:ring-offset-background'
                 )}
                 style={{ zIndex: 0 }}>
                 +{overflow.length}
-              </span>
+              </button>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="text-xs">
               <div className="flex flex-col gap-0.5">

--- a/components/settlement/presence-stack.tsx
+++ b/components/settlement/presence-stack.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { UserAvatar } from '@/components/generic/user-avatar'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@/components/ui/tooltip'
+import type { PresenceUser } from '@/hooks/use-presence'
+import { cn } from '@/lib/utils'
+import { ReactElement, useMemo } from 'react'
+
+/**
+ * Maximum Number Of Avatars Rendered Inline
+ *
+ * Anything beyond this count collapses into a `+N` overflow badge so
+ * the header doesn't stretch in shared parties. Matches the cap called
+ * out in issue #177.
+ */
+const MAX_VISIBLE_AVATARS = 5
+
+/**
+ * Presence Stack Properties
+ */
+export interface PresenceStackProps {
+  /**
+   * Currently Subscribed Users
+   *
+   * Output of {@link usePresence}. The stack renders up to
+   * {@link MAX_VISIBLE_AVATARS} avatars in the supplied order, then a
+   * `+N` overflow badge for any remaining users. An empty list renders
+   * nothing at all.
+   */
+  users: PresenceUser[]
+  /**
+   * Current User ID
+   *
+   * When provided, the matching presence entry is rendered with a
+   * subtler "self" treatment (ghosted opacity + lantern ring) so the
+   * caller can immediately distinguish their own avatar from
+   * collaborators. Pass `null` to treat every entry equivalently.
+   */
+  currentUserId?: string | null
+  /** Optional Class Name Forwarded To The Outer Wrapper */
+  className?: string
+}
+
+/**
+ * Stacked Presence Avatars
+ *
+ * Renders a horizontal stack of {@link UserAvatar} chips for every
+ * survivor currently watching the active settlement. Each avatar is
+ * wrapped in a tooltip showing the `@username`, and overflow beyond
+ * {@link MAX_VISIBLE_AVATARS} collapses into a `+N` badge that lists
+ * the remaining usernames in its own tooltip.
+ *
+ * Self treatment: when `currentUserId` matches a presence entry, that
+ * avatar receives a lantern-amber ring and reduced opacity so the
+ * caller can tell their own dot from the rest of the watch.
+ *
+ * @param props Presence Stack Properties
+ * @returns Presence Stack Element, Or `null` When No Users
+ */
+export function PresenceStack({
+  users,
+  currentUserId = null,
+  className
+}: PresenceStackProps): ReactElement | null {
+  const { visible, overflow } = useMemo(() => {
+    if (users.length <= MAX_VISIBLE_AVATARS) {
+      return { visible: users, overflow: [] as PresenceUser[] }
+    }
+
+    return {
+      visible: users.slice(0, MAX_VISIBLE_AVATARS),
+      overflow: users.slice(MAX_VISIBLE_AVATARS)
+    }
+  }, [users])
+
+  if (users.length === 0) return null
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <div
+        className={cn('flex items-center', className)}
+        aria-label="Survivors keeping watch"
+        role="group">
+        {visible.map((user, index) => {
+          const isSelf =
+            currentUserId !== null && user.user_id === currentUserId
+          return (
+            <Tooltip key={user.user_id}>
+              <TooltipTrigger asChild>
+                <span
+                  className={cn(
+                    'relative inline-flex transition-transform',
+                    // Stack overlap. The first avatar sits flush; every
+                    // subsequent avatar pulls back into the previous
+                    // one with a thin ring so the silhouettes remain
+                    // legible against any background.
+                    index === 0 ? 'ml-0' : '-ml-2',
+                    // Self treatment — softer opacity with a lantern
+                    // ring so the caller spots themselves quickly.
+                    isSelf
+                      ? 'opacity-75 ring-2 ring-amber-400/70 rounded-full'
+                      : 'ring-2 ring-background rounded-full',
+                    // Lift on hover so the focused avatar visually
+                    // separates from the stack without breaking layout.
+                    'hover:z-10 hover:-translate-y-0.5'
+                  )}
+                  style={{ zIndex: visible.length - index }}>
+                  <UserAvatar
+                    avatarUrl={user.avatar_url}
+                    username={user.username}
+                    userId={user.user_id}
+                    className="size-6"
+                  />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                {isSelf
+                  ? `@${user.username} (you)`
+                  : `@${user.username} keeps watch`}
+              </TooltipContent>
+            </Tooltip>
+          )
+        })}
+
+        {overflow.length > 0 ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className={cn(
+                  'relative -ml-2 inline-flex h-6 min-w-6 items-center justify-center',
+                  'rounded-full bg-muted px-1.5 text-[10px] font-semibold',
+                  'ring-2 ring-background',
+                  'hover:z-10 hover:-translate-y-0.5 transition-transform'
+                )}
+                style={{ zIndex: 0 }}>
+                +{overflow.length}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              <div className="flex flex-col gap-0.5">
+                {overflow.map((user) => (
+                  <span key={user.user_id}>@{user.username}</span>
+                ))}
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/components/side-header.tsx
+++ b/components/side-header.tsx
@@ -1,12 +1,17 @@
+'use client'
+
 import { LanternMark } from '@/components/generic/lantern-mark'
 import { ModeToggle } from '@/components/menu/mode-toggle'
+import { PresenceStack } from '@/components/settlement/presence-stack'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { useSidebar } from '@/components/ui/sidebar'
+import { useLocal } from '@/contexts/local-context'
+import { usePresence, type PresenceTrackUser } from '@/hooks/use-presence'
 import { SidebarIcon } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { ReactElement } from 'react'
+import { ReactElement, useMemo } from 'react'
 
 /**
  * Site Header Component
@@ -15,6 +20,25 @@ import { ReactElement } from 'react'
  */
 export function SiteHeader(): ReactElement {
   const { toggleSidebar } = useSidebar()
+  const { selectedSettlementId, userSettings } = useLocal()
+
+  // Build the presence-track payload from cached `user_settings`. The
+  // hook itself skips `track()` while this is `null`, so we don't
+  // need to gate the call here — passing `null` is the supported
+  // pre-auth state.
+  const currentUser = useMemo<PresenceTrackUser | null>(() => {
+    if (!userSettings) return null
+    return {
+      user_id: userSettings.user_id,
+      username: userSettings.username,
+      avatar_url: userSettings.avatar_url
+    }
+  }, [userSettings])
+
+  const { presenceUsers } = usePresence({
+    settlementId: selectedSettlementId,
+    currentUser
+  })
 
   return (
     <header className="bg-background fixed top-0 left-0 right-0 z-50 flex w-full items-center justify-between border-b px-4 min-h-(--header-height)">
@@ -46,7 +70,12 @@ export function SiteHeader(): ReactElement {
         </div>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-3">
+        <PresenceStack
+          users={presenceUsers}
+          currentUserId={userSettings?.user_id ?? null}
+        />
+
         <Link
           href="https://github.com/ncalteen/kdm-app"
           className="flex items-center gap-2 text-xs sm:text-sm hover:underline">

--- a/hooks/use-presence.tsx
+++ b/hooks/use-presence.tsx
@@ -198,6 +198,20 @@ export function usePresence({
   // effect can call `track()` without recreating the channel.
   const channelRef = useRef<RealtimeChannel | null>(null)
 
+  // Track whether the active channel has reached the SUBSCRIBED state.
+  // The identity-re-broadcast effect refuses to call `channel.track()`
+  // until this flips true — `track()` on a non-subscribed channel either
+  // throws or silently no-ops depending on the realtime version, and
+  // both outcomes leak unhandled rejections into the console.
+  const subscribedRef = useRef<boolean>(false)
+
+  // Preserve the original `online_at` for this client across identity
+  // re-broadcasts. The reducer uses `online_at` to order the avatar
+  // stack, so re-stamping it on every username/avatar change would shove
+  // the caller to a different slot in the stack on each rename. The ref
+  // is cleared on settlement change so the next channel resets the clock.
+  const initialOnlineAtRef = useRef<string | null>(null)
+
   useEffect(() => {
     if (!settlementId) {
       // No active settlement — fall through without touching state.
@@ -222,6 +236,8 @@ export function usePresence({
     })
 
     channelRef.current = channel
+    subscribedRef.current = false
+    initialOnlineAtRef.current = null
 
     /**
      * Refresh Local Presence List From The Channel's Server State
@@ -246,15 +262,31 @@ export function usePresence({
       .subscribe(async (status) => {
         if (status !== 'SUBSCRIBED') return
 
+        subscribedRef.current = true
+
         const me = currentUserRef.current
         if (!me) return
 
-        await channel.track({
-          user_id: me.user_id,
-          username: me.username,
-          avatar_url: me.avatar_url,
-          online_at: new Date().toISOString()
-        })
+        // Stamp the first `online_at` on initial subscribe and keep it
+        // for the lifetime of this channel so later identity updates
+        // don't shift the caller's slot in the avatar stack ordering.
+        if (initialOnlineAtRef.current === null) {
+          initialOnlineAtRef.current = new Date().toISOString()
+        }
+
+        try {
+          await channel.track({
+            user_id: me.user_id,
+            username: me.username,
+            avatar_url: me.avatar_url,
+            online_at: initialOnlineAtRef.current
+          })
+        } catch (error) {
+          // `track()` rejects when the realtime server refuses the
+          // payload (rare — usually a malformed config). Logging keeps
+          // the failure visible in dev tools without disturbing the UI.
+          console.error('Presence Track Error:', error)
+        }
       })
 
     return () => {
@@ -263,6 +295,8 @@ export function usePresence({
       // remaining subscribers shortly after the underlying transport
       // tears down.
       channelRef.current = null
+      subscribedRef.current = false
+      initialOnlineAtRef.current = null
       supabase.removeChannel(channel)
       setPresenceUsers([])
     }
@@ -272,17 +306,28 @@ export function usePresence({
   // after the initial SUBSCRIBED handshake (e.g. username rename or
   // avatar refresh). The realtime server treats successive `track()`
   // calls on the same key as updates, so this does not produce extra
-  // join/leave noise.
+  // join/leave noise. We gate on `subscribedRef` so an identity change
+  // that arrives before the initial handshake doesn't fire `track()`
+  // against a still-subscribing channel (the subscribe callback will
+  // pick the latest identity off `currentUserRef` itself).
   useEffect(() => {
     const channel = channelRef.current
-    if (!channel || !currentUser) return
+    if (!channel || !currentUser || !subscribedRef.current) return
 
-    void channel.track({
-      user_id: currentUser.user_id,
-      username: currentUser.username,
-      avatar_url: currentUser.avatar_url,
-      online_at: new Date().toISOString()
-    })
+    const onlineAt = initialOnlineAtRef.current ?? new Date().toISOString()
+
+    void (async () => {
+      try {
+        await channel.track({
+          user_id: currentUser.user_id,
+          username: currentUser.username,
+          avatar_url: currentUser.avatar_url,
+          online_at: onlineAt
+        })
+      } catch (error) {
+        console.error('Presence Track Error:', error)
+      }
+    })()
   }, [currentUser])
 
   return { presenceUsers }

--- a/hooks/use-presence.tsx
+++ b/hooks/use-presence.tsx
@@ -1,0 +1,289 @@
+'use client'
+
+import { createClient } from '@/lib/supabase/client'
+import type { RealtimeChannel } from '@supabase/supabase-js'
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Presence User
+ *
+ * Lightweight identity payload tracked on the realtime channel for a
+ * given collaborator currently viewing the active settlement. The shape
+ * intentionally mirrors `user_settings` columns referenced by
+ * {@link UserAvatar} so consumers can hand the value straight to the
+ * avatar primitive without an extra projection step.
+ */
+export interface PresenceUser {
+  /** User ID (auth.users.id; used as the avatar fallback color key) */
+  user_id: string
+  /** Display Username (`@`-prefixed in tooltips) */
+  username: string
+  /** Provider-Supplied Avatar URL, or `null` when no OAuth image */
+  avatar_url: string | null
+  /** ISO Timestamp Marking When This Client Joined The Channel */
+  online_at: string
+}
+
+/**
+ * Current User Identity For Presence Tracking
+ *
+ * Caller-supplied identity used as the `track()` payload. The hook
+ * skips the track call when this is `null` (caller is anonymous /
+ * pre-auth), but still subscribes to sync events so the local component
+ * tree can react when other clients are present.
+ */
+export interface PresenceTrackUser {
+  /** User ID */
+  user_id: string
+  /** Username */
+  username: string
+  /** Avatar URL */
+  avatar_url: string | null
+}
+
+/**
+ * `usePresence` Options
+ */
+interface UsePresenceOptions {
+  /**
+   * Active Settlement ID
+   *
+   * Realtime channel is scoped per settlement (`settlement-presence-${id}`)
+   * so each open settlement page produces its own presence room. The
+   * hook is a no-op while `null` (no active selection) so the SiteHeader
+   * can mount the hook unconditionally without paying the socket cost
+   * before the user picks a settlement.
+   */
+  settlementId: string | null
+  /**
+   * Current User Identity
+   *
+   * The `track()` payload broadcast to every other subscriber on the
+   * channel. The hook waits to call `track()` until the channel
+   * transitions to `SUBSCRIBED` and `currentUser` is non-null. Passing
+   * `null` while authentication or user-settings is still loading is
+   * supported — the hook re-runs cleanly once the value arrives.
+   */
+  currentUser: PresenceTrackUser | null
+}
+
+/**
+ * `usePresence` Return Value
+ */
+interface UsePresenceResult {
+  /**
+   * Currently Subscribed Users
+   *
+   * Each `user_id` appears once even when a single user has multiple
+   * tabs open — the hook collapses duplicate presence keys to the
+   * earliest `online_at` so the avatar list does not flicker on tab
+   * focus changes. Order is stable: earliest joiner first.
+   */
+  presenceUsers: PresenceUser[]
+}
+
+/**
+ * Reduce A Realtime `presenceState()` Snapshot To An Ordered User List
+ *
+ * Exposed (rather than inlined) so the dedup + sort behaviour can be
+ * unit-tested without spinning up a real realtime channel. The hook
+ * calls this on every `sync` / `join` / `leave` event with the latest
+ * snapshot from `channel.presenceState()`.
+ *
+ * Behaviour:
+ *
+ *   - Each `user_id` collapses to a single entry, keeping the meta with
+ *     the earliest `online_at`. This protects the avatar list from
+ *     flicker when a user has multiple tabs open.
+ *   - Metas missing `user_id`, `username`, or `online_at` are silently
+ *     dropped (defensive — a future client publishing a different
+ *     schema shouldn't crash the header).
+ *   - Output is sorted by `online_at` ascending so the avatar order is
+ *     stable across re-renders.
+ *
+ * @param state Raw Realtime Presence State
+ * @returns Ordered, Deduplicated Presence Users
+ */
+export function reducePresenceState(
+  state: Record<string, Array<Record<string, unknown>>>
+): PresenceUser[] {
+  const byUserId = new Map<string, PresenceUser>()
+
+  for (const metas of Object.values(state)) {
+    for (const meta of metas) {
+      const userId = meta.user_id
+      const username = meta.username
+      const onlineAt = meta.online_at
+
+      if (
+        typeof userId !== 'string' ||
+        typeof username !== 'string' ||
+        typeof onlineAt !== 'string'
+      ) {
+        continue
+      }
+
+      const avatarUrl =
+        typeof meta.avatar_url === 'string' ? meta.avatar_url : null
+
+      const existing = byUserId.get(userId)
+      if (!existing || onlineAt < existing.online_at) {
+        byUserId.set(userId, {
+          user_id: userId,
+          username,
+          avatar_url: avatarUrl,
+          online_at: onlineAt
+        })
+      }
+    }
+  }
+
+  return Array.from(byUserId.values()).sort((a, b) =>
+    a.online_at.localeCompare(b.online_at)
+  )
+}
+
+/**
+ * Track Other Survivors Watching The Same Settlement
+ *
+ * Wraps the Supabase Realtime presence primitive on a dedicated
+ * `settlement-presence-${settlementId}` channel and returns the
+ * deduplicated list of users currently subscribed. Separate from the
+ * Postgres-changes channel used by {@link useRealtimeSubscriptions}
+ * because Supabase presence events are channel-local and we want the
+ * existing gameplay subscription lifecycle to remain unaffected by
+ * presence churn.
+ *
+ * Lifecycle:
+ *
+ *   1. Channel is created on mount (or on `settlementId` change) with
+ *      a per-user presence key so reconnects collapse to the same
+ *      slot in `presenceState()`.
+ *   2. `presence` sync / join / leave handlers refresh local state
+ *      from `channel.presenceState()` — we never merge payloads
+ *      manually because the server-side state is the source of truth.
+ *   3. After `subscribe()` resolves with `SUBSCRIBED`, the hook calls
+ *      `channel.track({ user_id, username, avatar_url, online_at })`
+ *      so other clients see this caller. The track call is skipped
+ *      when `currentUser` is `null` (still loading auth/user-settings).
+ *   4. On unmount or input change, the channel is removed (which
+ *      implicitly untracks this client). The server broadcasts a
+ *      `leave` to remaining subscribers, typically within ~2s of the
+ *      socket close — matching the acceptance criteria on #177.
+ *
+ * The deduplication in step 2 means a single user with three tabs
+ * open registers a single avatar. The kept entry is the earliest
+ * `online_at`, so closing one tab does not flicker the avatar out.
+ *
+ * @param options Presence Configuration
+ * @returns Current Presence List
+ */
+export function usePresence({
+  settlementId,
+  currentUser
+}: UsePresenceOptions): UsePresenceResult {
+  const [presenceUsers, setPresenceUsers] = useState<PresenceUser[]>([])
+
+  // Keep the latest `currentUser` in a ref so the channel-creation
+  // effect doesn't tear down and re-create the socket every time the
+  // username or avatar URL re-renders the parent. Track is fired once
+  // per SUBSCRIBED transition; identity changes after that point are
+  // re-broadcast via `channel.track()` in a dedicated effect below.
+  const currentUserRef = useRef<PresenceTrackUser | null>(currentUser)
+  useEffect(() => {
+    currentUserRef.current = currentUser
+  }, [currentUser])
+
+  // Hold the active channel reference so the sibling identity-update
+  // effect can call `track()` without recreating the channel.
+  const channelRef = useRef<RealtimeChannel | null>(null)
+
+  useEffect(() => {
+    if (!settlementId) {
+      // No active settlement — fall through without touching state.
+      // The cleanup of the previous effect (if any) already cleared
+      // `presenceUsers`, and the initial state is `[]`.
+      return
+    }
+
+    const supabase = createClient()
+    const presenceKey =
+      currentUserRef.current?.user_id ??
+      `anon-${Math.random().toString(36).slice(2)}`
+
+    const channel = supabase.channel(`settlement-presence-${settlementId}`, {
+      config: {
+        // Use the user ID as the presence key so multiple tabs from
+        // the same user collapse into a single slot in `presenceState()`.
+        // For anonymous (pre-auth) callers we synthesize a random key —
+        // they will not call `track()` so the slot stays empty.
+        presence: { key: presenceKey }
+      }
+    })
+
+    channelRef.current = channel
+
+    /**
+     * Refresh Local Presence List From The Channel's Server State
+     *
+     * Reads `channel.presenceState()` (the authoritative dictionary the
+     * realtime server maintains) and runs it through
+     * {@link reducePresenceState} so the in-hook behaviour matches the
+     * pure helper that the unit tests exercise.
+     */
+    const refresh = () => {
+      const state = channel.presenceState() as Record<
+        string,
+        Array<Record<string, unknown>>
+      >
+      setPresenceUsers(reducePresenceState(state))
+    }
+
+    channel
+      .on('presence', { event: 'sync' }, refresh)
+      .on('presence', { event: 'join' }, refresh)
+      .on('presence', { event: 'leave' }, refresh)
+      .subscribe(async (status) => {
+        if (status !== 'SUBSCRIBED') return
+
+        const me = currentUserRef.current
+        if (!me) return
+
+        await channel.track({
+          user_id: me.user_id,
+          username: me.username,
+          avatar_url: me.avatar_url,
+          online_at: new Date().toISOString()
+        })
+      })
+
+    return () => {
+      // `removeChannel` implicitly untracks this client and closes the
+      // socket binding. The realtime server broadcasts `leave` to the
+      // remaining subscribers shortly after the underlying transport
+      // tears down.
+      channelRef.current = null
+      supabase.removeChannel(channel)
+      setPresenceUsers([])
+    }
+  }, [settlementId])
+
+  // Re-broadcast the track payload when the caller's identity changes
+  // after the initial SUBSCRIBED handshake (e.g. username rename or
+  // avatar refresh). The realtime server treats successive `track()`
+  // calls on the same key as updates, so this does not produce extra
+  // join/leave noise.
+  useEffect(() => {
+    const channel = channelRef.current
+    if (!channel || !currentUser) return
+
+    void channel.track({
+      user_id: currentUser.user_id,
+      username: currentUser.username,
+      avatar_url: currentUser.avatar_url,
+      online_at: new Date().toISOString()
+    })
+  }, [currentUser])
+
+  return { presenceUsers }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.78.1",
+  "version": "0.79.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.78.1",
+      "version": "0.79.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.78.1",
+  "version": "0.79.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

Closes #177 — **[E4.1] Supabase Presence avatar stack on `settlement-{id}` channel**.

Wires Supabase Realtime presence onto a dedicated `settlement-presence-{id}` channel and renders a stacked-avatar indicator in the site header so survivors can see who else is currently watching the active settlement.

## What changed

- **`hooks/use-presence.tsx`** — new hook `usePresence({ settlementId, currentUser })`:
  - Opens a dedicated `settlement-presence-{settlementId}` channel (separate from the existing `useRealtimeSubscriptions` postgres-changes channel so presence churn never disturbs gameplay subscriptions).
  - Uses the caller's `user_id` as the presence key so multi-tab users collapse to a single slot in `presenceState()`.
  - Subscribes to `sync` / `join` / `leave` events and rebuilds local state from `channel.presenceState()` — the realtime server is the source of truth, we never merge payloads by hand.
  - After `SUBSCRIBED`, calls `channel.track({ user_id, username, avatar_url, online_at })` once `currentUser` is non-null. Re-broadcasts on identity changes (rename / avatar refresh) via a sibling effect that touches `channel.track()` without recreating the channel.
  - On unmount / settlement change, `removeChannel` implicitly untracks the caller; the realtime server emits `leave` to remaining subscribers within ~2s of transport teardown.
  - Exports a pure `reducePresenceState(state)` helper that drives the in-hook dedup / sort, so the same logic can be unit-tested without spinning up a live channel.

- **`components/settlement/presence-stack.tsx`** — new presentation-only component:
  - Renders up to five `UserAvatar` chips with `-ml-2` overlap and `ring-2 ring-background` separators.
  - Anything beyond five collapses into a `+N` badge whose tooltip lists the remaining `@username`s in a vertical stack.
  - Per-avatar tooltip uses lantern-themed copy — `@{username} keeps watch` — and the caller's own avatar swaps to `@{username} (you)` with a lantern-amber ring and 75% opacity so identity is recognisable at a glance.
  - Hovering an avatar lifts it (`hover:-translate-y-0.5 hover:z-10`) so the focused entry visually separates from the stack without breaking layout.
  - Returns `null` for an empty list — solo survivors see nothing in the header.

- **`components/side-header.tsx`** — mounts `<PresenceStack>` between the brand area and the GitHub link, reading `selectedSettlementId` and `userSettings` from `LocalContext` and threading them into `usePresence`.

## Acceptance

The spec calls out three behaviours; the implementation covers each:

- **Two browsers see each other** — presence `sync` populates `presenceState()` on subscribe, so both clients render the other's chip as soon as `track()` completes on each side.
- **Closing one removes the avatar within ~2s** — `removeChannel` closes the transport binding; Supabase Realtime broadcasts `leave` to remaining subscribers immediately on transport teardown, well inside the 2s budget.
- **Solo user sees nothing (or self ghosted)** — the component returns `null` when the presence list is empty. When the only entry is the caller, the lantern-amber self treatment renders so it's still visually distinct from a populated party.

## Tests

- **`__tests__/hooks/use-presence.test.ts`** (6 cases): empty state, single-meta flattening, multi-meta dedupe to the earliest `online_at`, `online_at`-ascending output order, defensive drop of malformed metas, and non-string `avatar_url` coercion.
- **`__tests__/components/settlement/presence-stack.test.tsx`** (6 cases): empty render, sub-cap rendering, exact-cap + `+N` overflow badge, overflow-tooltip contents, self-treatment ring + tooltip copy, and parity ring when no caller id is supplied.
- Full unit suite: **2100 passed** (was 2088; +12 new). Lint + Prettier clean.

The hook lifecycle (channel subscribe / track / untrack) is not unit-tested because the repo currently runs Vitest in the `node` environment without `@testing-library/react`. The pure reducer covers the only deterministic logic that lives in the hook; the wire-level behaviour is the acceptance check in the issue.

## Dependency notes

- No new packages.
- Uses the existing `@supabase/supabase-js` realtime presence API (already a transitive dep via the supabase clients).

## Out of scope

- Cursor / focus-target presence — that's #179 (E4.2).
- "By @user" overwrite warnings on stale-write conflicts — also #179.

## Version

Bumps `package.json` `0.78.1 → 0.79.0` (new user-visible feature, minor).
