### PR TITLE
Add catalog archive lifecycle

### DIFF
--- a/__tests__/integration/rls/catalog-delete-guard.test.ts
+++ b/__tests__/integration/rls/catalog-delete-guard.test.ts
@@ -60,7 +60,7 @@ describe('RLS: catalog archive guard ([E4.7])', () => {
     await deleteTestUser(otherOwner.id)
   })
 
-  async function expectArchived(table: string, id: string): Promise<void> {
+  async function expectArchived(table: string, id: string): Promise<string> {
     const { data, error } = await admin
       .from(table)
       .select('archived_at')
@@ -69,6 +69,8 @@ describe('RLS: catalog archive guard ([E4.7])', () => {
 
     expect(error).toBeNull()
     expect(data?.archived_at).toEqual(expect.any(String))
+
+    return data?.archived_at ?? ''
   }
 
   // ---------------------------------------------------------------------------
@@ -223,7 +225,7 @@ describe('RLS: catalog archive guard ([E4.7])', () => {
         .delete()
         .eq('id', k.id)
       expect(archiveErr).toBeNull()
-      await expectArchived('knowledge', k.id)
+      const archivedAt = await expectArchived('knowledge', k.id)
 
       const { error: detachOtherErr } = await admin
         .from('settlement_knowledge')
@@ -250,7 +252,7 @@ describe('RLS: catalog archive guard ([E4.7])', () => {
           .select('id')
       expect(blockedDeleteErr).toBeNull()
       expect(blockedDelete).toEqual([])
-      await expectArchived('knowledge', k.id)
+      await expect(expectArchived('knowledge', k.id)).resolves.toBe(archivedAt)
 
       const { error: detachAuthorErr } = await admin
         .from('settlement_knowledge')

--- a/__tests__/integration/rls/catalog-delete-guard.test.ts
+++ b/__tests__/integration/rls/catalog-delete-guard.test.ts
@@ -8,23 +8,25 @@ import {
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 /**
- * RLS — Catalog Hard-Delete Guard ([E2.3])
+ * RLS — Catalog Archive Guard ([E4.7])
  *
- * Locks in the `enforce_catalog_delete_guard` BEFORE DELETE trigger added
- * in `20260518000000_catalog_delete_guard_trigger.sql`. Rules:
+ * Locks in the `archived_at` behavior added in
+ * `20260606000000_catalog_archived_at.sql`. Rules:
  *
  *  * Authors may hard-delete a custom catalog row only if every settlement
  *    that currently references it belongs to them.
- *  * If any non-self settlement references the row, the delete is rejected
- *    with a friendly error naming up to three blocking settlements.
+ *  * If any non-self settlement references the row, the delete archives the
+ *    row and skips the hard delete.
+ *  * Archived rows remain visible through existing settlement attachments so
+ *    collaborators can keep reading the rules text already in use.
  *  * The service role (admin / fixture teardown) bypasses the guard so
  *    test fixtures and auth.users cascade-deletes keep working.
  *
- * Architecture references: #122 Epic E2 Phase 2, #153 this issue,
+ * Architecture references: #122 Epic E2 Phase 2, #153, #181,
  * Appendix B EC-5 (author hard-deletes a referenced custom row), EC-8
  * (author hard-deletes their own unattached / self-only row).
  */
-describe('RLS: catalog delete guard ([E2.3])', () => {
+describe('RLS: catalog archive guard ([E4.7])', () => {
   let author: TestUser
   let otherOwner: TestUser
   let authorSettlementId: string
@@ -42,12 +44,32 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
       otherOwner.id,
       'Delete Guard — Other Settlement'
     )
+
+    const { error: shareErr } = await admin
+      .from('settlement_shared_user')
+      .insert({
+        settlement_id: otherSettlementId,
+        shared_user_id: author.id,
+        user_id: otherOwner.id
+      })
+    if (shareErr) throw new Error(`share settlement: ${shareErr.message}`)
   })
 
   afterAll(async () => {
     await deleteTestUser(author.id)
     await deleteTestUser(otherOwner.id)
   })
+
+  async function expectArchived(table: string, id: string): Promise<void> {
+    const { data, error } = await admin
+      .from(table)
+      .select('archived_at')
+      .eq('id', id)
+      .maybeSingle()
+
+    expect(error).toBeNull()
+    expect(data?.archived_at).toEqual(expect.any(String))
+  }
 
   // ---------------------------------------------------------------------------
   // EC-8 — author can hard-delete an unattached / self-only custom row.
@@ -115,18 +137,20 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // EC-5 — author cannot hard-delete when a non-self settlement references
-  // the row. Same shape repeated across reference paths so the dispatch
-  // catches each branch.
+  // EC-5 — author DELETE archives when a non-self settlement references the
+  // row. Same shape repeated across reference paths so the dispatch catches
+  // each branch.
   // ---------------------------------------------------------------------------
-  describe('EC-5: delete blocked when a non-self settlement references the row', () => {
-    it('settlement_<x> direct junction blocks (knowledge via settlement_knowledge)', async () => {
+  describe('EC-5: delete archives when a non-self settlement references the row', () => {
+    it('settlement_<x> direct junction archives and preserves transitive visibility', async () => {
+      const rulesText = `Archived Knowledge Rules ${Date.now()}-${Math.random()}`
       const { data: k, error: kErr } = await admin
         .from('knowledge')
         .insert({
           knowledge_name: `Knowledge Blocked ${Date.now()}-${Math.random()}`,
           custom: true,
-          user_id: author.id
+          user_id: author.id,
+          rules: rulesText
         })
         .select('id')
         .single()
@@ -145,21 +169,114 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         .from('knowledge')
         .delete()
         .eq('id', k.id)
-      expect(error).not.toBeNull()
-      expect(error?.code).toBe('0A000')
-      expect(error?.message).toMatch(/unmake what others rely upon/i)
-      expect(error?.message).toContain('Delete Guard — Other Settlement')
+      expect(error).toBeNull()
 
-      // Row must still exist (verified via admin to bypass RLS).
-      const { data: still } = await admin
+      await expectArchived('knowledge', k.id)
+
+      const { data: visible, error: visibleErr } = await otherOwner.client
+        .from('knowledge')
+        .select('id, rules, archived_at')
+        .eq('id', k.id)
+        .maybeSingle()
+      expect(visibleErr).toBeNull()
+      expect(visible?.rules).toBe(rulesText)
+      expect(visible?.archived_at).toEqual(expect.any(String))
+
+      const { error: restoreErr } = await author.client
+        .from('knowledge')
+        .update({ archived_at: null })
+        .eq('id', k.id)
+      expect(restoreErr).toBeNull()
+
+      const { data: restored, error: restoredErr } = await admin
+        .from('knowledge')
+        .select('archived_at')
+        .eq('id', k.id)
+        .maybeSingle()
+      expect(restoredErr).toBeNull()
+      expect(restored?.archived_at).toBeNull()
+    })
+
+    it('blocks permanent deletion while an archived row is still attached to any settlement', async () => {
+      const { data: k, error: kErr } = await admin
+        .from('knowledge')
+        .insert({
+          knowledge_name: `Permanent Delete Guard ${Date.now()}-${Math.random()}`,
+          custom: true,
+          user_id: author.id
+        })
+        .select('id')
+        .single()
+      if (kErr || !k) throw new Error(`seed knowledge: ${kErr?.message}`)
+
+      const { error: attachOtherErr } = await admin
+        .from('settlement_knowledge')
+        .insert({
+          settlement_id: otherSettlementId,
+          knowledge_id: k.id
+        })
+      if (attachOtherErr)
+        throw new Error(`attach other knowledge: ${attachOtherErr.message}`)
+
+      const { error: archiveErr } = await author.client
+        .from('knowledge')
+        .delete()
+        .eq('id', k.id)
+      expect(archiveErr).toBeNull()
+      await expectArchived('knowledge', k.id)
+
+      const { error: detachOtherErr } = await admin
+        .from('settlement_knowledge')
+        .delete()
+        .eq('settlement_id', otherSettlementId)
+        .eq('knowledge_id', k.id)
+      if (detachOtherErr)
+        throw new Error(`detach other knowledge: ${detachOtherErr.message}`)
+
+      const { error: attachAuthorErr } = await admin
+        .from('settlement_knowledge')
+        .insert({
+          settlement_id: authorSettlementId,
+          knowledge_id: k.id
+        })
+      if (attachAuthorErr)
+        throw new Error(`attach author knowledge: ${attachAuthorErr.message}`)
+
+      const { data: blockedDelete, error: blockedDeleteErr } =
+        await author.client
+          .from('knowledge')
+          .delete()
+          .eq('id', k.id)
+          .select('id')
+      expect(blockedDeleteErr).toBeNull()
+      expect(blockedDelete).toEqual([])
+      await expectArchived('knowledge', k.id)
+
+      const { error: detachAuthorErr } = await admin
+        .from('settlement_knowledge')
+        .delete()
+        .eq('settlement_id', authorSettlementId)
+        .eq('knowledge_id', k.id)
+      if (detachAuthorErr)
+        throw new Error(`detach author knowledge: ${detachAuthorErr.message}`)
+
+      const { data: deleted, error: deleteErr } = await author.client
+        .from('knowledge')
+        .delete()
+        .eq('id', k.id)
+        .select('id')
+      expect(deleteErr).toBeNull()
+      expect(deleted).toEqual([{ id: k.id }])
+
+      const { data: gone } = await admin
         .from('knowledge')
         .select('id')
         .eq('id', k.id)
         .maybeSingle()
-      expect(still).not.toBeNull()
+      expect(gone).toBeNull()
     })
 
-    it('survivor_<x> junction blocks (disorder via survivor_disorder on a non-self settlement)', async () => {
+    it('survivor_<x> junction archives (disorder via survivor_disorder on a non-self settlement)', async () => {
       const { data: sv, error: svErr } = await admin
         .from('survivor')
         .insert({
@@ -191,13 +308,12 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         .from('disorder')
         .delete()
         .eq('id', d.id)
-      expect(error).not.toBeNull()
-      expect(error?.code).toBe('0A000')
-      expect(error?.message).toMatch(/unmake what others rely upon/i)
-      expect(error?.message).toContain('Delete Guard — Other Settlement')
+      expect(error).toBeNull()
+
+      await expectArchived('disorder', d.id)
     })
 
-    it('survivor direct column blocks (philosophy via survivor.philosophy_id)', async () => {
+    it('survivor direct column archives (philosophy via survivor.philosophy_id)', async () => {
       const { data: p, error: pErr } = await admin
         .from('philosophy')
         .insert({
@@ -221,12 +337,12 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         .from('philosophy')
         .delete()
         .eq('id', p.id)
-      expect(error).not.toBeNull()
-      expect(error?.code).toBe('0A000')
-      expect(error?.message).toMatch(/unmake what others rely upon/i)
+      expect(error).toBeNull()
+
+      await expectArchived('philosophy', p.id)
     })
 
-    it("hunt_monster_trait junction blocks (trait via another owner's hunt)", async () => {
+    it("hunt_monster_trait junction archives (trait via another owner's hunt)", async () => {
       const { data: t, error: tErr } = await admin
         .from('trait')
         .insert({
@@ -272,13 +388,12 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         .from('trait')
         .delete()
         .eq('id', t.id)
-      expect(error).not.toBeNull()
-      expect(error?.code).toBe('0A000')
-      expect(error?.message).toMatch(/unmake what others rely upon/i)
-      expect(error?.message).toContain('Delete Guard — Other Settlement')
+      expect(error).toBeNull()
+
+      await expectArchived('trait', t.id)
     })
 
-    it('gear_grid selected_armor_set_id blocks (armor_set via gear_grid -> survivor)', async () => {
+    it('gear_grid selected_armor_set_id archives (armor_set via gear_grid -> survivor)', async () => {
       const { data: sv, error: svErr } = await admin
         .from('survivor')
         .insert({
@@ -311,15 +426,12 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         .from('armor_set')
         .delete()
         .eq('id', as_.id)
-      expect(error).not.toBeNull()
-      expect(error?.code).toBe('0A000')
-      expect(error?.message).toMatch(/unmake what others rely upon/i)
+      expect(error).toBeNull()
+
+      await expectArchived('armor_set', as_.id)
     })
 
-    it('counts and names up to 3 blocking settlements (sorted)', async () => {
-      // Three additional settlements for otherOwner, plus the existing
-      // one (= 4 total). The friendly message must list 3 of them and
-      // report the total count = 4.
+    it('archives once when multiple non-self settlements reference the row', async () => {
       const s2 = await seedSettlement(otherOwner.id, 'Delete Guard — Beta')
       const s3 = await seedSettlement(otherOwner.id, 'Delete Guard — Gamma')
       const s4 = await seedSettlement(otherOwner.id, 'Delete Guard — Delta')
@@ -347,17 +459,9 @@ describe('RLS: catalog delete guard ([E2.3])', () => {
         .from('knowledge')
         .delete()
         .eq('id', k.id)
-      expect(error).not.toBeNull()
-      expect(error?.code).toBe('0A000')
-      // Count of 4 blocking settlements.
-      expect(error?.message).toMatch(/4 settlement\(s\)/)
-      // Listed names are alphabetically sorted, first 3 only.
-      expect(error?.message).toContain('Delete Guard — Beta')
-      expect(error?.message).toContain('Delete Guard — Delta')
-      expect(error?.message).toContain('Delete Guard — Gamma')
-      // The "Other Settlement" sorts AFTER "Delta" / "Gamma" alphabetically
-      // and so should NOT appear in the trimmed 3-name list.
-      expect(error?.message).not.toContain('Delete Guard — Other Settlement')
+      expect(error).toBeNull()
+
+      await expectArchived('knowledge', k.id)
     })
   })
 

--- a/__tests__/integration/rls/catalog-transitive.test.ts
+++ b/__tests__/integration/rls/catalog-transitive.test.ts
@@ -434,37 +434,45 @@ describe('RLS: catalog transitive visibility (EC-2..EC-8)', () => {
 
   // ---------------------------------------------------------------------------
   // EC-8: (EC-6) + B tries to delete D while D is attached to A's
-  //       settlement → BEFORE DELETE trigger raises with code 0A000 and a
-  //       friendly message naming the blocking settlement.
+  //       settlement → the delete guard archives D and keeps the row
+  //       readable through the settlement attachment.
   // ---------------------------------------------------------------------------
-  it("EC-8: author cannot delete a custom disorder while it is still attached to another user's settlement", async () => {
+  it("EC-8: author delete archives a custom disorder while it is still attached to another user's settlement", async () => {
     const survivorId = await seedSurvivor(settlementId)
-    const { id: disorderId } = await seedDisorder(userB.id, 'EC-8')
+    const { id: disorderId, rules } = await seedDisorder(userB.id, 'EC-8')
 
     const { error: attachErr } = await admin
       .from('survivor_disorder')
       .insert({ survivor_id: survivorId, disorder_id: disorderId })
     if (attachErr) throw new Error(`attach disorder: ${attachErr.message}`)
 
-    // B (author) attempts to delete D. The BEFORE DELETE guard must
-    // raise because A's settlement still references D via the survivor.
+    // B (author) attempts to delete D. The BEFORE DELETE guard archives
+    // the row because A's settlement still references D via the survivor.
     const { error } = await userB.client
       .from('disorder')
       .delete()
       .eq('id', disorderId)
 
-    expect(error).not.toBeNull()
-    expect(error?.code).toBe('0A000')
-    expect(error?.message).toMatch(/unmake what others rely upon/i)
-    expect(error?.message).toContain('EC-2..EC-8 Test Settlement')
+    expect(error).toBeNull()
 
-    // The disorder row must still exist.
-    const { data: still } = await admin
+    // The disorder row must still exist, now marked archived.
+    const { data: archived, error: archivedErr } = await admin
       .from('disorder')
-      .select('id')
+      .select('id, archived_at')
       .eq('id', disorderId)
       .maybeSingle()
-    expect(still).not.toBeNull()
+    expect(archivedErr).toBeNull()
+    expect(archived?.archived_at).toEqual(expect.any(String))
+
+    // A can still read the rules text through the settlement attachment.
+    const { data: visible, error: visibleErr } = await userA.client
+      .from('disorder')
+      .select('id, rules, archived_at')
+      .eq('id', disorderId)
+      .maybeSingle()
+    expect(visibleErr).toBeNull()
+    expect(visible?.rules).toBe(rules)
+    expect(visible?.archived_at).toEqual(expect.any(String))
   })
 
   // ---------------------------------------------------------------------------

--- a/__tests__/lib/dal/settlement.test.ts
+++ b/__tests__/lib/dal/settlement.test.ts
@@ -517,4 +517,56 @@ describe('createSettlement (free-tier ownership cap)', () => {
     expect(countSelect).not.toHaveBeenCalled()
     expect(settlementInsert).toHaveBeenCalledOnce()
   })
+
+  it('falls back to the free-tier cap when the subscription lookup fails', async () => {
+    vi.mocked(getUserId).mockResolvedValue('user-1')
+    vi.mocked(getUserSubscription).mockRejectedValue(
+      new Error('rpc unavailable')
+    )
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    const countEq = vi.fn().mockResolvedValue({ count: 0, error: null })
+    const countSelect = vi.fn().mockReturnValue({ eq: countEq })
+    const settlementInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'insert reached' }
+        })
+      })
+    })
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'settlement') {
+        return {
+          select: countSelect,
+          insert: settlementInsert
+        }
+      }
+
+      return {
+        select: vi.fn(),
+        insert: vi.fn()
+      }
+    })
+
+    await expect(createSettlement(baseInput)).rejects.toThrow(
+      'Error Creating Settlement: insert reached'
+    )
+
+    expect(countSelect).toHaveBeenCalledWith('id', {
+      count: 'exact',
+      head: true
+    })
+    expect(countEq).toHaveBeenCalledWith('user_id', 'user-1')
+    expect(settlementInsert).toHaveBeenCalledOnce()
+    expect(consoleError).toHaveBeenCalledWith(
+      'Settlement Subscription Entitlement Error:',
+      expect.any(Error)
+    )
+
+    consoleError.mockRestore()
+  })
 })

--- a/__tests__/lib/dal/settlement.test.ts
+++ b/__tests__/lib/dal/settlement.test.ts
@@ -12,6 +12,23 @@ vi.mock('@/lib/dal/user', () => ({
   getUserId: vi.fn()
 }))
 
+vi.mock('@/lib/dal/user-subscription', () => ({
+  getUserSubscription: vi.fn()
+}))
+
+vi.mock('@/lib/campaigns/potl', () => ({
+  getPeopleOfTheLanternTemplate: vi.fn().mockResolvedValue({
+    collectiveCognitionRewardIds: [],
+    innovationIds: [],
+    locationIds: [],
+    milestoneIds: [],
+    nemesisIds: [],
+    principleIds: [],
+    quarryIds: [],
+    timeline: []
+  })
+}))
+
 // Mock all of the related DAL modules used by `getSettlement` so the test
 // file does not need to set up DB mocks for each one. These are used only
 // for verifying that `getSettlement` invokes them and aggregates results.
@@ -81,11 +98,20 @@ const {
   removeSettlement
 } = await import('@/lib/dal/settlement')
 const { getUserId } = await import('@/lib/dal/user')
+const { getUserSubscription } = await import('@/lib/dal/user-subscription')
 const { FREE_TIER_SETTLEMENT_LIMIT } = await import('@/lib/common')
+const { CampaignType, SurvivorType } = await import('@/lib/enums')
 const { FREE_TIER_SETTLEMENT_LIMIT_MESSAGE } = await import('@/lib/messages')
 
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.mocked(getUserSubscription).mockResolvedValue({
+    plan_id: 'free',
+    status: 'active',
+    current_period_end: null,
+    cancel_at_period_end: false,
+    can_share: false
+  })
 })
 
 describe('getSettlement', () => {
@@ -387,9 +413,9 @@ describe('createSettlement (free-tier ownership cap)', () => {
    * this test path — we only need a value the function can destructure.
    */
   const baseInput = {
-    campaignType: 'PEOPLE_OF_THE_LANTERN',
+    campaignType: CampaignType.PEOPLE_OF_THE_LANTERN,
     settlementName: 'Doomed',
-    survivorType: 'CORE',
+    survivorType: SurvivorType.CORE,
     usesScouts: false,
     monsterIds: {
       NQ1: [],
@@ -448,5 +474,47 @@ describe('createSettlement (free-tier ownership cap)', () => {
       FREE_TIER_SETTLEMENT_LIMIT_MESSAGE(FREE_TIER_SETTLEMENT_LIMIT)
     )
     expect(insert).not.toHaveBeenCalled()
+  })
+
+  it('does not enforce the free-tier cap for an active lantern subscriber', async () => {
+    vi.mocked(getUserId).mockResolvedValue('user-1')
+    vi.mocked(getUserSubscription).mockResolvedValue({
+      plan_id: 'lantern',
+      status: 'active',
+      current_period_end: '2027-01-01T00:00:00Z',
+      cancel_at_period_end: false,
+      can_share: false
+    })
+
+    const countSelect = vi.fn()
+    const settlementInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: null,
+          error: { message: 'insert reached' }
+        })
+      })
+    })
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'settlement') {
+        return {
+          select: countSelect,
+          insert: settlementInsert
+        }
+      }
+
+      return {
+        select: vi.fn(),
+        insert: vi.fn()
+      }
+    })
+
+    await expect(createSettlement(baseInput)).rejects.toThrow(
+      'Error Creating Settlement: insert reached'
+    )
+
+    expect(countSelect).not.toHaveBeenCalled()
+    expect(settlementInsert).toHaveBeenCalledOnce()
   })
 })

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -257,7 +257,7 @@ export function AppSidebar({
   // single early-access allowlist. When the rollout opens to everyone, the
   // Sharing entry should be re-gated on `canShare` so non-subscribers stop
   // seeing it; see `docs/settlement-sharing-architecture.md` §9.
-  const { subscriptionManagementEnabled } = useLocal()
+  const { subscriptionManagementEnabled, userSubscription } = useLocal()
 
   const navItems = useMemo(() => {
     const items =
@@ -324,6 +324,7 @@ export function AppSidebar({
           selectedSettlementPhaseId={selectedSettlementPhaseId}
           selectedShowdownId={selectedShowdownId}
           settlementList={settlementList}
+          userSubscription={userSubscription}
           setIsCreatingNewSettlement={setIsCreatingNewSettlement}
           setSelectedHuntId={setSelectedHuntId}
           setSelectedSettlementId={setSelectedSettlementId}

--- a/components/custom/archived-catalog-card.tsx
+++ b/components/custom/archived-catalog-card.tsx
@@ -1,0 +1,283 @@
+'use client'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table'
+import { LocalStateType } from '@/contexts/local-context'
+import { useToast } from '@/hooks/use-toast'
+import {
+  CatalogArchiveItem,
+  CatalogPermanentDeleteBlockedError,
+  getArchivedCatalogRows,
+  permanentlyDeleteArchivedCatalogRow,
+  restoreCatalogRow
+} from '@/lib/dal/catalog-archive'
+import {
+  CATALOG_PERMANENTLY_DELETED_MESSAGE,
+  CATALOG_PERMANENT_DELETE_BLOCKED_MESSAGE,
+  CATALOG_RESTORED_MESSAGE,
+  ERROR_MESSAGE
+} from '@/lib/messages'
+import { ArchiveRestoreIcon, Trash2Icon } from 'lucide-react'
+import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
+
+/** Archived Catalog Card Properties */
+interface ArchivedCatalogCardProps {
+  /** Local State */
+  local: LocalStateType
+}
+
+function getCatalogArchiveItemKey(
+  item: Pick<CatalogArchiveItem, 'id' | 'table'>
+): string {
+  return `${item.table}:${item.id}`
+}
+
+/**
+ * Archived Catalog Card
+ *
+ * Lists the current user's archived custom catalog rows and allows them to be
+ * restored into the active custom content library.
+ *
+ * @param props Component Properties
+ * @returns Archived Catalog Card Component
+ */
+export function ArchivedCatalogCard({
+  local
+}: ArchivedCatalogCardProps): ReactElement {
+  const { toast } = useToast(local)
+
+  const [items, setItems] = useState<CatalogArchiveItem[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [deletingKey, setDeletingKey] = useState<string | null>(null)
+  const [restoringKey, setRestoringKey] = useState<string | null>(null)
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short'
+      }),
+    []
+  )
+
+  useEffect(() => {
+    let cancelled = false
+
+    getArchivedCatalogRows()
+      .then((data) => {
+        if (!cancelled) setItems(data)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+
+        console.error('Load Archived Catalog Error:', err)
+        toast.error(ERROR_MESSAGE())
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [toast])
+
+  /**
+   * Handle Restore
+   *
+   * Optimistically removes the row from the archive list, then clears its
+   * archive timestamp in the database. Restores the row on failure.
+   *
+   * @param item Archived Catalog Item
+   */
+  const handleRestore = useCallback(
+    (item: CatalogArchiveItem) => {
+      if (restoringKey || deletingKey) return
+
+      const itemKey = getCatalogArchiveItemKey(item)
+      const previous = [...items]
+      setRestoringKey(itemKey)
+      setItems(
+        items.filter((entry) => getCatalogArchiveItemKey(entry) !== itemKey)
+      )
+
+      restoreCatalogRow(item.table, item.id)
+        .then(() => toast.success(CATALOG_RESTORED_MESSAGE()))
+        .catch((err: unknown) => {
+          setItems(previous)
+          console.error('Restore Catalog Row Error:', err)
+          toast.error(ERROR_MESSAGE())
+        })
+        .finally(() => setRestoringKey(null))
+    },
+    [deletingKey, items, restoringKey, toast]
+  )
+
+  /**
+   * Handle Permanent Delete
+   *
+   * Optimistically removes the row, then asks the database to hard-delete it.
+   * The delete guard returns no row when the catalog item is still attached to
+   * a settlement, so the item is restored locally and a specific toast is
+   * shown.
+   *
+   * @param item Archived Catalog Item
+   */
+  const handlePermanentDelete = useCallback(
+    (item: CatalogArchiveItem) => {
+      if (restoringKey || deletingKey) return
+
+      const itemKey = getCatalogArchiveItemKey(item)
+      const previous = [...items]
+      setDeletingKey(itemKey)
+      setItems(
+        items.filter((entry) => getCatalogArchiveItemKey(entry) !== itemKey)
+      )
+
+      permanentlyDeleteArchivedCatalogRow(item.table, item.id)
+        .then(() => toast.success(CATALOG_PERMANENTLY_DELETED_MESSAGE()))
+        .catch((err: unknown) => {
+          setItems(previous)
+          console.error('Permanent Delete Catalog Row Error:', err)
+
+          if (err instanceof CatalogPermanentDeleteBlockedError) {
+            toast.error(CATALOG_PERMANENT_DELETE_BLOCKED_MESSAGE())
+            return
+          }
+
+          toast.error(ERROR_MESSAGE())
+        })
+        .finally(() => setDeletingKey(null))
+    },
+    [deletingKey, items, restoringKey, toast]
+  )
+
+  return (
+    <Card className="p-0 border gap-0">
+      <CardHeader className="px-4 pt-4 pb-2">
+        <CardTitle className="text-md flex flex-row items-center justify-between">
+          <span>Archived</span>
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent className="p-2">
+        {isLoading ? (
+          <div className="flex items-center justify-center p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              Peering into the darkness...
+            </p>
+          </div>
+        ) : items.length === 0 ? (
+          <div className="flex items-center justify-center p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              No archived custom content waits in the dark.
+            </p>
+          </div>
+        ) : (
+          <div className="max-h-100 overflow-y-auto rounded-md border">
+            <Table>
+              <TableHeader className="sticky top-0 bg-background z-10">
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead className="hidden sm:table-cell">Type</TableHead>
+                  <TableHead className="hidden md:table-cell">
+                    Archived
+                  </TableHead>
+                  <TableHead className="w-25 text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((item) => {
+                  const itemKey = getCatalogArchiveItemKey(item)
+                  const isActionPending =
+                    restoringKey !== null || deletingKey !== null
+
+                  return (
+                    <TableRow key={itemKey}>
+                      <TableCell>
+                        <div className="font-medium">{item.name}</div>
+                        <div className="text-xs text-muted-foreground sm:hidden">
+                          {item.category}
+                        </div>
+                      </TableCell>
+                      <TableCell className="hidden sm:table-cell text-sm text-muted-foreground">
+                        {item.category}
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
+                        {dateFormatter.format(new Date(item.archived_at))}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleRestore(item)}
+                            disabled={isActionPending}
+                            title={`Restore ${item.name}`}
+                            aria-label={`Restore ${item.name}`}>
+                            <ArchiveRestoreIcon className="h-4 w-4" />
+                          </Button>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                disabled={isActionPending}
+                                title={`Permanently delete ${item.name}`}
+                                aria-label={`Permanently delete ${item.name}`}>
+                                <Trash2Icon className="h-4 w-4 text-destructive" />
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>
+                                  Delete Archived Item
+                                </AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  The darkness hungers for {item.name}. This can
+                                  only succeed once no settlement carries it,
+                                  and it cannot be undone.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction
+                                  onClick={() => handlePermanentDelete(item)}
+                                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                                  Delete forever
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/menu/settlement-switcher.tsx
+++ b/components/menu/settlement-switcher.tsx
@@ -23,7 +23,12 @@ import {
 import { FREE_TIER_SETTLEMENT_LIMIT } from '@/lib/common'
 import { CampaignType } from '@/lib/enums'
 import { FREE_TIER_SETTLEMENT_LIMIT_MESSAGE } from '@/lib/messages'
-import { SettlementDetail, SettlementListEntry } from '@/lib/types'
+import { canCreateUnlimitedSettlements } from '@/lib/subscription-entitlements'
+import {
+  SettlementDetail,
+  SettlementListEntry,
+  UserSubscriptionDetail
+} from '@/lib/types'
 import { Check, ChevronsUpDown, House, Plus } from 'lucide-react'
 import { ComponentProps, ReactElement } from 'react'
 
@@ -57,6 +62,8 @@ interface SettlementSwitcherProps extends ComponentProps<typeof Sidebar> {
    * (#144 / E1.5) propagate without an extra fetch.
    */
   settlementList: SettlementListEntry[]
+  /** User Subscription */
+  userSubscription: UserSubscriptionDetail | null
   /** Set Is Creating New Settlement */
   setIsCreatingNewSettlement: (isCreating: boolean) => void
   /** Set Selected Hunt ID */
@@ -91,6 +98,7 @@ export function SettlementSwitcher({
   selectedSettlementPhaseId,
   selectedShowdownId,
   settlementList,
+  userSubscription,
   setIsCreatingNewSettlement,
   setSelectedHuntId,
   setSelectedSettlementId,
@@ -108,14 +116,15 @@ export function SettlementSwitcher({
     setSelectedSettlementId(settlementId)
   }
 
-  // Free-tier ownership cap. Collaborator rows are excluded so users who
-  // accept shares are not punished for it. The DAL enforces the same cap on
-  // submit; the UI gate keeps the affordance honest before the user invests
-  // time in the create form.
+  // Free-tier ownership cap. Paid settlement tiers skip it; collaborator rows
+  // are excluded so users who accept shares are not punished for it. The DAL
+  // enforces the same cap on submit; the UI gate keeps the affordance honest
+  // before the user invests time in the create form.
   const ownedSettlementCount = settlementList.filter(
     (s) => s.role === 'owner'
   ).length
   const hasReachedSettlementLimit =
+    !canCreateUnlimitedSettlements(userSubscription) &&
     ownedSettlementCount >= FREE_TIER_SETTLEMENT_LIMIT
 
   if (isSettlementListLoading)

--- a/components/settlement/settlement-card.tsx
+++ b/components/settlement/settlement-card.tsx
@@ -59,6 +59,7 @@ import {
   TabType
 } from '@/lib/enums'
 import { FREE_TIER_SETTLEMENT_LIMIT_MESSAGE } from '@/lib/messages'
+import { canCreateUnlimitedSettlements } from '@/lib/subscription-entitlements'
 import {
   HuntDetail,
   HuntStateSetter,
@@ -205,7 +206,7 @@ export function SettlementCard({
   // skips the post-checkout tab switch). This local check protects against
   // a stale `selectedTab` value persisted to localStorage from a previous
   // session when the user was on the allowlist but has since been removed.
-  const { subscriptionManagementEnabled } = useLocal()
+  const { subscriptionManagementEnabled, userSubscription } = useLocal()
 
   // Settings tab is always accessible, regardless of settlement state.
   if (selectedTab === TabType.SETTINGS)
@@ -268,11 +269,13 @@ export function SettlementCard({
   if (!selectedSettlement) {
     // Mirror the SettlementSwitcher's free-tier ownership cap so the
     // empty-state "Found a settlement" affordance can't lure the user into a
-    // form that the DAL will refuse to submit.
+    // form that the DAL will refuse to submit. Active paid settlement tiers
+    // skip the cap.
     const ownedSettlementCount = settlementList.filter(
       (s) => s.role === 'owner'
     ).length
     const hasReachedSettlementLimit =
+      !canCreateUnlimitedSettlements(userSubscription) &&
       ownedSettlementCount >= FREE_TIER_SETTLEMENT_LIMIT
 
     return (

--- a/components/user/user-card.tsx
+++ b/components/user/user-card.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ArchivedCatalogCard } from '@/components/custom/archived-catalog-card'
 import { CustomAbilityImpairmentsCard } from '@/components/custom/custom-ability-impairments-card'
 import { CustomCharactersCard } from '@/components/custom/custom-characters-card'
 import { CustomCollectiveCognitionRewardsCard } from '@/components/custom/custom-collective-cognition-rewards-card'
@@ -280,6 +281,7 @@ export function UserCard({
               <SelectItem value="monsters">Monsters</SelectItem>
               <SelectItem value="wanderers">Wanderers</SelectItem>
               <SelectItem value="other">Other</SelectItem>
+              <SelectItem value="archived">Archived</SelectItem>
             </SelectContent>
           </Select>
         </div>
@@ -293,6 +295,7 @@ export function UserCard({
           <TabsTrigger value="monsters">Monsters</TabsTrigger>
           <TabsTrigger value="wanderers">Wanderers</TabsTrigger>
           <TabsTrigger value="other">Other</TabsTrigger>
+          <TabsTrigger value="archived">Archived</TabsTrigger>
         </TabsList>
         <TabsContent value="society">
           <div className="grid grid-cols-1 gap-4">
@@ -363,6 +366,9 @@ export function UserCard({
               <CustomWeaponTypesCard local={local} />
             </div>
           </div>
+        </TabsContent>
+        <TabsContent value="archived">
+          <ArchivedCatalogCard local={local} />
         </TabsContent>
       </Tabs>
     </div>

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -23,8 +23,8 @@ import {
  * included. The limit is enforced in the application layer (the
  * `createSettlement` DAL) rather than at the database so that direct
  * admin / service-role traffic — Supabase Studio, integration tests, ad-hoc
- * SQL — naturally bypasses it for testing purposes. Paid tiers that lift or
- * remove this cap are not yet implemented.
+ * SQL — naturally bypasses it for testing purposes. Active paid settlement
+ * tiers skip this cap via `canCreateUnlimitedSettlements`.
  */
 export const FREE_TIER_SETTLEMENT_LIMIT = 5
 

--- a/lib/dal/ability-impairment.ts
+++ b/lib/dal/ability-impairment.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { createClient } from '@/lib/supabase/client'
 import { AbilityImpairmentDetail } from '@/lib/types'
@@ -52,7 +53,7 @@ export async function getUserCustomAbilityImpairments(): Promise<{
 
   const { data, error } = await supabase
     .from('ability_impairment')
-    .select('id, custom, ability_impairment_name, rules')
+    .select('id, custom, ability_impairment_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
@@ -62,7 +63,7 @@ export async function getUserCustomAbilityImpairments(): Promise<{
     )
 
   const map: { [key: string]: AbilityImpairmentDetail } = {}
-  for (const a of data ?? []) map[a.id] = a
+  for (const a of data ?? []) if (!a.archived_at) map[a.id] = a
 
   return map
 }
@@ -134,13 +135,5 @@ export async function updateAbilityImpairment(
  * @param id Ability/Impairment ID
  */
 export async function removeAbilityImpairment(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase
-    .from('ability_impairment')
-    .delete()
-    .eq('id', id)
-
-  if (error)
-    throw new Error(`Error Removing Ability/Impairment: ${error.message}`)
+  await removeCatalogRow('ability_impairment', id, 'Ability/Impairment')
 }

--- a/lib/dal/catalog-archive.ts
+++ b/lib/dal/catalog-archive.ts
@@ -1,0 +1,262 @@
+import { getUserId } from '@/lib/dal/user'
+import { createClient } from '@/lib/supabase/client'
+
+/** Catalog Archive Table */
+export type CatalogArchiveTable =
+  | 'ability_impairment'
+  | 'armor_set'
+  | 'character'
+  | 'collective_cognition_reward'
+  | 'constellation'
+  | 'disorder'
+  | 'fighting_art'
+  | 'gear'
+  | 'innovation'
+  | 'knowledge'
+  | 'location'
+  | 'milestone'
+  | 'mood'
+  | 'nemesis'
+  | 'neurosis'
+  | 'pattern'
+  | 'philosophy'
+  | 'principle'
+  | 'quarry'
+  | 'resource'
+  | 'secret_fighting_art'
+  | 'seed_pattern'
+  | 'strain_milestone'
+  | 'survivor_status'
+  | 'trait'
+  | 'wanderer'
+  | 'weapon_type'
+
+/** Catalog Archive Item */
+export interface CatalogArchiveItem {
+  /** Archive Timestamp */
+  archived_at: string
+  /** Catalog Category Label */
+  category: string
+  /** Catalog Row ID */
+  id: string
+  /** Display Name */
+  name: string
+  /** Catalog Table */
+  table: CatalogArchiveTable
+}
+
+/** Catalog Permanent Delete Blocked Error */
+export class CatalogPermanentDeleteBlockedError extends Error {
+  /**
+   * Catalog Permanent Delete Blocked Error
+   */
+  constructor() {
+    super('Catalog row is still referenced by a settlement')
+    this.name = 'CatalogPermanentDeleteBlockedError'
+  }
+}
+
+interface CatalogArchiveSpec {
+  /** Catalog Category Label */
+  category: string
+  /** Name Column */
+  nameColumn: string
+  /** Catalog Table */
+  table: CatalogArchiveTable
+}
+
+const CATALOG_ARCHIVE_SPECS: CatalogArchiveSpec[] = [
+  {
+    category: 'Ability/Impairment',
+    nameColumn: 'ability_impairment_name',
+    table: 'ability_impairment'
+  },
+  { category: 'Armor Set', nameColumn: 'armor_set_name', table: 'armor_set' },
+  { category: 'Character', nameColumn: 'character_name', table: 'character' },
+  {
+    category: 'Collective Cognition Reward',
+    nameColumn: 'reward_name',
+    table: 'collective_cognition_reward'
+  },
+  {
+    category: 'Constellation',
+    nameColumn: 'constellation_name',
+    table: 'constellation'
+  },
+  { category: 'Disorder', nameColumn: 'disorder_name', table: 'disorder' },
+  {
+    category: 'Fighting Art',
+    nameColumn: 'fighting_art_name',
+    table: 'fighting_art'
+  },
+  { category: 'Gear', nameColumn: 'gear_name', table: 'gear' },
+  {
+    category: 'Innovation',
+    nameColumn: 'innovation_name',
+    table: 'innovation'
+  },
+  { category: 'Knowledge', nameColumn: 'knowledge_name', table: 'knowledge' },
+  { category: 'Location', nameColumn: 'location_name', table: 'location' },
+  { category: 'Milestone', nameColumn: 'milestone_name', table: 'milestone' },
+  { category: 'Mood', nameColumn: 'mood_name', table: 'mood' },
+  { category: 'Nemesis', nameColumn: 'monster_name', table: 'nemesis' },
+  { category: 'Neurosis', nameColumn: 'neurosis_name', table: 'neurosis' },
+  { category: 'Pattern', nameColumn: 'pattern_name', table: 'pattern' },
+  {
+    category: 'Philosophy',
+    nameColumn: 'philosophy_name',
+    table: 'philosophy'
+  },
+  { category: 'Principle', nameColumn: 'principle_name', table: 'principle' },
+  { category: 'Quarry', nameColumn: 'monster_name', table: 'quarry' },
+  { category: 'Resource', nameColumn: 'resource_name', table: 'resource' },
+  {
+    category: 'Secret Fighting Art',
+    nameColumn: 'secret_fighting_art_name',
+    table: 'secret_fighting_art'
+  },
+  {
+    category: 'Seed Pattern',
+    nameColumn: 'seed_pattern_name',
+    table: 'seed_pattern'
+  },
+  {
+    category: 'Strain Milestone',
+    nameColumn: 'strain_milestone_name',
+    table: 'strain_milestone'
+  },
+  {
+    category: 'Survivor Status',
+    nameColumn: 'survivor_status_name',
+    table: 'survivor_status'
+  },
+  { category: 'Trait', nameColumn: 'trait_name', table: 'trait' },
+  { category: 'Wanderer', nameColumn: 'wanderer_name', table: 'wanderer' },
+  {
+    category: 'Weapon Type',
+    nameColumn: 'weapon_type_name',
+    table: 'weapon_type'
+  }
+]
+
+/**
+ * Remove Catalog Row
+ *
+ * Requests deletion for a custom catalog row. The database delete guard decides
+ * whether the row can be hard-deleted or must be archived because another
+ * settlement still references it.
+ *
+ * @param table Catalog Table
+ * @param id Catalog Row ID
+ * @param label Error Label
+ */
+export async function removeCatalogRow(
+  table: CatalogArchiveTable,
+  id: string,
+  label: string
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase.from(table).delete().eq('id', id)
+
+  if (error) throw new Error(`Error Removing ${label}: ${error.message}`)
+}
+
+/**
+ * Restore Catalog Row
+ *
+ * Clears a catalog row's archive timestamp so it returns to the user's active
+ * custom content library.
+ *
+ * @param table Catalog Table
+ * @param id Catalog Row ID
+ */
+export async function restoreCatalogRow(
+  table: CatalogArchiveTable,
+  id: string
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from(table)
+    .update({ archived_at: null })
+    .eq('id', id)
+
+  if (error) throw new Error(`Error Restoring Catalog Row: ${error.message}`)
+}
+
+/**
+ * Permanently Delete Archived Catalog Row
+ *
+ * Attempts to hard-delete an archived custom catalog row. The database trigger
+ * is the final authority: if the row is still attached to any settlement, the
+ * trigger keeps it archived and returns no deleted row.
+ *
+ * @param table Catalog Table
+ * @param id Catalog Row ID
+ */
+export async function permanentlyDeleteArchivedCatalogRow(
+  table: CatalogArchiveTable,
+  id: string
+): Promise<void> {
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from(table)
+    .delete()
+    .eq('id', id)
+    .not('archived_at', 'is', null)
+    .select('id')
+    .maybeSingle()
+
+  if (error)
+    throw new Error(`Error Permanently Deleting Catalog Row: ${error.message}`)
+
+  if (!data) throw new CatalogPermanentDeleteBlockedError()
+}
+
+/**
+ * Get Archived Catalog Rows
+ *
+ * Retrieves archived custom catalog rows authored by the current user across
+ * every catalog table that supports custom content.
+ *
+ * @returns Archived Catalog Rows
+ */
+export async function getArchivedCatalogRows(): Promise<CatalogArchiveItem[]> {
+  const userId = await getUserId()
+  const supabase = createClient()
+
+  const results = await Promise.all(
+    CATALOG_ARCHIVE_SPECS.map(async (spec) => {
+      const { data, error } = await supabase
+        .from(spec.table)
+        .select(`id, ${spec.nameColumn}, archived_at`)
+        .eq('custom', true)
+        .eq('user_id', userId)
+        .not('archived_at', 'is', null)
+
+      if (error)
+        throw new Error(
+          `Error Fetching Archived ${spec.category}: ${error.message}`
+        )
+
+      return ((data ?? []) as unknown as Record<string, string | null>[]).map(
+        (row) => ({
+          archived_at: row.archived_at ?? '',
+          category: spec.category,
+          id: row.id ?? '',
+          name: row[spec.nameColumn] ?? 'Unnamed',
+          table: spec.table
+        })
+      )
+    })
+  )
+
+  return results
+    .flat()
+    .sort(
+      (a, b) =>
+        a.category.localeCompare(b.category) || a.name.localeCompare(b.name)
+    )
+}

--- a/lib/dal/character.ts
+++ b/lib/dal/character.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -47,7 +48,7 @@ export async function getUserCustomCharacters(): Promise<{
 
   const { data, error } = await supabase
     .from('character')
-    .select('id, custom, character_name, rules')
+    .select('id, custom, character_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
@@ -55,7 +56,7 @@ export async function getUserCustomCharacters(): Promise<{
     throw new Error(`Error Fetching Custom Characters: ${error.message}`)
 
   const characterMap: { [key: string]: CharacterDetail } = {}
-  for (const c of data ?? []) characterMap[c.id] = c
+  for (const c of data ?? []) if (!c.archived_at) characterMap[c.id] = c
 
   return characterMap
 }
@@ -124,9 +125,5 @@ export async function updateCharacter(
  * @param id Character ID
  */
 export async function removeCharacter(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('character').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Character: ${error.message}`)
+  await removeCatalogRow('character', id, 'Character')
 }

--- a/lib/dal/collective-cognition-reward.ts
+++ b/lib/dal/collective-cognition-reward.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -53,7 +54,7 @@ export async function getUserCustomCollectiveCognitionRewards(): Promise<{
 
   const { data, error } = await supabase
     .from('collective_cognition_reward')
-    .select('id, custom, reward_name, collective_cognition, rules')
+    .select('id, custom, reward_name, collective_cognition, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
@@ -63,7 +64,7 @@ export async function getUserCustomCollectiveCognitionRewards(): Promise<{
     )
 
   const rewardMap: { [key: string]: CollectiveCognitionRewardDetail } = {}
-  for (const r of data ?? []) rewardMap[r.id] = r
+  for (const r of data ?? []) if (!r.archived_at) rewardMap[r.id] = r
 
   return rewardMap
 }
@@ -185,15 +186,9 @@ export async function updateCollectiveCognitionReward(
 export async function removeCollectiveCognitionReward(
   id: string
 ): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase
-    .from('collective_cognition_reward')
-    .delete()
-    .eq('id', id)
-
-  if (error)
-    throw new Error(
-      `Error Removing Collective Cognition Reward: ${error.message}`
-    )
+  await removeCatalogRow(
+    'collective_cognition_reward',
+    id,
+    'Collective Cognition Reward'
+  )
 }

--- a/lib/dal/disorder.ts
+++ b/lib/dal/disorder.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -52,7 +53,7 @@ export async function getUserCustomDisorders(): Promise<{
 
   const { data, error } = await supabase
     .from('disorder')
-    .select('id, custom, disorder_name, rules')
+    .select('id, custom, disorder_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
@@ -60,7 +61,7 @@ export async function getUserCustomDisorders(): Promise<{
     throw new Error(`Error Fetching Custom Disorders: ${error.message}`)
 
   const disorderMap: { [key: string]: DisorderDetail } = {}
-  for (const d of data ?? []) disorderMap[d.id] = d
+  for (const d of data ?? []) if (!d.archived_at) disorderMap[d.id] = d
 
   return disorderMap
 }
@@ -128,9 +129,5 @@ export async function updateDisorder(
  * @param id Disorder ID
  */
 export async function removeDisorder(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('disorder').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Disorder: ${error.message}`)
+  await removeCatalogRow('disorder', id, 'Disorder')
 }

--- a/lib/dal/fighting-art.ts
+++ b/lib/dal/fighting-art.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -50,7 +51,7 @@ export async function getUserCustomFightingArts(): Promise<{
 
   const { data, error } = await supabase
     .from('fighting_art')
-    .select('id, custom, fighting_art_name, rules')
+    .select('id, custom, fighting_art_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
@@ -58,7 +59,7 @@ export async function getUserCustomFightingArts(): Promise<{
     throw new Error(`Error Fetching Custom Fighting Arts: ${error.message}`)
 
   const fightingArtMap: { [key: string]: FightingArtDetail } = {}
-  for (const f of data ?? []) fightingArtMap[f.id] = f
+  for (const f of data ?? []) if (!f.archived_at) fightingArtMap[f.id] = f
 
   return fightingArtMap
 }
@@ -130,11 +131,7 @@ export async function updateFightingArt(
  * @param id Fighting Art ID
  */
 export async function removeFightingArt(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('fighting_art').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Fighting Art: ${error.message}`)
+  await removeCatalogRow('fighting_art', id, 'Fighting Art')
 }
 
 /**
@@ -152,7 +149,7 @@ export async function getCustomFightingArts(): Promise<{
 
   const { data, error } = await supabase
     .from('fighting_art')
-    .select('id, custom, fighting_art_name, rules')
+    .select('id, custom, fighting_art_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
@@ -160,7 +157,7 @@ export async function getCustomFightingArts(): Promise<{
     throw new Error(`Error Fetching Custom Fighting Arts: ${error.message}`)
 
   const fightingArtMap: { [key: string]: FightingArtDetail } = {}
-  for (const f of data ?? []) fightingArtMap[f.id] = f
+  for (const f of data ?? []) if (!f.archived_at) fightingArtMap[f.id] = f
 
   return fightingArtMap
 }

--- a/lib/dal/gear.ts
+++ b/lib/dal/gear.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { Json, TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -100,7 +101,7 @@ export async function getUserCustomGear(): Promise<{
   const { data, error } = await supabase
     .from('gear')
     .select(
-      'id, custom, gear_name, location_id, accessory, accuracy, affinity_top, affinity_left, affinity_right, affinity_bottom, affinity_bonus, affinity_bonus_requirements, armor_points, armor_location, keywords, rules, speed, strength, weapon_type_id, gear_gear_cost!gear_gear_cost_gear_id_fkey(cost_gear_id, quantity), gear_resource_cost(resource_id, quantity), gear_resource_type_cost(resource_type, quantity)'
+      'id, custom, gear_name, location_id, accessory, accuracy, affinity_top, affinity_left, affinity_right, affinity_bottom, affinity_bonus, affinity_bonus_requirements, armor_points, armor_location, keywords, rules, speed, strength, weapon_type_id, gear_gear_cost!gear_gear_cost_gear_id_fkey(cost_gear_id, quantity), gear_resource_cost(resource_id, quantity), gear_resource_type_cost(resource_type, quantity), archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -108,7 +109,8 @@ export async function getUserCustomGear(): Promise<{
   if (error) throw new Error(`Error Fetching Custom Gear: ${error.message}`)
 
   const gearMap: { [key: string]: GearDetail } = {}
-  for (const g of data ?? []) gearMap[g.id] = toGearDetail(g)
+  for (const g of data ?? [])
+    if (!g.archived_at) gearMap[g.id] = toGearDetail(g)
 
   return gearMap
 }
@@ -178,11 +180,7 @@ export async function updateGear(
  * @param id Gear ID
  */
 export async function removeGear(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('gear').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Gear: ${error.message}`)
+  await removeCatalogRow('gear', id, 'Gear')
 }
 
 /**
@@ -201,7 +199,7 @@ export async function getCustomGear(): Promise<{
   const { data, error } = await supabase
     .from('gear')
     .select(
-      'id, custom, gear_name, location_id, accessory, accuracy, affinity_top, affinity_left, affinity_right, affinity_bottom, affinity_bonus, affinity_bonus_requirements, armor_points, armor_location, keywords, rules, speed, strength, weapon_type_id, gear_gear_cost!gear_gear_cost_gear_id_fkey(cost_gear_id, quantity), gear_resource_cost(resource_id, quantity), gear_resource_type_cost(resource_type, quantity)'
+      'id, custom, gear_name, location_id, accessory, accuracy, affinity_top, affinity_left, affinity_right, affinity_bottom, affinity_bonus, affinity_bonus_requirements, armor_points, armor_location, keywords, rules, speed, strength, weapon_type_id, gear_gear_cost!gear_gear_cost_gear_id_fkey(cost_gear_id, quantity), gear_resource_cost(resource_id, quantity), gear_resource_type_cost(resource_type, quantity), archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -209,7 +207,8 @@ export async function getCustomGear(): Promise<{
   if (error) throw new Error(`Error Fetching Custom Gear: ${error.message}`)
 
   const gearMap: { [key: string]: GearDetail } = {}
-  for (const g of data ?? []) gearMap[g.id] = toGearDetail(g)
+  for (const g of data ?? [])
+    if (!g.archived_at) gearMap[g.id] = toGearDetail(g)
 
   return gearMap
 }

--- a/lib/dal/innovation.ts
+++ b/lib/dal/innovation.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -49,7 +50,9 @@ export async function getUserCustomInnovations(): Promise<{
 
   const { data, error } = await supabase
     .from('innovation')
-    .select('id, custom, innovation_name, rules, consequences, benefits')
+    .select(
+      'id, custom, innovation_name, rules, consequences, benefits, archived_at'
+    )
     .eq('custom', true)
     .eq('user_id', userId)
 
@@ -57,7 +60,7 @@ export async function getUserCustomInnovations(): Promise<{
     throw new Error(`Error Fetching Custom Innovations: ${error.message}`)
 
   const innovationMap: { [key: string]: InnovationDetail } = {}
-  for (const i of data ?? []) innovationMap[i.id] = i
+  for (const i of data ?? []) if (!i.archived_at) innovationMap[i.id] = i
 
   return innovationMap
 }
@@ -168,9 +171,5 @@ export async function updateInnovation(
  * @param id Innovation ID
  */
 export async function removeInnovation(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('innovation').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Innovation: ${error.message}`)
+  await removeCatalogRow('innovation', id, 'Innovation')
 }

--- a/lib/dal/knowledge.ts
+++ b/lib/dal/knowledge.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -52,7 +53,7 @@ export async function getUserCustomKnowledges(): Promise<{
   const { data, error } = await supabase
     .from('knowledge')
     .select(
-      'id, custom, knowledge_name, philosophy_id, rules, observation_conditions, observation_rank_up_milestone'
+      'id, custom, knowledge_name, philosophy_id, rules, observation_conditions, observation_rank_up_milestone, archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -61,7 +62,7 @@ export async function getUserCustomKnowledges(): Promise<{
     throw new Error(`Error Fetching Custom Knowledges: ${error.message}`)
 
   const knowledgeMap: { [key: string]: KnowledgeDetail } = {}
-  for (const k of data ?? []) knowledgeMap[k.id] = k
+  for (const k of data ?? []) if (!k.archived_at) knowledgeMap[k.id] = k
 
   return knowledgeMap
 }
@@ -132,9 +133,5 @@ export async function updateKnowledge(
  * @param id Knowledge ID
  */
 export async function removeKnowledge(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('knowledge').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Knowledge: ${error.message}`)
+  await removeCatalogRow('knowledge', id, 'Knowledge')
 }

--- a/lib/dal/location.ts
+++ b/lib/dal/location.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -49,7 +50,7 @@ export async function getUserCustomLocations(): Promise<{
 
   const { data, error } = await supabase
     .from('location')
-    .select('id, custom, location_name, rules')
+    .select('id, custom, location_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
@@ -57,7 +58,7 @@ export async function getUserCustomLocations(): Promise<{
     throw new Error(`Error Fetching Custom Locations: ${error.message}`)
 
   const locationMap: { [key: string]: LocationDetail } = {}
-  for (const l of data ?? []) locationMap[l.id] = l
+  for (const l of data ?? []) if (!l.archived_at) locationMap[l.id] = l
 
   return locationMap
 }
@@ -164,9 +165,5 @@ export async function updateLocation(
  * @param id Location ID
  */
 export async function removeLocation(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('location').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Location: ${error.message}`)
+  await removeCatalogRow('location', id, 'Location')
 }

--- a/lib/dal/milestone.ts
+++ b/lib/dal/milestone.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { CampaignType, DatabaseCampaignType } from '@/lib/enums'
@@ -53,7 +54,7 @@ export async function getUserCustomMilestones(): Promise<{
   const { data, error } = await supabase
     .from('milestone')
     .select(
-      'id, custom, milestone_name, event_name, campaign_types, requirements, rules'
+      'id, custom, milestone_name, event_name, campaign_types, requirements, rules, archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -62,7 +63,7 @@ export async function getUserCustomMilestones(): Promise<{
     throw new Error(`Error Fetching Custom Milestones: ${error.message}`)
 
   const milestoneMap: { [key: string]: MilestoneDetail } = {}
-  for (const m of data ?? []) milestoneMap[m.id] = m
+  for (const m of data ?? []) if (!m.archived_at) milestoneMap[m.id] = m
 
   return milestoneMap
 }
@@ -179,9 +180,5 @@ export async function updateMilestone(
  * @param id Milestone ID
  */
 export async function removeMilestone(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('milestone').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Milestone: ${error.message}`)
+  await removeCatalogRow('milestone', id, 'Milestone')
 }

--- a/lib/dal/mood.ts
+++ b/lib/dal/mood.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { createClient } from '@/lib/supabase/client'
 import { MoodDetail } from '@/lib/types'
@@ -45,14 +46,14 @@ export async function getUserCustomMoods(): Promise<{
 
   const { data, error } = await supabase
     .from('mood')
-    .select('id, custom, mood_name, rules')
+    .select('id, custom, mood_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
   if (error) throw new Error(`Error Fetching Custom Moods: ${error.message}`)
 
   const map: { [key: string]: MoodDetail } = {}
-  for (const m of data ?? []) map[m.id] = m
+  for (const m of data ?? []) if (!m.archived_at) map[m.id] = m
 
   return map
 }
@@ -116,11 +117,7 @@ export async function updateMood(
  * @param id Mood ID
  */
 export async function removeMood(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('mood').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Mood: ${error.message}`)
+  await removeCatalogRow('mood', id, 'Mood')
 }
 
 /**

--- a/lib/dal/nemesis.ts
+++ b/lib/dal/nemesis.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { MonsterNode } from '@/lib/enums'
@@ -81,7 +82,7 @@ export async function getUserCustomNemeses(): Promise<{
   const { data, error } = await supabase
     .from('nemesis')
     .select(
-      'id, alternate_id, custom, monster_name, multi_monster, node, vignette_id, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome'
+      'id, alternate_id, custom, monster_name, multi_monster, node, vignette_id, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome, archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -89,7 +90,7 @@ export async function getUserCustomNemeses(): Promise<{
   if (error) throw new Error(`Error Fetching Custom Nemeses: ${error.message}`)
 
   const nemesisMap: { [key: string]: NemesisDetail } = {}
-  for (const n of data ?? []) nemesisMap[n.id] = n
+  for (const n of data ?? []) if (!n.archived_at) nemesisMap[n.id] = n
 
   return nemesisMap
 }
@@ -248,9 +249,5 @@ export async function updateNemesis(
  * @param id Nemesis ID
  */
 export async function removeNemesis(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('nemesis').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Nemesis: ${error.message}`)
+  await removeCatalogRow('nemesis', id, 'Nemesis')
 }

--- a/lib/dal/neurosis.ts
+++ b/lib/dal/neurosis.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -48,14 +49,14 @@ export async function getUserCustomNeuroses(): Promise<{
 
   const { data, error } = await supabase
     .from('neurosis')
-    .select('id, custom, neurosis_name, rules')
+    .select('id, custom, neurosis_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
   if (error) throw new Error(`Error Fetching Custom Neuroses: ${error.message}`)
 
   const neurosisMap: { [key: string]: NeurosisDetail } = {}
-  for (const n of data ?? []) neurosisMap[n.id] = n
+  for (const n of data ?? []) if (!n.archived_at) neurosisMap[n.id] = n
 
   return neurosisMap
 }
@@ -124,9 +125,5 @@ export async function updateNeurosis(
  * @param id Neurosis ID
  */
 export async function removeNeurosis(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('neurosis').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Neurosis: ${error.message}`)
+  await removeCatalogRow('neurosis', id, 'Neurosis')
 }

--- a/lib/dal/pattern.ts
+++ b/lib/dal/pattern.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -97,7 +98,7 @@ export async function getUserCustomPatterns(): Promise<{
   const { data, error } = await supabase
     .from('pattern')
     .select(
-      'id, custom, pattern_name, crafting_limit, endeavor_cost, crafted_gear_id, pattern_gear_cost(cost_gear_id, quantity), pattern_resource_cost(resource_id, quantity), pattern_resource_type_cost(resource_type, quantity), pattern_innovation_requirement(innovation_id)'
+      'id, custom, pattern_name, crafting_limit, endeavor_cost, crafted_gear_id, pattern_gear_cost(cost_gear_id, quantity), pattern_resource_cost(resource_id, quantity), pattern_resource_type_cost(resource_type, quantity), pattern_innovation_requirement(innovation_id), archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -105,7 +106,8 @@ export async function getUserCustomPatterns(): Promise<{
   if (error) throw new Error(`Error Fetching Custom Patterns: ${error.message}`)
 
   const patternMap: { [key: string]: PatternDetail } = {}
-  for (const p of data ?? []) patternMap[p.id] = toPatternDetail(p)
+  for (const p of data ?? [])
+    if (!p.archived_at) patternMap[p.id] = toPatternDetail(p)
 
   return patternMap
 }
@@ -181,11 +183,7 @@ export async function updatePattern(
  * @param id Pattern ID
  */
 export async function removePattern(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('pattern').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Pattern: ${error.message}`)
+  await removeCatalogRow('pattern', id, 'Pattern')
 }
 
 /**

--- a/lib/dal/philosophy.ts
+++ b/lib/dal/philosophy.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -51,7 +52,7 @@ export async function getUserCustomPhilosophies(): Promise<{
   const { data, error } = await supabase
     .from('philosophy')
     .select(
-      'id, custom, philosophy_name, hunt_xp_milestones, tenet_knowledge_id, tier, neurosis_id'
+      'id, custom, philosophy_name, hunt_xp_milestones, tenet_knowledge_id, tier, neurosis_id, archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -60,7 +61,7 @@ export async function getUserCustomPhilosophies(): Promise<{
     throw new Error(`Error Fetching Custom Philosophies: ${error.message}`)
 
   const philosophyMap: { [key: string]: PhilosophyDetail } = {}
-  for (const p of data ?? []) philosophyMap[p.id] = p
+  for (const p of data ?? []) if (!p.archived_at) philosophyMap[p.id] = p
 
   return philosophyMap
 }
@@ -141,9 +142,5 @@ export async function updatePhilosophy(
  * @param id Philosophy ID
  */
 export async function removePhilosophy(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('philosophy').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Philosophy: ${error.message}`)
+  await removeCatalogRow('philosophy', id, 'Philosophy')
 }

--- a/lib/dal/principle.ts
+++ b/lib/dal/principle.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { CampaignType, DatabaseCampaignType } from '@/lib/enums'
@@ -53,7 +54,7 @@ export async function getUserCustomPrinciples(): Promise<{
   const { data, error } = await supabase
     .from('principle')
     .select(
-      'id, custom, principle_name, option_1_name, option_2_name, campaign_types, option_1_rules, option_2_rules'
+      'id, custom, principle_name, option_1_name, option_2_name, campaign_types, option_1_rules, option_2_rules, archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -62,7 +63,7 @@ export async function getUserCustomPrinciples(): Promise<{
     throw new Error(`Error Fetching Custom Principles: ${error.message}`)
 
   const principleMap: { [key: string]: PrincipleDetail } = {}
-  for (const p of data ?? []) principleMap[p.id] = p
+  for (const p of data ?? []) if (!p.archived_at) principleMap[p.id] = p
 
   return principleMap
 }
@@ -179,9 +180,5 @@ export async function updatePrinciple(
  * @param id Principle ID
  */
 export async function removePrinciple(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('principle').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Principle: ${error.message}`)
+  await removeCatalogRow('principle', id, 'Principle')
 }

--- a/lib/dal/quarry.ts
+++ b/lib/dal/quarry.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { MonsterNode } from '@/lib/enums'
@@ -80,7 +81,7 @@ export async function getUserCustomQuarries(): Promise<{
   const { data, error } = await supabase
     .from('quarry')
     .select(
-      'id, alternate_id, custom, monster_name, multi_monster, node, prologue, vignette_id, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome'
+      'id, alternate_id, custom, monster_name, multi_monster, node, prologue, vignette_id, instinct, basic_action, blind_spot, defeat_outcome, deployment_rules, victory_outcome, archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -88,7 +89,7 @@ export async function getUserCustomQuarries(): Promise<{
   if (error) throw new Error(`Error Fetching Custom Quarries: ${error.message}`)
 
   const quarryMap: { [key: string]: QuarryDetail } = {}
-  for (const q of data ?? []) quarryMap[q.id] = q
+  for (const q of data ?? []) if (!q.archived_at) quarryMap[q.id] = q
 
   return quarryMap
 }
@@ -245,9 +246,5 @@ export async function updateQuarry(
  * @param id Quarry ID
  */
 export async function removeQuarry(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('quarry').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Quarry: ${error.message}`)
+  await removeCatalogRow('quarry', id, 'Quarry')
 }

--- a/lib/dal/resource.ts
+++ b/lib/dal/resource.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -77,7 +78,7 @@ export async function getUserCustomResources(): Promise<{
   const { data, error } = await supabase
     .from('resource')
     .select(
-      'id, custom, resource_name, category, quarry_id, resource_types, pattern_id, rules, quarry(monster_name, node)'
+      'id, custom, resource_name, category, quarry_id, resource_types, pattern_id, rules, quarry(monster_name, node), archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -109,7 +110,8 @@ export async function getUserCustomResources(): Promise<{
     }
   }
 
-  for (const r of data ?? []) resourceMap[r.id] = toDetail(r)
+  for (const r of data ?? [])
+    if (!r.archived_at) resourceMap[r.id] = toDetail(r)
 
   return resourceMap
 }
@@ -198,9 +200,5 @@ export async function updateResource(
  * @param id Resource ID
  */
 export async function removeResource(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('resource').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Resource: ${error.message}`)
+  await removeCatalogRow('resource', id, 'Resource')
 }

--- a/lib/dal/secret-fighting-art.ts
+++ b/lib/dal/secret-fighting-art.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -53,7 +54,7 @@ export async function getUserCustomSecretFightingArts(): Promise<{
 
   const { data, error } = await supabase
     .from('secret_fighting_art')
-    .select('id, custom, secret_fighting_art_name, rules')
+    .select('id, custom, secret_fighting_art_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
@@ -63,7 +64,7 @@ export async function getUserCustomSecretFightingArts(): Promise<{
     )
 
   const secretFightingArtMap: { [key: string]: SecretFightingArtDetail } = {}
-  for (const s of data ?? []) secretFightingArtMap[s.id] = s
+  for (const s of data ?? []) if (!s.archived_at) secretFightingArtMap[s.id] = s
 
   return secretFightingArtMap
 }
@@ -137,13 +138,5 @@ export async function updateSecretFightingArt(
  * @param id Secret Fighting Art ID
  */
 export async function removeSecretFightingArt(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase
-    .from('secret_fighting_art')
-    .delete()
-    .eq('id', id)
-
-  if (error)
-    throw new Error(`Error Removing Secret Fighting Art: ${error.message}`)
+  await removeCatalogRow('secret_fighting_art', id, 'Secret Fighting Art')
 }

--- a/lib/dal/seed-pattern.ts
+++ b/lib/dal/seed-pattern.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -75,7 +76,7 @@ export async function getUserCustomSeedPatterns(): Promise<{
   const { data, error } = await supabase
     .from('seed_pattern')
     .select(
-      'id, custom, seed_pattern_name, crafting_limit, crafting_steps, endeavor_cost, era, keywords, requirements, crafted_gear_id, seed_pattern_gear_cost(cost_gear_id, quantity)'
+      'id, custom, seed_pattern_name, crafting_limit, crafting_steps, endeavor_cost, era, keywords, requirements, crafted_gear_id, seed_pattern_gear_cost(cost_gear_id, quantity), archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -84,7 +85,8 @@ export async function getUserCustomSeedPatterns(): Promise<{
     throw new Error(`Error Fetching Custom Seed Patterns: ${error.message}`)
 
   const seedPatternMap: { [key: string]: SeedPatternDetail } = {}
-  for (const s of data ?? []) seedPatternMap[s.id] = toSeedPatternDetail(s)
+  for (const s of data ?? [])
+    if (!s.archived_at) seedPatternMap[s.id] = toSeedPatternDetail(s)
 
   return seedPatternMap
 }
@@ -159,11 +161,7 @@ export async function updateSeedPattern(
  * @param id Seed Pattern ID
  */
 export async function removeSeedPattern(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('seed_pattern').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Seed Pattern: ${error.message}`)
+  await removeCatalogRow('seed_pattern', id, 'Seed Pattern')
 }
 
 /**

--- a/lib/dal/settlement.ts
+++ b/lib/dal/settlement.ts
@@ -53,6 +53,7 @@ import {
 } from '@/lib/dal/settlement-timeline-year'
 import { addSquiresOfTheCitadelSurvivors } from '@/lib/dal/survivor'
 import { getUserId } from '@/lib/dal/user'
+import { getUserSubscription } from '@/lib/dal/user-subscription'
 import { getWandererTimelineYears } from '@/lib/dal/wanderer-timeline-year'
 import { Tables } from '@/lib/database.types'
 import {
@@ -62,6 +63,7 @@ import {
   SurvivorType
 } from '@/lib/enums'
 import { FREE_TIER_SETTLEMENT_LIMIT_MESSAGE } from '@/lib/messages'
+import { canCreateUnlimitedSettlements } from '@/lib/subscription-entitlements'
 import { createClient } from '@/lib/supabase/client'
 import { SettlementDetail, SettlementTimelineYearDetail } from '@/lib/types'
 import { NewSettlementInput } from '@/schemas/new-settlement-input'
@@ -104,10 +106,11 @@ export async function getOwnedSettlementCount(): Promise<number> {
  * locations / timeline / CC-reward data is then committed in one final
  * parallel batch.
  *
- * Enforces the free-tier ownership cap before any inserts run. The check is
- * application-layer only — admins driving the database directly
- * (Supabase Studio, integration tests via service role, etc.) bypass it
- * naturally because they never enter this code path.
+ * Enforces the free-tier ownership cap before any inserts run. Active paid
+ * settlement tiers skip the cap. The check is application-layer only — admins
+ * driving the database directly (Supabase Studio, integration tests via
+ * service role, etc.) bypass it naturally because they never enter this code
+ * path.
  *
  * @param options Settlement Input Data
  * @returns Settlement ID
@@ -118,13 +121,17 @@ export async function createSettlement(
   const userId = await getUserId()
   const supabase = createClient()
 
-  // Free-tier ownership cap. Counted up-front so we fail fast before any of
-  // the template fan-out work runs.
-  const ownedCount = await getOwnedSettlementCount()
-  if (ownedCount >= FREE_TIER_SETTLEMENT_LIMIT)
-    throw new Error(
-      FREE_TIER_SETTLEMENT_LIMIT_MESSAGE(FREE_TIER_SETTLEMENT_LIMIT)
-    )
+  // Free-tier ownership cap. Paid settlement tiers skip the count entirely;
+  // free/missing/non-entitling subscriptions fail fast before any template
+  // fan-out work runs.
+  const userSubscription = await getUserSubscription()
+  if (!canCreateUnlimitedSettlements(userSubscription)) {
+    const ownedCount = await getOwnedSettlementCount()
+    if (ownedCount >= FREE_TIER_SETTLEMENT_LIMIT)
+      throw new Error(
+        FREE_TIER_SETTLEMENT_LIMIT_MESSAGE(FREE_TIER_SETTLEMENT_LIMIT)
+      )
+  }
 
   const template = await {
     [CampaignType.CUSTOM]: getCustomCampaignTemplate,

--- a/lib/dal/settlement.ts
+++ b/lib/dal/settlement.ts
@@ -123,8 +123,15 @@ export async function createSettlement(
 
   // Free-tier ownership cap. Paid settlement tiers skip the count entirely;
   // free/missing/non-entitling subscriptions fail fast before any template
-  // fan-out work runs.
-  const userSubscription = await getUserSubscription()
+  // fan-out work runs. If the entitlement lookup fails, fall back to the
+  // free-tier cap so billing/RPC hiccups do not block under-cap users.
+  let userSubscription: Awaited<ReturnType<typeof getUserSubscription>> = null
+  try {
+    userSubscription = await getUserSubscription()
+  } catch (error) {
+    console.error('Settlement Subscription Entitlement Error:', error)
+  }
+
   if (!canCreateUnlimitedSettlements(userSubscription)) {
     const ownedCount = await getOwnedSettlementCount()
     if (ownedCount >= FREE_TIER_SETTLEMENT_LIMIT)

--- a/lib/dal/strain-milestone.ts
+++ b/lib/dal/strain-milestone.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -54,7 +55,7 @@ export async function getUserCustomStrainMilestones(): Promise<{
   const { data, error } = await supabase
     .from('strain_milestone')
     .select(
-      'id, custom, strain_milestone_name, milestone_condition, permanent_effect'
+      'id, custom, strain_milestone_name, milestone_condition, permanent_effect, archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -63,7 +64,7 @@ export async function getUserCustomStrainMilestones(): Promise<{
     throw new Error(`Error Fetching Custom Strain Milestones: ${error.message}`)
 
   const strainMilestoneMap: { [key: string]: StrainMilestoneDetail } = {}
-  for (const s of data ?? []) strainMilestoneMap[s.id] = s
+  for (const s of data ?? []) if (!s.archived_at) strainMilestoneMap[s.id] = s
 
   return strainMilestoneMap
 }
@@ -138,13 +139,5 @@ export async function updateStrainMilestone(
  * @param id Strain Milestone ID
  */
 export async function removeStrainMilestone(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase
-    .from('strain_milestone')
-    .delete()
-    .eq('id', id)
-
-  if (error)
-    throw new Error(`Error Removing Strain Milestone: ${error.message}`)
+  await removeCatalogRow('strain_milestone', id, 'Strain Milestone')
 }

--- a/lib/dal/survivor-status.ts
+++ b/lib/dal/survivor-status.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { createClient } from '@/lib/supabase/client'
 import { SurvivorStatusDetail } from '@/lib/types'
@@ -49,7 +50,7 @@ export async function getUserCustomSurvivorStatuses(): Promise<{
 
   const { data, error } = await supabase
     .from('survivor_status')
-    .select('id, custom, survivor_status_name, rules')
+    .select('id, custom, survivor_status_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
@@ -57,7 +58,7 @@ export async function getUserCustomSurvivorStatuses(): Promise<{
     throw new Error(`Error Fetching Custom Survivor Statuses: ${error.message}`)
 
   const map: { [key: string]: SurvivorStatusDetail } = {}
-  for (const s of data ?? []) map[s.id] = s
+  for (const s of data ?? []) if (!s.archived_at) map[s.id] = s
 
   return map
 }
@@ -124,11 +125,7 @@ export async function updateSurvivorStatus(
  * @param id Survivor Status ID
  */
 export async function removeSurvivorStatus(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('survivor_status').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Survivor Status: ${error.message}`)
+  await removeCatalogRow('survivor_status', id, 'Survivor Status')
 }
 
 /**

--- a/lib/dal/trait.ts
+++ b/lib/dal/trait.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { createClient } from '@/lib/supabase/client'
 import { TraitDetail } from '@/lib/types'
@@ -45,14 +46,14 @@ export async function getUserCustomTraits(): Promise<{
 
   const { data, error } = await supabase
     .from('trait')
-    .select('id, custom, trait_name, rules')
+    .select('id, custom, trait_name, rules, archived_at')
     .eq('custom', true)
     .eq('user_id', userId)
 
   if (error) throw new Error(`Error Fetching Custom Traits: ${error.message}`)
 
   const map: { [key: string]: TraitDetail } = {}
-  for (const t of data ?? []) map[t.id] = t
+  for (const t of data ?? []) if (!t.archived_at) map[t.id] = t
 
   return map
 }
@@ -116,11 +117,7 @@ export async function updateTrait(
  * @param id Trait ID
  */
 export async function removeTrait(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('trait').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Trait: ${error.message}`)
+  await removeCatalogRow('trait', id, 'Trait')
 }
 
 /**

--- a/lib/dal/wanderer.ts
+++ b/lib/dal/wanderer.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -171,11 +172,7 @@ export async function updateWanderer(
  * @param id Wanderer ID
  */
 export async function removeWanderer(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('wanderer').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Wanderer: ${error.message}`)
+  await removeCatalogRow('wanderer', id, 'Wanderer')
 }
 
 /**
@@ -194,7 +191,7 @@ export async function getCustomWanderers(): Promise<{
   const { data, error } = await supabase
     .from('wanderer')
     .select(
-      'id, custom, accuracy, arc, courage, disposition, evasion, fighting_art_ids, gender, hunt_xp, hunt_xp_rank_up, insanity, luck, lumi, movement, wanderer_name, permanent_injuries, rare_gear_ids, speed, strength, survival, systemic_pressure, torment, understanding, abilities_impairments:wanderer_ability_impairment(ability_impairment(id, custom, ability_impairment_name, rules))'
+      'id, custom, accuracy, arc, courage, disposition, evasion, fighting_art_ids, gender, hunt_xp, hunt_xp_rank_up, insanity, luck, lumi, movement, wanderer_name, permanent_injuries, rare_gear_ids, speed, strength, survival, systemic_pressure, torment, understanding, abilities_impairments:wanderer_ability_impairment(ability_impairment(id, custom, ability_impairment_name, rules)), archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -204,7 +201,8 @@ export async function getCustomWanderers(): Promise<{
 
   const wandererMap: { [key: string]: WandererDetail } = {}
   for (const w of data ?? [])
-    wandererMap[w.id] = flattenWanderer(w as unknown as RawWandererRow)
+    if (!w.archived_at)
+      wandererMap[w.id] = flattenWanderer(w as unknown as RawWandererRow)
 
   return wandererMap
 }

--- a/lib/dal/weapon-type.ts
+++ b/lib/dal/weapon-type.ts
@@ -1,3 +1,4 @@
+import { removeCatalogRow } from '@/lib/dal/catalog-archive'
 import { getUserId, getUserIdOrNull } from '@/lib/dal/user'
 import { TablesInsert, TablesUpdate } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
@@ -52,7 +53,7 @@ export async function getUserCustomWeaponTypes(): Promise<{
   const { data, error } = await supabase
     .from('weapon_type')
     .select(
-      'id, custom, weapon_type_name, specialist_proficiency_rules, master_proficiency_rules'
+      'id, custom, weapon_type_name, specialist_proficiency_rules, master_proficiency_rules, archived_at'
     )
     .eq('custom', true)
     .eq('user_id', userId)
@@ -61,7 +62,7 @@ export async function getUserCustomWeaponTypes(): Promise<{
     throw new Error(`Error Fetching Custom Weapon Types: ${error.message}`)
 
   const weaponTypeMap: { [key: string]: WeaponTypeDetail } = {}
-  for (const w of data ?? []) weaponTypeMap[w.id] = w
+  for (const w of data ?? []) if (!w.archived_at) weaponTypeMap[w.id] = w
 
   return weaponTypeMap
 }
@@ -135,9 +136,5 @@ export async function updateWeaponType(
  * @param id Weapon Type ID
  */
 export async function removeWeaponType(id: string): Promise<void> {
-  const supabase = createClient()
-
-  const { error } = await supabase.from('weapon_type').delete().eq('id', id)
-
-  if (error) throw new Error(`Error Removing Weapon Type: ${error.message}`)
+  await removeCatalogRow('weapon_type', id, 'Weapon Type')
 }

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -37,6 +37,7 @@ export type Database = {
       ability_impairment: {
         Row: {
           ability_impairment_name: string
+          archived_at: string | null
           created_at: string
           custom: boolean
           id: string
@@ -46,6 +47,7 @@ export type Database = {
         }
         Insert: {
           ability_impairment_name: string
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -55,6 +57,7 @@ export type Database = {
         }
         Update: {
           ability_impairment_name?: string
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -66,6 +69,7 @@ export type Database = {
       }
       armor_set: {
         Row: {
+          archived_at: string | null
           armor_set_name: string
           bonuses: string | null
           created_at: string
@@ -75,6 +79,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           armor_set_name: string
           bonuses?: string | null
           created_at?: string
@@ -84,6 +89,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           armor_set_name?: string
           bonuses?: string | null
           created_at?: string
@@ -164,6 +170,7 @@ export type Database = {
       }
       character: {
         Row: {
+          archived_at: string | null
           character_name: string
           created_at: string
           custom: boolean
@@ -173,6 +180,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           character_name: string
           created_at?: string
           custom?: boolean
@@ -182,6 +190,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           character_name?: string
           created_at?: string
           custom?: boolean
@@ -194,6 +203,7 @@ export type Database = {
       }
       collective_cognition_reward: {
         Row: {
+          archived_at: string | null
           collective_cognition: number
           created_at: string
           custom: boolean
@@ -204,6 +214,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           collective_cognition?: number
           created_at?: string
           custom?: boolean
@@ -214,6 +225,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           collective_cognition?: number
           created_at?: string
           custom?: boolean
@@ -227,6 +239,7 @@ export type Database = {
       }
       constellation: {
         Row: {
+          archived_at: string | null
           constellation_name: string
           created_at: string
           custom: boolean
@@ -236,6 +249,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           constellation_name: string
           created_at?: string
           custom?: boolean
@@ -245,6 +259,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           constellation_name?: string
           created_at?: string
           custom?: boolean
@@ -257,6 +272,7 @@ export type Database = {
       }
       disorder: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           disorder_name: string
@@ -266,6 +282,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           disorder_name: string
@@ -275,6 +292,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           disorder_name?: string
@@ -287,6 +305,7 @@ export type Database = {
       }
       fighting_art: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           fighting_art_name: string
@@ -296,6 +315,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           fighting_art_name: string
@@ -305,6 +325,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           fighting_art_name?: string
@@ -325,6 +346,7 @@ export type Database = {
           affinity_left: Database["public"]["Enums"]["affinity"] | null
           affinity_right: Database["public"]["Enums"]["affinity"] | null
           affinity_top: Database["public"]["Enums"]["affinity"] | null
+          archived_at: string | null
           armor_location: Database["public"]["Enums"]["armor_location"] | null
           armor_points: number | null
           created_at: string
@@ -349,6 +371,7 @@ export type Database = {
           affinity_left?: Database["public"]["Enums"]["affinity"] | null
           affinity_right?: Database["public"]["Enums"]["affinity"] | null
           affinity_top?: Database["public"]["Enums"]["affinity"] | null
+          archived_at?: string | null
           armor_location?: Database["public"]["Enums"]["armor_location"] | null
           armor_points?: number | null
           created_at?: string
@@ -373,6 +396,7 @@ export type Database = {
           affinity_left?: Database["public"]["Enums"]["affinity"] | null
           affinity_right?: Database["public"]["Enums"]["affinity"] | null
           affinity_top?: Database["public"]["Enums"]["affinity"] | null
+          archived_at?: string | null
           armor_location?: Database["public"]["Enums"]["armor_location"] | null
           armor_points?: number | null
           created_at?: string
@@ -1120,6 +1144,7 @@ export type Database = {
       }
       innovation: {
         Row: {
+          archived_at: string | null
           benefits: string | null
           consequences: string | null
           created_at: string
@@ -1131,6 +1156,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           benefits?: string | null
           consequences?: string | null
           created_at?: string
@@ -1142,6 +1168,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           benefits?: string | null
           consequences?: string | null
           created_at?: string
@@ -1156,6 +1183,7 @@ export type Database = {
       }
       knowledge: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           id: string
@@ -1168,6 +1196,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -1180,6 +1209,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -1203,6 +1233,7 @@ export type Database = {
       }
       location: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           id: string
@@ -1212,6 +1243,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -1221,6 +1253,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -1248,6 +1281,7 @@ export type Database = {
       }
       milestone: {
         Row: {
+          archived_at: string | null
           campaign_types: Database["public"]["Enums"]["campaign_type"][]
           created_at: string
           custom: boolean
@@ -1260,6 +1294,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           campaign_types?: Database["public"]["Enums"]["campaign_type"][]
           created_at?: string
           custom?: boolean
@@ -1272,6 +1307,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           campaign_types?: Database["public"]["Enums"]["campaign_type"][]
           created_at?: string
           custom?: boolean
@@ -1287,6 +1323,7 @@ export type Database = {
       }
       mood: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           id: string
@@ -1296,6 +1333,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -1305,6 +1343,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -1318,6 +1357,7 @@ export type Database = {
       nemesis: {
         Row: {
           alternate_id: string | null
+          archived_at: string | null
           basic_action: string | null
           blind_spot: string | null
           created_at: string
@@ -1336,6 +1376,7 @@ export type Database = {
         }
         Insert: {
           alternate_id?: string | null
+          archived_at?: string | null
           basic_action?: string | null
           blind_spot?: string | null
           created_at?: string
@@ -1354,6 +1395,7 @@ export type Database = {
         }
         Update: {
           alternate_id?: string | null
+          archived_at?: string | null
           basic_action?: string | null
           blind_spot?: string | null
           created_at?: string
@@ -1684,6 +1726,7 @@ export type Database = {
       }
       neurosis: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           id: string
@@ -1693,6 +1736,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -1702,6 +1746,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -1712,8 +1757,36 @@ export type Database = {
         }
         Relationships: []
       }
+      notification: {
+        Row: {
+          created_at: string
+          id: string
+          kind: string
+          payload: Json
+          read_at: string | null
+          recipient_user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          kind: string
+          payload?: Json
+          read_at?: string | null
+          recipient_user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          kind?: string
+          payload?: Json
+          read_at?: string | null
+          recipient_user_id?: string
+        }
+        Relationships: []
+      }
       pattern: {
         Row: {
+          archived_at: string | null
           crafted_gear_id: string | null
           crafting_limit: number | null
           created_at: string
@@ -1725,6 +1798,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           crafted_gear_id?: string | null
           crafting_limit?: number | null
           created_at?: string
@@ -1736,6 +1810,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           crafted_gear_id?: string | null
           crafting_limit?: number | null
           created_at?: string
@@ -1880,6 +1955,7 @@ export type Database = {
       }
       philosophy: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           hunt_xp_milestones: number[] | null
@@ -1892,6 +1968,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           hunt_xp_milestones?: number[] | null
@@ -1904,6 +1981,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           hunt_xp_milestones?: number[] | null
@@ -1969,6 +2047,7 @@ export type Database = {
       }
       principle: {
         Row: {
+          archived_at: string | null
           campaign_types: Database["public"]["Enums"]["campaign_type"][]
           created_at: string
           custom: boolean
@@ -1982,6 +2061,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           campaign_types?: Database["public"]["Enums"]["campaign_type"][]
           created_at?: string
           custom?: boolean
@@ -1995,6 +2075,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           campaign_types?: Database["public"]["Enums"]["campaign_type"][]
           created_at?: string
           custom?: boolean
@@ -2012,6 +2093,7 @@ export type Database = {
       quarry: {
         Row: {
           alternate_id: string | null
+          archived_at: string | null
           basic_action: string | null
           blind_spot: string | null
           created_at: string
@@ -2031,6 +2113,7 @@ export type Database = {
         }
         Insert: {
           alternate_id?: string | null
+          archived_at?: string | null
           basic_action?: string | null
           blind_spot?: string | null
           created_at?: string
@@ -2050,6 +2133,7 @@ export type Database = {
         }
         Update: {
           alternate_id?: string | null
+          archived_at?: string | null
           basic_action?: string | null
           blind_spot?: string | null
           created_at?: string
@@ -2514,6 +2598,7 @@ export type Database = {
       }
       resource: {
         Row: {
+          archived_at: string | null
           category: Database["public"]["Enums"]["resource_category"]
           created_at: string
           custom: boolean
@@ -2528,6 +2613,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           category: Database["public"]["Enums"]["resource_category"]
           created_at?: string
           custom?: boolean
@@ -2542,6 +2628,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           category?: Database["public"]["Enums"]["resource_category"]
           created_at?: string
           custom?: boolean
@@ -2581,6 +2668,7 @@ export type Database = {
       }
       secret_fighting_art: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           id: string
@@ -2590,6 +2678,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -2599,6 +2688,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -2611,6 +2701,7 @@ export type Database = {
       }
       seed_pattern: {
         Row: {
+          archived_at: string | null
           crafted_gear_id: string | null
           crafting_limit: number | null
           crafting_steps: string | null
@@ -2626,6 +2717,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           crafted_gear_id?: string | null
           crafting_limit?: number | null
           crafting_steps?: string | null
@@ -2641,6 +2733,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           crafted_gear_id?: string | null
           crafting_limit?: number | null
           crafting_steps?: string | null
@@ -3990,6 +4083,7 @@ export type Database = {
       }
       strain_milestone: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           id: string
@@ -4000,6 +4094,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -4010,6 +4105,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -4690,6 +4786,7 @@ export type Database = {
       }
       survivor_status: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           id: string
@@ -4699,6 +4796,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -4708,6 +4806,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -4720,6 +4819,7 @@ export type Database = {
       }
       trait: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           id: string
@@ -4729,6 +4829,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -4738,6 +4839,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -4832,6 +4934,7 @@ export type Database = {
         Row: {
           accuracy: number
           arc: boolean
+          archived_at: string | null
           courage: number
           created_at: string
           custom: boolean
@@ -4861,6 +4964,7 @@ export type Database = {
         Insert: {
           accuracy?: number
           arc?: boolean
+          archived_at?: string | null
           courage?: number
           created_at?: string
           custom?: boolean
@@ -4890,6 +4994,7 @@ export type Database = {
         Update: {
           accuracy?: number
           arc?: boolean
+          archived_at?: string | null
           courage?: number
           created_at?: string
           custom?: boolean
@@ -4994,6 +5099,7 @@ export type Database = {
       }
       weapon_type: {
         Row: {
+          archived_at: string | null
           created_at: string
           custom: boolean
           id: string
@@ -5004,6 +5110,7 @@ export type Database = {
           weapon_type_name: string
         }
         Insert: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string
@@ -5014,6 +5121,7 @@ export type Database = {
           weapon_type_name: string
         }
         Update: {
+          archived_at?: string | null
           created_at?: string
           custom?: boolean
           id?: string

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -261,6 +261,30 @@ export const CUSTOM_MONSTER_UPDATED_MESSAGE = (monsterType: MonsterType) =>
     : 'The quarry shifts in the darkness.'
 
 /**
+ * Catalog Restored
+ *
+ * @returns Catalog Restored Message
+ */
+export const CATALOG_RESTORED_MESSAGE = () =>
+  'The lantern finds what was nearly lost.'
+
+/**
+ * Catalog Permanently Deleted
+ *
+ * @returns Catalog Permanently Deleted Message
+ */
+export const CATALOG_PERMANENTLY_DELETED_MESSAGE = () =>
+  'The record is ash, and no settlement remembers it.'
+
+/**
+ * Catalog Permanent Delete Blocked
+ *
+ * @returns Catalog Permanent Delete Blocked Message
+ */
+export const CATALOG_PERMANENT_DELETE_BLOCKED_MESSAGE = () =>
+  'A settlement still clings to this memory. Remove it from every settlement before consigning it to the dark.'
+
+/**
  * Departing Bonus Removed
  *
  * @returns Departing Bonus Removed Message
@@ -1459,16 +1483,15 @@ export const SETTLEMENT_CREATED_MESSAGE = () =>
  * Free-Tier Settlement Limit Reached
  *
  * Surfaced both as a tooltip on the "Found a settlement" affordance and as a
- * toast on the rare race where a user submits the form while already at the
- * cap. Paid tiers that lift this cap are still in progress, so the copy
- * explicitly calls that out and reminds the user that shared settlements
- * remain unlimited.
+ * toast on the rare race where a free user submits the form while already at
+ * the cap. Paid settlement tiers can found beyond this limit; shared
+ * settlements remain unlimited.
  *
  * @param limit Maximum Settlements Allowed On The Free Tier
  * @returns Free-Tier Settlement Limit Message
  */
 export const FREE_TIER_SETTLEMENT_LIMIT_MESSAGE = (limit: number) =>
-  `The lantern hoard is full — free survivors may keep watch over ${limit} settlements. Paid tiers are still being forged. Settlements shared with you remain unlimited.`
+  `The lantern hoard is full — free survivors may keep watch over ${limit} settlements. Light a Lantern to found more. Settlements shared with you remain unlimited.`
 
 /**
  * Settlement Deleted

--- a/lib/subscription-entitlements.ts
+++ b/lib/subscription-entitlements.ts
@@ -1,0 +1,28 @@
+import { PlanSlug, UserSubscriptionDetail } from '@/lib/types'
+
+const UNLIMITED_OWNED_SETTLEMENT_PLAN_IDS: ReadonlySet<PlanSlug> = new Set([
+  'lantern',
+  'lantern_hoard'
+])
+
+const ENTITLED_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing'])
+
+/**
+ * Can Create Unlimited Settlements
+ *
+ * Returns true when the current subscription is on a paid settlement tier and
+ * still in an entitling Stripe status. Missing, free, canceled, past-due, and
+ * incomplete rows all fall back to the free-tier owned-settlement cap.
+ *
+ * @param subscription User Subscription Detail
+ * @returns Whether The User Can Create Unlimited Owned Settlements
+ */
+export function canCreateUnlimitedSettlements(
+  subscription: Pick<UserSubscriptionDetail, 'plan_id' | 'status'> | null
+): boolean {
+  return (
+    !!subscription &&
+    ENTITLED_SUBSCRIPTION_STATUSES.has(subscription.status) &&
+    UNLIMITED_OWNED_SETTLEMENT_PLAN_IDS.has(subscription.plan_id)
+  )
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,7 +43,7 @@ export type CampaignTemplate = {
  */
 export type AbilityImpairmentDetail = Omit<
   Tables<'ability_impairment'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 > & {}
 
 /**
@@ -54,7 +54,7 @@ export type AbilityImpairmentDetail = Omit<
  */
 export type TraitDetail = Omit<
   Tables<'trait'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 > & {}
 
 /**
@@ -65,7 +65,7 @@ export type TraitDetail = Omit<
  */
 export type MoodDetail = Omit<
   Tables<'mood'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 > & {}
 
 /**
@@ -77,7 +77,7 @@ export type MoodDetail = Omit<
  */
 export type SurvivorStatusDetail = Omit<
   Tables<'survivor_status'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 > & {}
 
 /**
@@ -88,7 +88,7 @@ export type SurvivorStatusDetail = Omit<
  */
 export type CharacterDetail = Omit<
   Tables<'character'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 > & {}
 
 /**
@@ -98,7 +98,7 @@ export type CharacterDetail = Omit<
  */
 export type CollectiveCognitionRewardDetail = Omit<
   Tables<'collective_cognition_reward'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -108,7 +108,7 @@ export type CollectiveCognitionRewardDetail = Omit<
  */
 export type DisorderDetail = Omit<
   Tables<'disorder'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -118,7 +118,7 @@ export type DisorderDetail = Omit<
  */
 export type FightingArtDetail = Omit<
   Tables<'fighting_art'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -128,7 +128,7 @@ export type FightingArtDetail = Omit<
  */
 export type SecretFightingArtDetail = Omit<
   Tables<'secret_fighting_art'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -150,7 +150,7 @@ export type SeedPatternGearCostDetail = {
  */
 export type SeedPatternDetail = Omit<
   Tables<'seed_pattern'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 > & {
   /** Gear Costs Required to Craft the Seed Pattern */
   gear_costs: SeedPatternGearCostDetail[]
@@ -213,7 +213,11 @@ export type GearResourceTypeCostDetail = {
  */
 export type GearDetail = Omit<
   Tables<'gear'>,
-  'created_at' | 'updated_at' | 'user_id' | 'affinity_bonus_requirements'
+  | 'created_at'
+  | 'updated_at'
+  | 'user_id'
+  | 'affinity_bonus_requirements'
+  | 'archived_at'
 > & {
   /** Affinity Bonus Requirements */
   affinity_bonus_requirements: GearAffinityRequirementDetail[]
@@ -253,7 +257,7 @@ export type ArmorSetSlotDetail = {
  */
 export type ArmorSetDetail = Omit<
   Tables<'armor_set'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 > & {
   /** Slots Composing the Set */
   slots: ArmorSetSlotDetail[]
@@ -453,7 +457,7 @@ export type HuntSurvivorDetail = Omit<
  */
 export type InnovationDetail = Omit<
   Tables<'innovation'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -463,7 +467,7 @@ export type InnovationDetail = Omit<
  */
 export type KnowledgeDetail = Omit<
   Tables<'knowledge'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -473,7 +477,7 @@ export type KnowledgeDetail = Omit<
  */
 export type LocationDetail = Omit<
   Tables<'location'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -483,7 +487,7 @@ export type LocationDetail = Omit<
  */
 export type MilestoneDetail = Omit<
   Tables<'milestone'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -552,7 +556,7 @@ export type MonsterLevelData = {
  */
 export type NemesisDetail = Omit<
   Tables<'nemesis'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -590,7 +594,7 @@ export type NemesisTimelineDetail = Omit<
  */
 export type NeurosisDetail = Omit<
   Tables<'neurosis'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -637,7 +641,7 @@ export type PatternResourceTypeCostDetail = {
  */
 export type PatternDetail = Omit<
   Tables<'pattern'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 > & {
   /** Gear Costs Required to Craft the Pattern */
   gear_costs: PatternGearCostDetail[]
@@ -656,7 +660,7 @@ export type PatternDetail = Omit<
  */
 export type PhilosophyDetail = Omit<
   Tables<'philosophy'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -685,7 +689,7 @@ export type PlanSlug = 'free' | 'lantern' | 'lantern_hoard'
  */
 export type PrincipleDetail = Omit<
   Tables<'principle'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -695,7 +699,7 @@ export type PrincipleDetail = Omit<
  */
 export type QuarryDetail = Omit<
   Tables<'quarry'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -757,7 +761,7 @@ export type QuarryTimelineDetail = Omit<
  */
 export type ResourceDetail = Omit<
   Tables<'resource'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 > & {
   /** Quarry Monster Name (joined from quarry table) */
   quarry_monster_name: string | null
@@ -1334,7 +1338,7 @@ export type ShowdownSurvivorDetail = Omit<
  */
 export type StrainMilestoneDetail = Omit<
   Tables<'strain_milestone'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >
 
 /**
@@ -1711,7 +1715,7 @@ export interface UserSubscriptionDetail {
  */
 export type WandererDetail = Omit<
   Tables<'wanderer'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 > & {
   /** Abilities and Impairments (resolved via junction table) */
   abilities_impairments: WandererAbilityImpairmentDetail[]
@@ -1744,5 +1748,5 @@ export type WandererTimelineYearDetail = Omit<
  */
 export type WeaponTypeDetail = Omit<
   Tables<'weapon_type'>,
-  'created_at' | 'updated_at' | 'user_id'
+  'created_at' | 'updated_at' | 'user_id' | 'archived_at'
 >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.82.0",
+      "version": "0.83.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260606000000_catalog_archived_at.sql
+++ b/supabase/migrations/20260606000000_catalog_archived_at.sql
@@ -728,7 +728,7 @@ end case
 -- For archived rows, they count any settlement reference so permanent deletion
 -- only succeeds after the item is fully detached.
 if blocking_count > 0 then execute format(
-  'update public.%I set archived_at = now() where id = $1',
+  'update public.%I set archived_at = coalesce(archived_at, now()) where id = $1',
   tg_table_name
 ) using old.id;
 return null;

--- a/supabase/migrations/20260606000000_catalog_archived_at.sql
+++ b/supabase/migrations/20260606000000_catalog_archived_at.sql
@@ -1,0 +1,784 @@
+--------------------------------------------------------------------------------
+-- [E4.7] Catalog archive support.
+--
+-- Custom catalog rows now get a nullable archived_at timestamp. Author DELETEs
+-- still hard-delete rows when they are unattached or only attached to the
+-- author's own settlements. When the row is still referenced by another
+-- settlement, the delete guard marks the row archived and skips the hard delete
+-- so existing settlement joins keep rendering the custom rules text. Once a row
+-- is archived, future DELETEs are stricter: the guard only permits permanent
+-- deletion after every settlement reference has been removed.
+--------------------------------------------------------------------------------
+do $$
+declare t text;
+catalog_tables text [] := array [
+  'ability_impairment',
+  'armor_set',
+  'character',
+  'collective_cognition_reward',
+  'constellation',
+  'disorder',
+  'fighting_art',
+  'gear',
+  'innovation',
+  'knowledge',
+  'location',
+  'milestone',
+  'mood',
+  'nemesis',
+  'neurosis',
+  'pattern',
+  'philosophy',
+  'principle',
+  'quarry',
+  'resource',
+  'secret_fighting_art',
+  'seed_pattern',
+  'strain_milestone',
+  'survivor_status',
+  'trait',
+  'wanderer',
+  'weapon_type'
+];
+begin foreach t in array catalog_tables loop execute format(
+  'alter table public.%I add column if not exists archived_at timestamptz;',
+  t
+);
+execute format(
+  'alter policy "Allow select for authenticated and non-custom" on public.%I using (not custom and archived_at is null);',
+  t
+);
+end loop;
+end $$;
+create or replace function public.enforce_catalog_delete_guard() returns trigger language plpgsql security definer
+set search_path = '' as $$
+declare blocking_count int := 0;
+blocking_names text [] := array []::text [];
+begin -- Bypass for service-role / admin contexts. Triggers fire even when RLS
+-- is bypassed, so fixture teardown and auth.users cascade-deletes must
+-- skip the guard explicitly. `public.is_admin()` covers the
+-- `auth.role() = 'admin'` case (and stays in lock-step with that helper
+-- if its definition ever changes). The two explicit checks handle the
+-- Supabase service_role and the no-auth / direct-DB context (where
+-- `auth.role()` returns NULL) that `is_admin()` would not match.
+if (
+  auth.role() = 'service_role'
+  or auth.role() is null
+  or public.is_admin()
+) then return old;
+end if;
+-- Non-custom rows: catalog seed data. The RLS policies govern these;
+-- the guard does not apply.
+if not old.custom then return old;
+end if;
+case
+  tg_table_name
+  when 'ability_impairment' then with blocking as (
+    select distinct s.id,
+      s.settlement_name
+    from public.survivor_ability_impairment j
+      join public.survivor sv on sv.id = j.survivor_id
+      join public.settlement s on s.id = sv.settlement_id
+    where j.ability_impairment_id = old.id
+      and (
+        old.archived_at is not null
+        or s.user_id <> old.user_id
+      )
+  )
+  select count(*),
+    (
+      array_agg(
+        settlement_name
+        order by settlement_name
+      )
+    ) [1:3] into blocking_count,
+    blocking_names
+  from blocking;
+when 'armor_set' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.gear_grid gg
+    join public.survivor sv on sv.id = gg.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where gg.selected_armor_set_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'collective_cognition_reward' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_collective_cognition_reward j
+    join public.settlement s on s.id = j.settlement_id
+  where j.collective_cognition_reward_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'disorder' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor_disorder j
+    join public.survivor sv on sv.id = j.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where j.disorder_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'fighting_art' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor_fighting_art j
+    join public.survivor sv on sv.id = j.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where j.fighting_art_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'gear' then -- Settlement-attached gear: settlement_gear, survivor_cursed_gear,
+-- and any of the 9 gear_grid pos_* slots (3x3 layout).
+with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_gear j
+    join public.settlement s on s.id = j.settlement_id
+  where j.gear_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor_cursed_gear j
+    join public.survivor sv on sv.id = j.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where j.gear_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.gear_grid gg
+    join public.survivor sv on sv.id = gg.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where (
+      gg.pos_top_left = old.id
+      or gg.pos_top_center = old.id
+      or gg.pos_top_right = old.id
+      or gg.pos_mid_left = old.id
+      or gg.pos_mid_center = old.id
+      or gg.pos_mid_right = old.id
+      or gg.pos_bottom_left = old.id
+      or gg.pos_bottom_center = old.id
+      or gg.pos_bottom_right = old.id
+    )
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'innovation' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_innovation j
+    join public.settlement s on s.id = j.settlement_id
+  where j.innovation_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'knowledge' then -- knowledge is reachable via settlement_knowledge (direct) AND via
+-- three survivor columns (knowledge_1_id, knowledge_2_id,
+-- tenet_knowledge_id), matching the SELECT predicate in
+-- 20260515000000_catalog_transitive_via_survivor.sql.
+with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_knowledge j
+    join public.settlement s on s.id = j.settlement_id
+  where j.knowledge_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor sv
+    join public.settlement s on s.id = sv.settlement_id
+  where (
+      sv.knowledge_1_id = old.id
+      or sv.knowledge_2_id = old.id
+      or sv.tenet_knowledge_id = old.id
+    )
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'location' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_location j
+    join public.settlement s on s.id = j.settlement_id
+  where j.location_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'milestone' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_milestone j
+    join public.settlement s on s.id = j.settlement_id
+  where j.milestone_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'mood' then -- mood is reachable via four hunt/showdown/quarry/nemesis junctions,
+-- matching the SELECT predicate in
+-- 20260516000000_catalog_transitive_hunt_showdown.sql.
+with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.hunt_monster_mood j
+    join public.hunt_monster m on m.id = j.hunt_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.mood_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.showdown_monster_mood j
+    join public.showdown_monster m on m.id = j.showdown_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.mood_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.quarry_level_mood j
+    join public.quarry_level ql on ql.id = j.quarry_level_id
+    join public.settlement_quarry sq on sq.quarry_id = ql.quarry_id
+    join public.settlement s on s.id = sq.settlement_id
+  where j.mood_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.nemesis_level_mood j
+    join public.nemesis_level nl on nl.id = j.nemesis_level_id
+    join public.settlement_nemesis sn on sn.nemesis_id = nl.nemesis_id
+    join public.settlement s on s.id = sn.settlement_id
+  where j.mood_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'nemesis' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_nemesis j
+    join public.settlement s on s.id = j.settlement_id
+  where j.nemesis_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'neurosis' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor sv
+    join public.settlement s on s.id = sv.settlement_id
+  where sv.neurosis_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'pattern' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_pattern j
+    join public.settlement s on s.id = j.settlement_id
+  where j.pattern_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'philosophy' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_philosophy j
+    join public.settlement s on s.id = j.settlement_id
+  where j.philosophy_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor sv
+    join public.settlement s on s.id = sv.settlement_id
+  where sv.philosophy_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'principle' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_principle j
+    join public.settlement s on s.id = j.settlement_id
+  where j.principle_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'quarry' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_quarry j
+    join public.settlement s on s.id = j.settlement_id
+  where j.quarry_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'resource' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_resource j
+    join public.settlement s on s.id = j.settlement_id
+  where j.resource_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'secret_fighting_art' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor_secret_fighting_art j
+    join public.survivor sv on sv.id = j.survivor_id
+    join public.settlement s on s.id = sv.settlement_id
+  where j.secret_fighting_art_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'seed_pattern' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.settlement_seed_pattern j
+    join public.settlement s on s.id = j.settlement_id
+  where j.seed_pattern_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'survivor_status' then -- survivor_status is reachable via four hunt/showdown/quarry/nemesis
+-- junctions (parallel to mood/trait).
+with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.hunt_monster_survivor_status j
+    join public.hunt_monster m on m.id = j.hunt_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.survivor_status_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.showdown_monster_survivor_status j
+    join public.showdown_monster m on m.id = j.showdown_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.survivor_status_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.quarry_level_survivor_status j
+    join public.quarry_level ql on ql.id = j.quarry_level_id
+    join public.settlement_quarry sq on sq.quarry_id = ql.quarry_id
+    join public.settlement s on s.id = sq.settlement_id
+  where j.survivor_status_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.nemesis_level_survivor_status j
+    join public.nemesis_level nl on nl.id = j.nemesis_level_id
+    join public.settlement_nemesis sn on sn.nemesis_id = nl.nemesis_id
+    join public.settlement s on s.id = sn.settlement_id
+  where j.survivor_status_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'trait' then -- trait is reachable via four hunt/showdown/quarry/nemesis junctions,
+-- matching the SELECT predicate in
+-- 20260516000000_catalog_transitive_hunt_showdown.sql.
+with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.hunt_monster_trait j
+    join public.hunt_monster m on m.id = j.hunt_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.trait_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.showdown_monster_trait j
+    join public.showdown_monster m on m.id = j.showdown_monster_id
+    join public.settlement s on s.id = m.settlement_id
+  where j.trait_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.quarry_level_trait j
+    join public.quarry_level ql on ql.id = j.quarry_level_id
+    join public.settlement_quarry sq on sq.quarry_id = ql.quarry_id
+    join public.settlement s on s.id = sq.settlement_id
+  where j.trait_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+  union
+  select distinct s.id,
+    s.settlement_name
+  from public.nemesis_level_trait j
+    join public.nemesis_level nl on nl.id = j.nemesis_level_id
+    join public.settlement_nemesis sn on sn.nemesis_id = nl.nemesis_id
+    join public.settlement s on s.id = sn.settlement_id
+  where j.trait_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+when 'weapon_type' then with blocking as (
+  select distinct s.id,
+    s.settlement_name
+  from public.survivor sv
+    join public.settlement s on s.id = sv.settlement_id
+  where sv.weapon_type_id = old.id
+    and (
+      old.archived_at is not null
+      or s.user_id <> old.user_id
+    )
+)
+select count(*),
+  (
+    array_agg(
+      settlement_name
+      order by settlement_name
+    )
+  ) [1:3] into blocking_count,
+  blocking_names
+from blocking;
+else -- character / constellation / strain_milestone / wanderer have no
+-- settlement-attached junctions today. The trigger still fires for
+-- symmetry (so adding a future settlement junction can plug into
+-- the same dispatch), but blocking_count stays 0 and the delete
+-- proceeds.
+null;
+end case
+;
+-- For active rows, the branch predicates above count non-author settlements.
+-- For archived rows, they count any settlement reference so permanent deletion
+-- only succeeds after the item is fully detached.
+if blocking_count > 0 then execute format(
+  'update public.%I set archived_at = now() where id = $1',
+  tg_table_name
+) using old.id;
+return null;
+end if;
+return old;
+end;
+$$;
+--
+-- Attach the trigger to every catalog table (every table with
+-- `custom` + `user_id` columns). The trigger name is the same on every
+-- table because Postgres scopes trigger names per-table.
+--
+do $$
+declare t text;
+catalog_tables text [] := array [
+  'ability_impairment',
+  'armor_set',
+  'character',
+  'collective_cognition_reward',
+  'constellation',
+  'disorder',
+  'fighting_art',
+  'gear',
+  'innovation',
+  'knowledge',
+  'location',
+  'milestone',
+  'mood',
+  'nemesis',
+  'neurosis',
+  'pattern',
+  'philosophy',
+  'principle',
+  'quarry',
+  'resource',
+  'secret_fighting_art',
+  'seed_pattern',
+  'strain_milestone',
+  'survivor_status',
+  'trait',
+  'wanderer',
+  'weapon_type'
+];
+begin foreach t in array catalog_tables loop execute format(
+  'drop trigger if exists enforce_catalog_delete_guard on public.%I;',
+  t
+);
+execute format(
+  'create trigger enforce_catalog_delete_guard before delete on public.%I for each row execute function public.enforce_catalog_delete_guard();',
+  t
+);
+end loop;
+end $$;


### PR DESCRIPTION
## Summary
- Adds `archived_at` support for custom catalog tables so referenced custom rows archive on delete instead of disappearing from settlements that still need them.
- Adds the Archived custom content tab with restore and guarded permanent-delete actions.
- Filters archived custom content out of active catalog lists while preserving settlement transitive visibility.
- Lets active/trialing `lantern` and `lantern_hoard` users create more than five owned settlements while keeping the free-tier cap.
- Bumps the app version to `0.83.0`.

## Dependencies
- No dependency changes.

## Related Issues
- Fixes #181.

## Verification
- `npx tsc --noEmit`
- Targeted `npx prettier --check ...` for changed files and package metadata
- `git --no-pager diff --check`
- `npx vitest run --coverage.enabled=false` — 117 files / 2120 tests passed
- `npm run integration-test -- __tests__/integration/rls/catalog-delete-guard.test.ts` — 15 tests passed