### PR TITLE
[E4.4] Add notification DAL helpers

### DIFF
--- a/__tests__/lib/dal/notification.test.ts
+++ b/__tests__/lib/dal/notification.test.ts
@@ -136,7 +136,8 @@ describe('markRead', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-20T12:34:56.000Z'))
 
-    const inFilter = vi.fn().mockResolvedValue({ error: null })
+    const is = vi.fn().mockResolvedValue({ error: null })
+    const inFilter = vi.fn().mockReturnValue({ is })
     const eq = vi.fn().mockReturnValue({ in: inFilter })
     const update = vi.fn().mockReturnValue({ eq })
     mockSupabase.from.mockReturnValue({ update })
@@ -152,12 +153,14 @@ describe('markRead', () => {
       'notification-1',
       'notification-2'
     ])
+    expect(is).toHaveBeenCalledWith('read_at', null)
   })
 
   it('throws when marking notifications read fails', async () => {
-    const inFilter = vi
+    const is = vi
       .fn()
       .mockResolvedValue({ error: { message: 'update failed' } })
+    const inFilter = vi.fn().mockReturnValue({ is })
     const eq = vi.fn().mockReturnValue({ in: inFilter })
     const update = vi.fn().mockReturnValue({ eq })
     mockSupabase.from.mockReturnValue({ update })

--- a/__tests__/lib/dal/notification.test.ts
+++ b/__tests__/lib/dal/notification.test.ts
@@ -1,0 +1,203 @@
+import type { NotificationRow } from '@/lib/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSupabase = {
+  from: vi.fn()
+}
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabase
+}))
+
+vi.mock('@/lib/dal/user', () => ({
+  getUserId: vi.fn()
+}))
+
+const { getNotifications, getUnreadCount, markRead, markAllRead } =
+  await import('@/lib/dal/notification')
+const { getUserId } = await import('@/lib/dal/user')
+
+beforeEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+  vi.mocked(getUserId).mockResolvedValue('user-1')
+})
+
+describe('getNotifications', () => {
+  it('fetches the authenticated user notifications newest first with a limit', async () => {
+    const rows: NotificationRow[] = [
+      {
+        id: 'notification-1',
+        recipient_user_id: 'user-1',
+        kind: 'settlement_shared_with_you',
+        payload: { settlementId: 'settlement-1' },
+        read_at: null,
+        created_at: '2026-05-20T12:00:00.000Z'
+      }
+    ]
+    const limit = vi.fn().mockResolvedValue({ data: rows, error: null })
+    const order = vi.fn().mockReturnValue({ limit })
+    const eq = vi.fn().mockReturnValue({ order })
+    const select = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ select })
+
+    const result = await getNotifications()
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('notification')
+    expect(select).toHaveBeenCalledWith(
+      'id, recipient_user_id, kind, payload, read_at, created_at'
+    )
+    expect(eq).toHaveBeenCalledWith('recipient_user_id', 'user-1')
+    expect(order).toHaveBeenCalledWith('created_at', { ascending: false })
+    expect(limit).toHaveBeenCalledWith(50)
+    expect(result).toEqual(rows)
+  })
+
+  it('returns an empty list when data is null', async () => {
+    const limit = vi.fn().mockResolvedValue({ data: null, error: null })
+    const order = vi.fn().mockReturnValue({ limit })
+    const eq = vi.fn().mockReturnValue({ order })
+    const select = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ select })
+
+    const result = await getNotifications()
+
+    expect(result).toEqual([])
+  })
+
+  it('throws when the notification query fails', async () => {
+    const limit = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: 'DB error' } })
+    const order = vi.fn().mockReturnValue({ limit })
+    const eq = vi.fn().mockReturnValue({ order })
+    const select = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ select })
+
+    await expect(getNotifications()).rejects.toThrow(
+      'Error Fetching Notifications: DB error'
+    )
+  })
+})
+
+describe('getUnreadCount', () => {
+  it('counts unread notifications for the authenticated user', async () => {
+    const is = vi.fn().mockResolvedValue({ count: 7, error: null })
+    const eq = vi.fn().mockReturnValue({ is })
+    const select = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ select })
+
+    const result = await getUnreadCount()
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('notification')
+    expect(select).toHaveBeenCalledWith('id', {
+      count: 'exact',
+      head: true
+    })
+    expect(eq).toHaveBeenCalledWith('recipient_user_id', 'user-1')
+    expect(is).toHaveBeenCalledWith('read_at', null)
+    expect(result).toBe(7)
+  })
+
+  it('treats a null count as zero', async () => {
+    const is = vi.fn().mockResolvedValue({ count: null, error: null })
+    const eq = vi.fn().mockReturnValue({ is })
+    const select = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ select })
+
+    const result = await getUnreadCount()
+
+    expect(result).toBe(0)
+  })
+
+  it('throws when the unread count query fails', async () => {
+    const is = vi
+      .fn()
+      .mockResolvedValue({ count: null, error: { message: 'count failed' } })
+    const eq = vi.fn().mockReturnValue({ is })
+    const select = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ select })
+
+    await expect(getUnreadCount()).rejects.toThrow(
+      'Error Fetching Unread Notification Count: count failed'
+    )
+  })
+})
+
+describe('markRead', () => {
+  it('returns early without calling Supabase when no ids are provided', async () => {
+    await markRead([])
+
+    expect(getUserId).not.toHaveBeenCalled()
+    expect(mockSupabase.from).not.toHaveBeenCalled()
+  })
+
+  it('marks the requested notifications read for the authenticated user', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-20T12:34:56.000Z'))
+
+    const inFilter = vi.fn().mockResolvedValue({ error: null })
+    const eq = vi.fn().mockReturnValue({ in: inFilter })
+    const update = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ update })
+
+    await markRead(['notification-1', 'notification-2'])
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('notification')
+    expect(update).toHaveBeenCalledWith({
+      read_at: '2026-05-20T12:34:56.000Z'
+    })
+    expect(eq).toHaveBeenCalledWith('recipient_user_id', 'user-1')
+    expect(inFilter).toHaveBeenCalledWith('id', [
+      'notification-1',
+      'notification-2'
+    ])
+  })
+
+  it('throws when marking notifications read fails', async () => {
+    const inFilter = vi
+      .fn()
+      .mockResolvedValue({ error: { message: 'update failed' } })
+    const eq = vi.fn().mockReturnValue({ in: inFilter })
+    const update = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ update })
+
+    await expect(markRead(['notification-1'])).rejects.toThrow(
+      'Error Marking Notifications Read: update failed'
+    )
+  })
+})
+
+describe('markAllRead', () => {
+  it('marks all unread notifications read for the authenticated user', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-20T12:34:56.000Z'))
+
+    const is = vi.fn().mockResolvedValue({ error: null })
+    const eq = vi.fn().mockReturnValue({ is })
+    const update = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ update })
+
+    await markAllRead()
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('notification')
+    expect(update).toHaveBeenCalledWith({
+      read_at: '2026-05-20T12:34:56.000Z'
+    })
+    expect(eq).toHaveBeenCalledWith('recipient_user_id', 'user-1')
+    expect(is).toHaveBeenCalledWith('read_at', null)
+  })
+
+  it('throws when marking all notifications read fails', async () => {
+    const is = vi
+      .fn()
+      .mockResolvedValue({ error: { message: 'update failed' } })
+    const eq = vi.fn().mockReturnValue({ is })
+    const update = vi.fn().mockReturnValue({ eq })
+    mockSupabase.from.mockReturnValue({ update })
+
+    await expect(markAllRead()).rejects.toThrow(
+      'Error Marking All Notifications Read: update failed'
+    )
+  })
+})

--- a/lib/dal/notification.ts
+++ b/lib/dal/notification.ts
@@ -73,6 +73,7 @@ export async function markRead(ids: string[]): Promise<void> {
     .update({ read_at: readAt })
     .eq('recipient_user_id', userId)
     .in('id', ids)
+    .is('read_at', null)
 
   if (error)
     throw new Error(`Error Marking Notifications Read: ${error.message}`)

--- a/lib/dal/notification.ts
+++ b/lib/dal/notification.ts
@@ -1,0 +1,99 @@
+import { getUserId } from '@/lib/dal/user'
+import { createClient } from '@/lib/supabase/client'
+import { NotificationRow } from '@/lib/types'
+
+/**
+ * Get Notifications
+ *
+ * Fetches the authenticated user's most recent notification rows, newest
+ * first. RLS also scopes rows to the recipient, but the explicit
+ * `recipient_user_id` filter keeps the query contract and index usage clear.
+ *
+ * @returns Notification rows for the authenticated user.
+ */
+export async function getNotifications(): Promise<NotificationRow[]> {
+  const userId = await getUserId()
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('notification')
+    .select('id, recipient_user_id, kind, payload, read_at, created_at')
+    .eq('recipient_user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(50)
+
+  if (error) throw new Error(`Error Fetching Notifications: ${error.message}`)
+
+  return (data ?? []) as NotificationRow[]
+}
+
+/**
+ * Get Unread Count
+ *
+ * Counts unread notifications for the authenticated user. Returns zero when
+ * PostgREST does not include a count value.
+ *
+ * @returns Unread notification count.
+ */
+export async function getUnreadCount(): Promise<number> {
+  const userId = await getUserId()
+  const supabase = createClient()
+
+  const { count, error } = await supabase
+    .from('notification')
+    .select('id', { count: 'exact', head: true })
+    .eq('recipient_user_id', userId)
+    .is('read_at', null)
+
+  if (error)
+    throw new Error(
+      `Error Fetching Unread Notification Count: ${error.message}`
+    )
+
+  return count ?? 0
+}
+
+/**
+ * Mark Read
+ *
+ * Marks the provided notification IDs as read for the authenticated user.
+ * Empty batches return without touching Supabase.
+ *
+ * @param ids Notification IDs to mark read.
+ */
+export async function markRead(ids: string[]): Promise<void> {
+  if (ids.length === 0) return
+
+  const userId = await getUserId()
+  const supabase = createClient()
+  const readAt = new Date().toISOString()
+
+  const { error } = await supabase
+    .from('notification')
+    .update({ read_at: readAt })
+    .eq('recipient_user_id', userId)
+    .in('id', ids)
+
+  if (error)
+    throw new Error(`Error Marking Notifications Read: ${error.message}`)
+}
+
+/**
+ * Mark All Read
+ *
+ * Marks every unread notification for the authenticated user as read.
+ */
+export async function markAllRead(): Promise<void> {
+  const userId = await getUserId()
+  const supabase = createClient()
+  const readAt = new Date().toISOString()
+
+  const { error } = await supabase
+    .from('notification')
+    .update({ read_at: readAt })
+    .eq('recipient_user_id', userId)
+    .is('read_at', null)
+
+  if (error)
+    throw new Error(`Error Marking All Notifications Read: ${error.message}`)
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-import { Database, Tables } from '@/lib/database.types'
+import { Database, Json, Tables } from '@/lib/database.types'
 import { DatabaseCampaignType, HuntEventType } from '@/lib/enums'
 
 /**
@@ -1621,6 +1621,39 @@ export type SurvivorsStateSetter = (
     | SurvivorDetail[]
     | ((prev: SurvivorDetail[]) => SurvivorDetail[])
 ) => void
+
+/**
+ * Notification Kind
+ *
+ * Discriminator for in-app notification rows. Trigger producers write these
+ * values into `notification.kind`; UI renderers can switch on them to choose
+ * copy and destination links.
+ */
+export type NotificationKind =
+  | 'settlement_shared_with_you'
+  | 'removed_from_settlement'
+
+/**
+ * Notification Row
+ *
+ * Client-side row shape for the `notification` table. Kept explicit because
+ * the generated Supabase database types do not include the pending
+ * notification migration yet.
+ */
+export interface NotificationRow {
+  /** Notification ID */
+  id: string
+  /** Recipient User ID */
+  recipient_user_id: string
+  /** Notification Kind */
+  kind: NotificationKind
+  /** Notification Payload */
+  payload: Json
+  /** Read Timestamp */
+  read_at: string | null
+  /** Created Timestamp */
+  created_at: string
+}
 
 /**
  * User Settings Detail

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.79.1",
+  "version": "0.80.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.79.1",
+      "version": "0.80.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.79.1",
+  "version": "0.80.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary
- Add `lib/dal/notification.ts` helpers for listing notifications, unread counts, marking selected notifications read, and marking all unread notifications read.
- Add `NotificationRow` and `NotificationKind` app-level types for the initial notification kinds.
- Add mocked Supabase unit coverage for the notification DAL query chains and error handling.
- Bump package version to `0.80.0` for this feature PR.

## Dependencies
- No dependency changes.

## Related Issues
- Closes #178

## Additional Context
- Realtime UI wiring remains out of scope for this PR and is expected in E4.5.

## Verification
- `npx vitest run __tests__/lib/dal/notification.test.ts --coverage.enabled=false`
- `npx prettier --check lib/dal/notification.ts __tests__/lib/dal/notification.test.ts lib/types.ts package.json package-lock.json`
- `git diff --check`