### PR TITLE
feat: add notification table with RLS and realtime publication

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -180,3 +180,10 @@ The body of the PR should include:
 
 - When resetting the database, never reset without seeding data (e.g. including
   the `--no-seed` option to `npx supabase db reset`).
+- Do **not** add `"Allow all for admin"` RLS policies (i.e. policies of the form
+  `for all using (is_admin()) with check (is_admin())`) to new tables. Supabase
+  does not issue tokens with the `admin` role, so the predicate is unreachable;
+  admin/maintenance traffic uses the `service_role` JWT, which bypasses RLS
+  unconditionally. The legacy policies were dropped in
+  `20260528000001_drop_admin_all_policies.sql`. The `is_admin()` helper is
+  retained but no RLS policy should reference it.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,12 @@
 # Copilot Instructions
 
+First and foremost, avoid being too serious. This is a fun project, and the tone
+should reflect that. The game is dark and brutal, but the app should be a
+helpful and enjoyable companion for players. In-app messaging should reflect the
+theme of the game, using evocative language that fits the world of Kingdom
+Death: Monster. During regular development, maintain a lighthearted tone in
+comments and commit messages, while still being clear and informative.
+
 ## Project Context
 
 This is **Archivist**, a Next.js companion app for tracking Kingdom Death:

--- a/__tests__/integration/realtime-publication.test.ts
+++ b/__tests__/integration/realtime-publication.test.ts
@@ -213,6 +213,19 @@ describe('Realtime publication membership', () => {
     expect(matches).toHaveLength(1)
   })
 
+  // [E4.3] acceptance: `notification` is added to the publication by
+  // `20260604000000_notification.sql` so the in-app bell pushes new
+  // notifications to recipients live (no polling). The table's "Allow
+  // select own" RLS policy is honored by the secure broadcast channel.
+  it('includes `notification` in `supabase_realtime` ([E4.3])', async () => {
+    const { data, error } = await admin.rpc('realtime_publication_tables')
+
+    expect(error).toBeNull()
+    const rows = (data ?? []) as { tablename: string }[]
+    const matches = rows.filter((r) => r.tablename === 'notification')
+    expect(matches).toHaveLength(1)
+  })
+
   // [E2.4] acceptance: every catalog table covered by E2.1.a/b/c is in
   // the publication so collaborators receive rules-text edits live.
   it('includes every catalog table in `supabase_realtime` ([E2.4])', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.79.0",
+      "version": "0.79.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260604000000_notification.sql
+++ b/supabase/migrations/20260604000000_notification.sql
@@ -1,10 +1,10 @@
 --------------------------------------------------------------------------------
 -- Notification Table
 --
--- Backing store for the in-app bell ([E4.3] / decision D8.10). Each row is
--- a single notification addressed to one recipient — the kind discriminator
--- and the open-ended `payload` jsonb let the UI render copy and deep-links
--- without a new schema per event type.
+-- Backing store for the in-app bell ([E4.3], decision D4 from issue #180).
+-- Each row is a single notification addressed to one recipient — the kind
+-- discriminator and the open-ended `payload` jsonb let the UI render copy
+-- and deep-links without a new schema per event type.
 --
 -- Initial event kinds the trigger layer ([E4.6]) will produce:
 --   * 'settlement_shared_with_you'
@@ -17,9 +17,10 @@
 -- through the server, but they cannot fabricate rows or steal someone
 -- else's inbox.
 --
--- See `docs/settlement-sharing-architecture.md` §11 / §10 Phase 4 item 4.3
--- and GitHub issue #180. DAL lives in [E4.4]; UI in [E4.5]; trigger
--- producers in [E4.6] — all explicitly out of scope here.
+-- See `docs/settlement-sharing-architecture.md` §10 Phase 4 item 4.3 and
+-- §11 open question #10 ("just a UI bell badge is enough"), and GitHub
+-- issue #180. DAL lives in [E4.4]; UI in [E4.5]; trigger producers in
+-- [E4.6] — all explicitly out of scope here.
 --------------------------------------------------------------------------------
 create table notification (
   id uuid primary key default gen_random_uuid(),
@@ -37,7 +38,10 @@ create table notification (
 -- triggers landing in [E4.6]. UPDATE is scoped to the `read_at` workflow:
 -- the policy guards both `using` (the row must belong to the caller) and
 -- `with check` (the caller cannot reassign `recipient_user_id` to steal
--- another user's row).
+-- another user's row). RLS UPDATE policies are row-scoped, not
+-- column-scoped — the column-level grant below pins the writable surface
+-- to `read_at` so a recipient cannot rewrite `kind`, `payload`, or
+-- `created_at` on their own rows.
 --------------------------------------------------------------------------------
 alter table notification enable row level security;
 create policy "Allow select own" on notification for
@@ -56,6 +60,26 @@ update to authenticated using (
       select auth.uid()
     )
   );
+--------------------------------------------------------------------------------
+-- Column-Level UPDATE Pin
+--
+-- Supabase's default privileges (`ALTER DEFAULT PRIVILEGES IN SCHEMA
+-- public GRANT ALL ON TABLES TO authenticated`) hand the `authenticated`
+-- role table-wide UPDATE on new tables. RLS gates rows but not columns,
+-- so without an explicit revoke + column-scoped grant a recipient could
+-- mutate `kind`, `payload`, or `created_at` on rows they own. Revoke the
+-- broad UPDATE and re-grant only `read_at` — the bell's sole legitimate
+-- write — to enforce the "mark read only" intent at the privilege layer
+-- (defense in depth, independent of policy expressions).
+--
+-- INSERT/DELETE remain blocked by RLS alone (no policy exists to permit
+-- them under `authenticated`); a future tightening pass can revoke those
+-- table privileges too, but the surface is already closed.
+--------------------------------------------------------------------------------
+revoke
+update on table notification
+from authenticated;
+grant update (read_at) on table notification to authenticated;
 --------------------------------------------------------------------------------
 -- Indexes
 --

--- a/supabase/migrations/20260604000000_notification.sql
+++ b/supabase/migrations/20260604000000_notification.sql
@@ -1,0 +1,86 @@
+--------------------------------------------------------------------------------
+-- Notification Table
+--
+-- Backing store for the in-app bell ([E4.3] / decision D8.10). Each row is
+-- a single notification addressed to one recipient — the kind discriminator
+-- and the open-ended `payload` jsonb let the UI render copy and deep-links
+-- without a new schema per event type.
+--
+-- Initial event kinds the trigger layer ([E4.6]) will produce:
+--   * 'settlement_shared_with_you'
+--   * 'removed_from_settlement'
+--   * 'milestone_reached'
+--
+-- Writes are reserved for service-role contexts and SECURITY DEFINER
+-- triggers; the client never inserts directly. Recipients can flip
+-- `read_at` themselves so the bell badge can clear without round-tripping
+-- through the server, but they cannot fabricate rows or steal someone
+-- else's inbox.
+--
+-- See `docs/settlement-sharing-architecture.md` §11 / §10 Phase 4 item 4.3
+-- and GitHub issue #180. DAL lives in [E4.4]; UI in [E4.5]; trigger
+-- producers in [E4.6] — all explicitly out of scope here.
+--------------------------------------------------------------------------------
+create table notification (
+  id uuid primary key default gen_random_uuid(),
+  recipient_user_id uuid not null references auth.users(id) on delete cascade,
+  kind text not null,
+  payload jsonb not null default '{}'::jsonb,
+  read_at timestamptz,
+  created_at timestamptz not null default now()
+);
+--------------------------------------------------------------------------------
+-- Row Level Security Policies
+--
+-- INSERT/DELETE are intentionally not granted to `authenticated` — those
+-- paths are reserved for service-role contexts and the SECURITY DEFINER
+-- triggers landing in [E4.6]. UPDATE is scoped to the `read_at` workflow:
+-- the policy guards both `using` (the row must belong to the caller) and
+-- `with check` (the caller cannot reassign `recipient_user_id` to steal
+-- another user's row).
+--------------------------------------------------------------------------------
+alter table notification enable row level security;
+create policy "Allow select own" on notification for
+select to authenticated using (
+    recipient_user_id = (
+      select auth.uid()
+    )
+  );
+create policy "Allow update own (mark read)" on notification for
+update to authenticated using (
+    recipient_user_id = (
+      select auth.uid()
+    )
+  ) with check (
+    recipient_user_id = (
+      select auth.uid()
+    )
+  );
+--------------------------------------------------------------------------------
+-- Indexes
+--
+-- The bell's primary query is "give me my unread notifications, newest
+-- first", so the partial index covers exactly that predicate and stays
+-- small as historical rows accumulate.
+--------------------------------------------------------------------------------
+create index notification_recipient_unread_idx on notification(recipient_user_id, created_at desc)
+where read_at is null;
+--------------------------------------------------------------------------------
+-- Realtime Publication
+--
+-- Add `notification` to `supabase_realtime` so the bell can push-update
+-- without polling. The "Allow select own" policy above is honored by the
+-- secure broadcast channel, so subscribers only ever see their own rows.
+--
+-- Idempotent via `pg_publication_tables` so the migration replays cleanly
+-- against environments where the table was added piecemeal.
+--------------------------------------------------------------------------------
+do $$ begin if not exists (
+  select 1
+  from pg_publication_tables
+  where pubname = 'supabase_realtime'
+    and tablename = 'notification'
+) then alter publication supabase_realtime
+add table notification;
+end if;
+end $$;


### PR DESCRIPTION
## Summary

Implements **[E4.3]** (#180): the schema, RLS, and realtime-publication membership for the in-app notification inbox (the "bell"). DAL ([E4.4]), UI ([E4.5]), and trigger producers ([E4.6]) are explicitly **out of scope** per the issue and will land in follow-ups.

## Changes

### New migration — `supabase/migrations/20260604000000_notification.sql`

Creates the `notification` table:

| column              | type          | notes                                                  |
| ------------------- | ------------- | ------------------------------------------------------ |
| `id`                | `uuid` PK     | `default gen_random_uuid()`                            |
| `recipient_user_id` | `uuid` FK     | references `auth.users(id) on delete cascade`          |
| `kind`              | `text`        | event discriminator (e.g. `settlement_shared_with_you`) |
| `payload`           | `jsonb`       | `default '{}'::jsonb` — UI copy/deep-link inputs       |
| `read_at`           | `timestamptz` | nullable; flipped by the bell to dismiss               |
| `created_at`        | `timestamptz` | `default now()`                                        |

Adds a partial index covering the bell's primary query ("unread for me, newest first"):

```sql
create index notification_recipient_unread_idx
  on notification(recipient_user_id, created_at desc)
  where read_at is null;
```

### RLS

Two policies, both scoped to `authenticated`:

- **`Allow select own`** — `recipient_user_id = (select auth.uid())`
- **`Allow update own (mark read)`** — same predicate in both `using` and `with check` so the caller can flip `read_at` but can't reassign the row to themselves

INSERT/DELETE are intentionally **not** granted to `authenticated` — those paths are reserved for service-role contexts and the SECURITY DEFINER triggers landing in [E4.6].

No `"Allow all for admin"` policy is added. The legacy admin policies were dropped in `20260528000001_drop_admin_all_policies.sql` because `is_admin()` is unreachable (`auth.role() = 'admin'` is never satisfied by any token Supabase issues) while admin/maintenance traffic uses `service_role`, which bypasses RLS unconditionally. The [.github/copilot-instructions.md](.github/copilot-instructions.md) update in this PR records that guidance for future tables.

### Realtime publication

`notification` is added to `supabase_realtime` (idempotent via `pg_publication_tables`) so the bell push-updates without polling. The `Allow select own` policy is honored by the secure broadcast channel, so subscribers only ever receive their own rows.

### Test coverage

[__tests__/integration/realtime-publication.test.ts](__tests__/integration/realtime-publication.test.ts) gains a `notification` membership assertion mirroring the existing `user_subscription` / `settlement_shared_user` pattern. Full publication suite: **6/6 passing**.

### Docs

[.github/copilot-instructions.md](.github/copilot-instructions.md) — adds a "Database Considerations" bullet documenting that new tables should **not** carry `"Allow all for admin"` policies and pointing at `20260528000001_drop_admin_all_policies.sql` for context.

## Acceptance Criteria (issue #180)

- [x] **Table exists with RLS** — `notification` created with `alter table … enable row level security`.
- [x] **A user only sees notifications addressed to them** — `Allow select own` policy.
- [x] **A user can mark their own notifications read** — `Allow update own (mark read)` policy with both `using` and `with check`.
- [x] **Admin can manage all notifications** — satisfied via the project-wide `service_role` bypass; the legacy `Allow all for admin` RLS pattern is intentionally not re-introduced (see `20260528000001_drop_admin_all_policies.sql` and the new `.github/copilot-instructions.md` guidance).

## Verification

- `npx supabase db reset` (with seed) — clean
- `npm run integration-test -- __tests__/integration/realtime-publication.test.ts` — **6 passed (6)**
- `select … from pg_policy where polrelid = 'public.notification'::regclass` — exactly the two `authenticated`-scoped policies above, nothing else
- `select … from pg_policies where policyname = 'Allow all for admin'` — `0 rows` across the schema
- `select … from pg_policies where qual ilike '%is_admin%' or with_check ilike '%is_admin%'` — `0 rows`

## Dependencies

No dependency changes.

## Version

`0.79.0` → `0.79.1` (patch — additive schema change, no behavior change to existing surfaces).

## Out of Scope

- [E4.4] DAL
- [E4.5] UI / bell badge
- [E4.6] Trigger producers that write notification rows

## Related

- Closes #180
- Part of Epic [E4 — Phase 4: Real-time Polish & Notifications](https://github.com/ncalteen/kdm-app/issues/124)
- Decision **D4** in [docs/settlement-sharing-architecture.md](docs/settlement-sharing-architecture.md) §11 / §10 Phase 4 item 4.3
