### PR TITLE
[E4.5] Add notification bell popover UI

### DIFF
--- a/__tests__/components/notifications/notification-bell.test.tsx
+++ b/__tests__/components/notifications/notification-bell.test.tsx
@@ -1,0 +1,67 @@
+import {
+  formatNotificationCopy,
+  formatUnreadBadgeCount
+} from '@/components/notifications/notification-bell'
+import { NotificationRow } from '@/lib/types'
+import { describe, expect, it } from 'vitest'
+
+const baseNotification: NotificationRow = {
+  id: 'notification-1',
+  recipient_user_id: 'user-1',
+  kind: 'settlement_shared_with_you',
+  payload: {},
+  read_at: null,
+  created_at: '2026-05-20T12:00:00.000Z'
+}
+
+describe('formatNotificationCopy', () => {
+  it('formats settlement share notifications with owner and settlement payload fields', () => {
+    expect(
+      formatNotificationCopy({
+        ...baseNotification,
+        payload: {
+          owner: 'Nick',
+          settlement_name: 'Lantern Hold'
+        }
+      })
+    ).toBe('Nick extended a hand. The Lantern Hold watches with you.')
+  })
+
+  it('supports camelCase payload fields for settlement share notifications', () => {
+    expect(
+      formatNotificationCopy({
+        ...baseNotification,
+        payload: {
+          ownerUsername: 'Archivist',
+          settlementName: 'Stone Face'
+        }
+      })
+    ).toBe('Archivist extended a hand. The Stone Face watches with you.')
+  })
+
+  it('formats settlement removal notifications', () => {
+    expect(
+      formatNotificationCopy({
+        ...baseNotification,
+        kind: 'removed_from_settlement',
+        payload: { settlement_name: 'Lantern Hold' }
+      })
+    ).toBe('Your watch on Lantern Hold ends.')
+  })
+
+  it('falls back gracefully when payload copy fields are missing', () => {
+    expect(formatNotificationCopy(baseNotification)).toBe(
+      'Someone extended a hand. The settlement watches with you.'
+    )
+  })
+})
+
+describe('formatUnreadBadgeCount', () => {
+  it('returns the unread count for double-digit values', () => {
+    expect(formatUnreadBadgeCount(42)).toBe('42')
+  })
+
+  it('caps three-digit values', () => {
+    expect(formatUnreadBadgeCount(100)).toBe('99+')
+  })
+})

--- a/components/notifications/notification-bell.tsx
+++ b/components/notifications/notification-bell.tsx
@@ -1,0 +1,315 @@
+'use client'
+
+import { LanternMark } from '@/components/generic/lantern-mark'
+import { Button } from '@/components/ui/button'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from '@/components/ui/popover'
+import { useLocal } from '@/contexts/local-context'
+import {
+  getNotifications,
+  getUnreadCount,
+  markAllRead,
+  markRead
+} from '@/lib/dal/notification'
+import { ERROR_MESSAGE } from '@/lib/messages'
+import { NotificationRow } from '@/lib/types'
+import { cn } from '@/lib/utils'
+import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+const MAX_VISIBLE_NOTIFICATIONS = 10
+
+type NotificationPayloadRecord = Exclude<
+  Extract<NotificationRow['payload'], object>,
+  unknown[]
+>
+
+interface NotificationSnapshot {
+  /** Notification Rows */
+  notifications: NotificationRow[]
+  /** Unread Count */
+  unreadCount: number
+}
+
+/**
+ * Is Notification Payload Record
+ *
+ * @param payload Notification Payload
+ * @returns Whether the payload is an object record
+ */
+function isNotificationPayloadRecord(
+  payload: NotificationRow['payload']
+): payload is NotificationPayloadRecord {
+  return (
+    typeof payload === 'object' && payload !== null && !Array.isArray(payload)
+  )
+}
+
+/**
+ * Fetch Notification Snapshot
+ *
+ * Reads the notification list and unread count in parallel.
+ *
+ * @returns Notification Snapshot
+ */
+async function fetchNotificationSnapshot(): Promise<NotificationSnapshot> {
+  const [notifications, unreadCount] = await Promise.all([
+    getNotifications(),
+    getUnreadCount()
+  ])
+
+  return { notifications, unreadCount }
+}
+
+/**
+ * Read Payload String
+ *
+ * Reads the first non-empty string from a notification payload.
+ *
+ * @param payload Notification Payload
+ * @param keys Candidate Keys
+ * @param fallback Fallback Copy
+ * @returns Payload String or Fallback
+ */
+function readPayloadString(
+  payload: NotificationRow['payload'],
+  keys: string[],
+  fallback: string
+): string {
+  if (!isNotificationPayloadRecord(payload)) return fallback
+
+  for (const key of keys) {
+    const value = payload[key]
+    if (typeof value === 'string' && value.trim().length > 0)
+      return value.trim()
+  }
+
+  return fallback
+}
+
+/**
+ * Format Notification Copy
+ *
+ * @param notification Notification Row
+ * @returns Notification Copy
+ */
+export function formatNotificationCopy(
+  notification: Pick<NotificationRow, 'kind' | 'payload'>
+): string {
+  const settlementName = readPayloadString(
+    notification.payload,
+    ['settlement_name', 'settlementName'],
+    'settlement'
+  )
+
+  switch (notification.kind) {
+    case 'settlement_shared_with_you': {
+      const owner = readPayloadString(
+        notification.payload,
+        ['owner', 'owner_username', 'ownerUsername', 'owner_name', 'ownerName'],
+        'Someone'
+      )
+
+      return `${owner} extended a hand. The ${settlementName} watches with you.`
+    }
+    case 'removed_from_settlement':
+      return `Your watch on ${settlementName} ends.`
+    default:
+      return 'A message waits in the dark.'
+  }
+}
+
+/**
+ * Format Unread Badge Count
+ *
+ * @param unreadCount Unread Count
+ * @returns Badge Text
+ */
+export function formatUnreadBadgeCount(unreadCount: number): string {
+  return unreadCount > 99 ? '99+' : String(unreadCount)
+}
+
+/**
+ * Notification Bell Component
+ *
+ * @returns Notification bell with unread badge and notification popover.
+ */
+export function NotificationBell(): ReactElement {
+  const { isAuthenticated, notificationRefreshToken } = useLocal()
+  const [notifications, setNotifications] = useState<NotificationRow[]>([])
+  const [unreadCount, setUnreadCount] = useState(0)
+  const [isMarkingAllRead, setIsMarkingAllRead] = useState(false)
+
+  const visibleNotifications = useMemo(
+    () => notifications.slice(0, MAX_VISIBLE_NOTIFICATIONS),
+    [notifications]
+  )
+
+  const refreshNotifications = useCallback(async () => {
+    if (isAuthenticated !== true) return
+
+    try {
+      const snapshot = await fetchNotificationSnapshot()
+
+      setNotifications(snapshot.notifications)
+      setUnreadCount(snapshot.unreadCount)
+    } catch (error) {
+      console.error('Notification Fetch Error:', error)
+      toast.error(ERROR_MESSAGE())
+    }
+  }, [isAuthenticated])
+
+  useEffect(() => {
+    if (isAuthenticated !== true) return
+
+    let isCancelled = false
+
+    fetchNotificationSnapshot()
+      .then((snapshot) => {
+        if (isCancelled) return
+
+        setNotifications(snapshot.notifications)
+        setUnreadCount(snapshot.unreadCount)
+      })
+      .catch((error: unknown) => {
+        if (isCancelled) return
+
+        console.error('Notification Fetch Error:', error)
+        toast.error(ERROR_MESSAGE())
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [isAuthenticated, notificationRefreshToken])
+
+  const handleMarkRead = async (notification: NotificationRow) => {
+    if (notification.read_at) return
+
+    const readAt = new Date().toISOString()
+    setNotifications((prev) =>
+      prev.map((row) =>
+        row.id === notification.id ? { ...row, read_at: readAt } : row
+      )
+    )
+    setUnreadCount((prev) => Math.max(prev - 1, 0))
+
+    try {
+      await markRead([notification.id])
+    } catch (error) {
+      console.error('Notification Mark Read Error:', error)
+      toast.error(ERROR_MESSAGE())
+      void refreshNotifications()
+    }
+  }
+
+  const handleMarkAllRead = async () => {
+    if (unreadCount === 0 || isMarkingAllRead) return
+
+    setIsMarkingAllRead(true)
+    const readAt = new Date().toISOString()
+    setNotifications((prev) =>
+      prev.map((row) => ({ ...row, read_at: row.read_at ?? readAt }))
+    )
+    setUnreadCount(0)
+
+    try {
+      await markAllRead()
+      await refreshNotifications()
+    } catch (error) {
+      console.error('Notification Mark All Read Error:', error)
+      toast.error(ERROR_MESSAGE())
+      void refreshNotifications()
+    } finally {
+      setIsMarkingAllRead(false)
+    }
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={
+            unreadCount > 0
+              ? `${unreadCount} unread notifications`
+              : 'Notifications'
+          }
+          className="relative h-8 w-8 shrink-0 px-0">
+          <LanternMark
+            className="size-4 text-amber-400/90"
+            aria-hidden="true"
+          />
+          {unreadCount > 0 && (
+            <span className="bg-destructive text-destructive-foreground absolute -top-1 -right-1 flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[10px] leading-none font-semibold">
+              {formatUnreadBadgeCount(unreadCount)}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent align="start" className="w-80 p-0">
+        <div className="flex items-center justify-between gap-3 border-b px-3 py-2.5">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold">Notifications</h2>
+            <p className="text-muted-foreground text-xs">
+              {unreadCount > 0 ? `${unreadCount} unread` : 'All accounted for'}
+            </p>
+          </div>
+
+          {unreadCount > 0 && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 px-2 text-xs"
+              disabled={isMarkingAllRead}
+              onClick={handleMarkAllRead}>
+              Mark all read
+            </Button>
+          )}
+        </div>
+
+        <div className="max-h-80 overflow-y-auto p-1">
+          {visibleNotifications.length === 0 ? (
+            <div className="text-muted-foreground px-3 py-6 text-center text-sm">
+              Your settlement is quiet. For now.
+            </div>
+          ) : (
+            <ul className="space-y-1">
+              {visibleNotifications.map((notification) => (
+                <li key={notification.id}>
+                  <button
+                    type="button"
+                    onClick={() => void handleMarkRead(notification)}
+                    className={cn(
+                      'hover:bg-accent hover:text-accent-foreground flex w-full items-start gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors',
+                      notification.read_at
+                        ? 'text-muted-foreground'
+                        : 'text-foreground'
+                    )}>
+                    <span
+                      className={cn(
+                        'mt-1 size-2 shrink-0 rounded-full',
+                        notification.read_at
+                          ? 'bg-muted-foreground/25'
+                          : 'bg-amber-400'
+                      )}
+                      aria-hidden="true"
+                    />
+                    <span>{formatNotificationCopy(notification)}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/notifications/notification-bell.tsx
+++ b/components/notifications/notification-bell.tsx
@@ -138,7 +138,7 @@ export function formatUnreadBadgeCount(unreadCount: number): string {
  * @returns Notification bell with unread badge and notification popover.
  */
 export function NotificationBell(): ReactElement {
-  const { isAuthenticated, notificationRefreshToken } = useLocal()
+  const { isAuthenticated, subscribeToNotificationInserts } = useLocal()
   const [notifications, setNotifications] = useState<NotificationRow[]>([])
   const [unreadCount, setUnreadCount] = useState(0)
   const [isMarkingAllRead, setIsMarkingAllRead] = useState(false)
@@ -167,24 +167,31 @@ export function NotificationBell(): ReactElement {
 
     let isCancelled = false
 
-    fetchNotificationSnapshot()
-      .then((snapshot) => {
-        if (isCancelled) return
+    const handleSnapshot = (snapshot: NotificationSnapshot) => {
+      if (isCancelled) return
 
-        setNotifications(snapshot.notifications)
-        setUnreadCount(snapshot.unreadCount)
-      })
-      .catch((error: unknown) => {
-        if (isCancelled) return
+      setNotifications(snapshot.notifications)
+      setUnreadCount(snapshot.unreadCount)
+    }
 
-        console.error('Notification Fetch Error:', error)
-        toast.error(ERROR_MESSAGE())
-      })
+    const handleFetchError = (error: unknown) => {
+      if (isCancelled) return
+
+      console.error('Notification Fetch Error:', error)
+      toast.error(ERROR_MESSAGE())
+    }
+
+    fetchNotificationSnapshot().then(handleSnapshot).catch(handleFetchError)
+
+    const unsubscribe = subscribeToNotificationInserts(() => {
+      fetchNotificationSnapshot().then(handleSnapshot).catch(handleFetchError)
+    })
 
     return () => {
       isCancelled = true
+      unsubscribe()
     }
-  }, [isAuthenticated, notificationRefreshToken])
+  }, [isAuthenticated, subscribeToNotificationInserts])
 
   const handleMarkRead = async (notification: NotificationRow) => {
     if (notification.read_at) return

--- a/components/side-header.tsx
+++ b/components/side-header.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { LanternMark } from '@/components/generic/lantern-mark'
 import { ModeToggle } from '@/components/menu/mode-toggle'
+import { NotificationBell } from '@/components/notifications/notification-bell'
 import { PresenceStack } from '@/components/settlement/presence-stack'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
@@ -56,10 +56,7 @@ export function SiteHeader(): ReactElement {
         <ModeToggle />
 
         <div className="flex items-center gap-2 pl-1">
-          <LanternMark
-            className="h-4 w-4 text-amber-400/90"
-            aria-hidden="true"
-          />
+          <NotificationBell />
           <h1 className="text-xs sm:text-sm whitespace-nowrap leading-none">
             <span className="text-muted-foreground">
               Kingdom Death: Monster

--- a/contexts/local-context.tsx
+++ b/contexts/local-context.tsx
@@ -81,6 +81,10 @@ const newLocal: LocalStateType = {
   selectedTab: null
 }
 
+const NOTIFICATION_INSERT_COALESCE_MS = 250
+
+type NotificationInsertListener = () => void
+
 /**
  * Local Context Type
  */
@@ -201,8 +205,10 @@ interface LocalContextType {
   userSubscription: UserSubscriptionDetail | null
   /** Set User Subscription */
   setUserSubscription: (subscription: UserSubscriptionDetail | null) => void
-  /** Notification Refresh Token */
-  notificationRefreshToken: number
+  /** Subscribe To Notification Inserts */
+  subscribeToNotificationInserts: (
+    listener: NotificationInsertListener
+  ) => () => void
   /**
    * Whether The User May Create New Shares
    *
@@ -360,10 +366,14 @@ export function LocalProvider({
   // to avoid a redundant round trip.
   const [userId, setUserId] = useState<string | null>(null)
 
-  // Incremented by the per-user realtime channel whenever a notification row
-  // is inserted for this user. Consumers use it as a refetch signal without
-  // needing their own Supabase channel.
-  const [notificationRefreshToken, setNotificationRefreshToken] = useState(0)
+  // Notification insert listeners hang off refs so realtime inbox events do not
+  // mutate the global context value and re-render unrelated consumers.
+  const notificationInsertListenersRef = useRef(
+    new Set<NotificationInsertListener>()
+  )
+  const notificationInsertTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
 
   // Settlement list shown in the switcher. Held at the context layer so the
   // user-level realtime channel can refresh it from a single source of
@@ -807,13 +817,49 @@ export function LocalProvider({
   }, [])
 
   /**
+   * Subscribe To Notification Inserts
+   *
+   * Registers a lightweight listener for notification INSERT events without
+   * storing notification churn in the global context value.
+   *
+   * @param listener Notification Insert Listener
+   * @returns Unsubscribe Function
+   */
+  const subscribeToNotificationInserts = useCallback(
+    (listener: NotificationInsertListener) => {
+      notificationInsertListenersRef.current.add(listener)
+
+      return () => {
+        notificationInsertListenersRef.current.delete(listener)
+      }
+    },
+    []
+  )
+
+  /**
    * Handle Notification Insert
    *
-   * Signals notification consumers to refetch their cached list/count when the
-   * per-user realtime channel receives a new inbox row.
+   * Coalesces bursty inbox INSERT events before notifying subscribers, keeping
+   * the bell fresh without causing one list/count refetch per row.
    */
   const handleNotificationInsert = useCallback(() => {
-    setNotificationRefreshToken((prev) => prev + 1)
+    if (notificationInsertTimerRef.current)
+      clearTimeout(notificationInsertTimerRef.current)
+
+    notificationInsertTimerRef.current = setTimeout(() => {
+      notificationInsertTimerRef.current = null
+
+      notificationInsertListenersRef.current.forEach((listener) => {
+        listener()
+      })
+    }, NOTIFICATION_INSERT_COALESCE_MS)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (notificationInsertTimerRef.current)
+        clearTimeout(notificationInsertTimerRef.current)
+    }
   }, [])
 
   // Coalesces bursty INSERT / DELETE events on `settlement` (e.g. the
@@ -1719,7 +1765,7 @@ export function LocalProvider({
 
       userSubscription,
       setUserSubscription,
-      notificationRefreshToken,
+      subscribeToNotificationInserts,
       canShare: userSubscription?.can_share === true,
       subscriptionManagementEnabled,
 
@@ -1750,7 +1796,7 @@ export function LocalProvider({
       local,
       userSettings,
       userSubscription,
-      notificationRefreshToken,
+      subscribeToNotificationInserts,
       subscriptionManagementEnabled,
       settlementList,
       isSettlementListLoading,

--- a/contexts/local-context.tsx
+++ b/contexts/local-context.tsx
@@ -201,6 +201,8 @@ interface LocalContextType {
   userSubscription: UserSubscriptionDetail | null
   /** Set User Subscription */
   setUserSubscription: (subscription: UserSubscriptionDetail | null) => void
+  /** Notification Refresh Token */
+  notificationRefreshToken: number
   /**
    * Whether The User May Create New Shares
    *
@@ -357,6 +359,11 @@ export function LocalProvider({
   // `isAuthenticated` and is captured from the same `auth.getUser()` call
   // to avoid a redundant round trip.
   const [userId, setUserId] = useState<string | null>(null)
+
+  // Incremented by the per-user realtime channel whenever a notification row
+  // is inserted for this user. Consumers use it as a refetch signal without
+  // needing their own Supabase channel.
+  const [notificationRefreshToken, setNotificationRefreshToken] = useState(0)
 
   // Settlement list shown in the switcher. Held at the context layer so the
   // user-level realtime channel can refresh it from a single source of
@@ -799,6 +806,16 @@ export function LocalProvider({
       })
   }, [])
 
+  /**
+   * Handle Notification Insert
+   *
+   * Signals notification consumers to refetch their cached list/count when the
+   * per-user realtime channel receives a new inbox row.
+   */
+  const handleNotificationInsert = useCallback(() => {
+    setNotificationRefreshToken((prev) => prev + 1)
+  }, [])
+
   // Coalesces bursty INSERT / DELETE events on `settlement` (e.g. the
   // seed-data generator dropping a handful of settlements in quick
   // succession) into a single refetch of the cached list. Matches the
@@ -843,6 +860,7 @@ export function LocalProvider({
     userId,
     onShareChange: handleShareChange,
     onSubscriptionChange: handleSubscriptionChange,
+    onNotificationInsert: handleNotificationInsert,
     onOwnedSettlementChange: handleOwnedSettlementChange
   })
 
@@ -1701,6 +1719,7 @@ export function LocalProvider({
 
       userSubscription,
       setUserSubscription,
+      notificationRefreshToken,
       canShare: userSubscription?.can_share === true,
       subscriptionManagementEnabled,
 
@@ -1731,6 +1750,7 @@ export function LocalProvider({
       local,
       userSettings,
       userSubscription,
+      notificationRefreshToken,
       subscriptionManagementEnabled,
       settlementList,
       isSettlementListLoading,

--- a/hooks/use-realtime.tsx
+++ b/hooks/use-realtime.tsx
@@ -442,6 +442,8 @@ interface UseUserRealtimeSubscriptionsOptions {
    * not care about subscription state can omit it.
    */
   onSubscriptionChange?: () => void
+  /** Called when a notification row is inserted for the current user */
+  onNotificationInsert?: () => void
   /**
    * Called when the current user inserts or deletes a row in `settlement`
    * (i.e. an owned settlement appears or disappears). Powers the cached
@@ -472,6 +474,8 @@ interface UseUserRealtimeSubscriptionsOptions {
  *     cancellation flip. Closes the timing window where the user returns
  *     from the Customer Portal before the webhook has processed. See
  *     issue #170.
+ *   - `notification` — INSERT where `recipient_user_id = userId`, so the
+ *     bell badge and popover can refetch without polling. See issue #182.
  *   - `settlement` — INSERT / DELETE where `user_id = userId`, so the
  *     cached `settlementList` in `LocalContext` (and therefore the
  *     sidebar settlement switcher + free-tier ownership cap on the
@@ -491,11 +495,13 @@ export function useUserRealtimeSubscriptions(
 ) {
   const shareCallbackRef = useRef(options.onShareChange)
   const subscriptionCallbackRef = useRef(options.onSubscriptionChange)
+  const notificationCallbackRef = useRef(options.onNotificationInsert)
   const ownedSettlementCallbackRef = useRef(options.onOwnedSettlementChange)
 
   useEffect(() => {
     shareCallbackRef.current = options.onShareChange
     subscriptionCallbackRef.current = options.onSubscriptionChange
+    notificationCallbackRef.current = options.onNotificationInsert
     ownedSettlementCallbackRef.current = options.onOwnedSettlementChange
   })
 
@@ -564,6 +570,18 @@ export function useUserRealtimeSubscriptions(
           // delegate refresh entirely to the caller instead of
           // hand-rolling a partial reconstruction here.
           subscriptionCallbackRef.current?.()
+        }
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'notification',
+          filter: `recipient_user_id=eq.${userId}`
+        },
+        () => {
+          notificationCallbackRef.current?.()
         }
       )
       .on(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.80.0",
+      "version": "0.81.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary
- Add a LanternMark-powered notification popover in the site header with unread badge support.
- Refresh notification list/count from the existing user realtime channel when new notification rows arrive.
- Support optimistic mark-read and mark-all-read actions with fallback refetching on failure.
- Add focused tests for notification copy and unread badge formatting.
- Bump the app version to `0.81.0` for this PR.

## Dependencies
- No dependency changes.

## Related Issues
- Closes #182

## Verification
- `npx eslint components/notifications/notification-bell.tsx components/side-header.tsx contexts/local-context.tsx hooks/use-realtime.tsx __tests__/components/notifications/notification-bell.test.tsx`
- `npx vitest run __tests__/components/notifications/notification-bell.test.tsx __tests__/lib/dal/notification.test.ts --coverage.enabled=false`
- `npm run format:check`
- `git diff --check`
- `npm test`