### PR TITLE
[E4.6] Add settlement share notification triggers

### DIFF
--- a/__tests__/components/notifications/notification-bell.test.tsx
+++ b/__tests__/components/notifications/notification-bell.test.tsx
@@ -24,7 +24,7 @@ describe('formatNotificationCopy', () => {
           settlement_name: 'Lantern Hold'
         }
       })
-    ).toBe('Nick extended a hand. The Lantern Hold watches with you.')
+    ).toBe('Nick has invited you to Lantern Hold.')
   })
 
   it('supports camelCase payload fields for settlement share notifications', () => {
@@ -36,7 +36,7 @@ describe('formatNotificationCopy', () => {
           settlementName: 'Stone Face'
         }
       })
-    ).toBe('Archivist extended a hand. The Stone Face watches with you.')
+    ).toBe('Archivist has invited you to Stone Face.')
   })
 
   it('formats settlement removal notifications', () => {
@@ -51,7 +51,7 @@ describe('formatNotificationCopy', () => {
 
   it('falls back gracefully when payload copy fields are missing', () => {
     expect(formatNotificationCopy(baseNotification)).toBe(
-      'Someone extended a hand. The settlement watches with you.'
+      'Someone has invited you to a settlement.'
     )
   })
 })

--- a/__tests__/integration/rls/notification-triggers.test.ts
+++ b/__tests__/integration/rls/notification-triggers.test.ts
@@ -116,6 +116,22 @@ describe('RLS: notification triggers', () => {
     expect(unshareError).toBeNull()
     expect(deletedShare?.shared_user_id).toBe(collaborator.id)
 
+    const { data: inaccessibleSettlement, error: inaccessibleSettlementError } =
+      await collaborator.client
+        .from('settlement')
+        .select('id')
+        .eq('id', settlementId)
+    expect(inaccessibleSettlementError).toBeNull()
+    expect(inaccessibleSettlement ?? []).toEqual([])
+
+    const { data: inaccessibleShare, error: inaccessibleShareError } =
+      await collaborator.client
+        .from('settlement_shared_user')
+        .select('shared_user_id')
+        .eq('settlement_id', settlementId)
+    expect(inaccessibleShareError).toBeNull()
+    expect(inaccessibleShare ?? []).toEqual([])
+
     const afterUnshare = await getCollaboratorNotifications()
     expect(afterUnshare).toHaveLength(2)
     expect(afterUnshare[1]).toEqual({

--- a/__tests__/integration/rls/notification-triggers.test.ts
+++ b/__tests__/integration/rls/notification-triggers.test.ts
@@ -1,0 +1,129 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+interface NotificationPayload {
+  /** Owner User ID */
+  owner_user_id?: string
+  /** Owner Username */
+  owner_username?: string
+  /** Settlement ID */
+  settlement_id?: string
+  /** Settlement Name */
+  settlement_name?: string
+}
+
+interface NotificationRow {
+  /** Notification Kind */
+  kind: string
+  /** Notification Payload */
+  payload: NotificationPayload
+}
+
+/**
+ * RLS — Notification Triggers
+ *
+ * Verifies the SECURITY DEFINER trigger layer from issue #176. Sharing a
+ * settlement writes an inbox row for the invitee, and removing that share
+ * writes a second row that remains visible after the recipient loses access to
+ * the settlement itself.
+ */
+describe('RLS: notification triggers', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let settlementId: string
+  let ownerUsername: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    settlementId = await seedSettlement(owner.id, 'E4.6 Trigger Settlement')
+
+    const { error: subscriptionError } = await admin
+      .from('user_subscription')
+      .update({ plan_id: 'lantern_hoard', status: 'active' })
+      .eq('user_id', owner.id)
+    expect(subscriptionError).toBeNull()
+
+    const { data: ownerSettings, error: ownerSettingsError } = await admin
+      .from('user_settings')
+      .select('username')
+      .eq('user_id', owner.id)
+      .single<{ username: string }>()
+    expect(ownerSettingsError).toBeNull()
+    ownerUsername = ownerSettings?.username ?? ''
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+  })
+
+  /**
+   * Get Collaborator Notifications
+   *
+   * Reads notification rows through the collaborator's authenticated client so
+   * the assertion exercises the recipient SELECT policy rather than service
+   * role bypass.
+   *
+   * @returns Notification Rows
+   */
+  async function getCollaboratorNotifications(): Promise<NotificationRow[]> {
+    const { data, error } = await collaborator.client
+      .from('notification')
+      .select('kind, payload')
+      .order('created_at', { ascending: true })
+      .returns<NotificationRow[]>()
+
+    expect(error).toBeNull()
+    return data ?? []
+  }
+
+  it('writes recipient-visible notifications on share insert and delete', async () => {
+    const { error: shareError } = await owner.client
+      .from('settlement_shared_user')
+      .insert({
+        settlement_id: settlementId,
+        shared_user_id: collaborator.id,
+        user_id: owner.id
+      })
+    expect(shareError).toBeNull()
+
+    const afterShare = await getCollaboratorNotifications()
+    expect(afterShare).toHaveLength(1)
+    expect(afterShare[0]).toEqual({
+      kind: 'settlement_shared_with_you',
+      payload: {
+        owner_user_id: owner.id,
+        owner_username: ownerUsername,
+        settlement_id: settlementId,
+        settlement_name: 'E4.6 Trigger Settlement'
+      }
+    })
+
+    const { data: deletedShare, error: unshareError } = await owner.client
+      .from('settlement_shared_user')
+      .delete()
+      .eq('settlement_id', settlementId)
+      .eq('shared_user_id', collaborator.id)
+      .select('shared_user_id')
+      .single<{ shared_user_id: string }>()
+    expect(unshareError).toBeNull()
+    expect(deletedShare?.shared_user_id).toBe(collaborator.id)
+
+    const afterUnshare = await getCollaboratorNotifications()
+    expect(afterUnshare).toHaveLength(2)
+    expect(afterUnshare[1]).toEqual({
+      kind: 'removed_from_settlement',
+      payload: {
+        settlement_id: settlementId,
+        settlement_name: 'E4.6 Trigger Settlement'
+      }
+    })
+  })
+})

--- a/components/notifications/notification-bell.tsx
+++ b/components/notifications/notification-bell.tsx
@@ -102,7 +102,7 @@ export function formatNotificationCopy(
   const settlementName = readPayloadString(
     notification.payload,
     ['settlement_name', 'settlementName'],
-    'settlement'
+    'a settlement'
   )
 
   switch (notification.kind) {
@@ -113,7 +113,7 @@ export function formatNotificationCopy(
         'Someone'
       )
 
-      return `${owner} extended a hand. The ${settlementName} watches with you.`
+      return `${owner} has invited you to ${settlementName}.`
     }
     case 'removed_from_settlement':
       return `Your watch on ${settlementName} ends.`

--- a/components/side-header.tsx
+++ b/components/side-header.tsx
@@ -58,7 +58,8 @@ export function SiteHeader(): ReactElement {
         <div className="flex items-center gap-2 pl-1">
           <NotificationBell />
           <h1 className="text-xs sm:text-sm whitespace-nowrap leading-none">
-            <span className="text-muted-foreground">
+            <span className="text-muted-foreground md:hidden">KD:M</span>
+            <span className="text-muted-foreground hidden md:inline">
               Kingdom Death: Monster
             </span>
             <span className="mx-1 text-muted-foreground/60">/</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.81.0",
+  "version": "0.82.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.81.0",
+      "version": "0.82.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.81.0",
+  "version": "0.82.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260605000000_notification_triggers.sql
+++ b/supabase/migrations/20260605000000_notification_triggers.sql
@@ -1,0 +1,70 @@
+--------------------------------------------------------------------------------
+-- Notification Triggers
+--
+-- Emits notification rows when settlement shares are granted or revoked.
+-- These run as SECURITY DEFINER because authenticated users are intentionally
+-- blocked from inserting into `notification` directly; the trigger layer is the
+-- trusted producer for inbox events.
+--
+-- Reference: GitHub issue #176 ([E4.6]).
+--------------------------------------------------------------------------------
+create or replace function public.write_settlement_share_notification() returns trigger language plpgsql security definer
+set search_path = '' as $$
+declare target_settlement record;
+begin if TG_OP = 'INSERT' then
+select s.id as settlement_id,
+  s.settlement_name,
+  s.user_id as owner_user_id,
+  us.username as owner_username into target_settlement
+from public.settlement s
+  left join public.user_settings us on us.user_id = s.user_id
+where s.id = NEW.settlement_id;
+if not found then return NEW;
+end if;
+insert into public.notification (recipient_user_id, kind, payload)
+values (
+    NEW.shared_user_id,
+    'settlement_shared_with_you',
+    jsonb_build_object(
+      'settlement_id',
+      target_settlement.settlement_id,
+      'settlement_name',
+      target_settlement.settlement_name,
+      'owner_user_id',
+      target_settlement.owner_user_id,
+      'owner_username',
+      target_settlement.owner_username
+    )
+  );
+return NEW;
+end if;
+if TG_OP = 'DELETE' then
+select s.id as settlement_id,
+  s.settlement_name into target_settlement
+from public.settlement s
+where s.id = OLD.settlement_id;
+if not found then return OLD;
+end if;
+insert into public.notification (recipient_user_id, kind, payload)
+values (
+    OLD.shared_user_id,
+    'removed_from_settlement',
+    jsonb_build_object(
+      'settlement_id',
+      target_settlement.settlement_id,
+      'settlement_name',
+      target_settlement.settlement_name
+    )
+  );
+return OLD;
+end if;
+return null;
+end;
+$$;
+drop trigger if exists notify_settlement_shared_user_insert on public.settlement_shared_user;
+create trigger notify_settlement_shared_user_insert
+after
+insert on public.settlement_shared_user for each row execute function public.write_settlement_share_notification();
+drop trigger if exists notify_settlement_shared_user_delete on public.settlement_shared_user;
+create trigger notify_settlement_shared_user_delete
+after delete on public.settlement_shared_user for each row execute function public.write_settlement_share_notification();

--- a/supabase/migrations/20260605000000_notification_triggers.sql
+++ b/supabase/migrations/20260605000000_notification_triggers.sql
@@ -61,6 +61,12 @@ end if;
 return null;
 end;
 $$;
+-- Trigger firing does not require runtime EXECUTE on the function. Revoke the
+-- default RPC surface so this SECURITY DEFINER producer is not anon-callable.
+revoke execute on function public.write_settlement_share_notification()
+from public;
+revoke execute on function public.write_settlement_share_notification()
+from anon;
 drop trigger if exists notify_settlement_shared_user_insert on public.settlement_shared_user;
 create trigger notify_settlement_shared_user_insert
 after


### PR DESCRIPTION
## Summary
- Add SECURITY DEFINER triggers that write notification rows when settlement shares are granted or revoked.
- Capture settlement and owner details in notification payloads at trigger time.
- Add integration coverage proving recipients can SELECT share and unshare notifications through RLS.
- Include the small notification/header copy polish already committed on this branch.
- Bump the app version to `0.82.0`.

## Dependencies
- No dependency changes.

## Related Issues
- Closes #176

## Verification
- `npx eslint __tests__/integration/rls/notification-triggers.test.ts`
- `npm run integration-test -- __tests__/integration/rls/notification-triggers.test.ts`
- `npm run format:check`
- `git diff --check`
- `npm test`
- `npm run integration-test`