### PR TITLE
Fix realtime scope for gameplay junctions

### DIFF
--- a/__tests__/hooks/use-realtime.test.ts
+++ b/__tests__/hooks/use-realtime.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { TABLE_DOMAIN_MAP } from '@/hooks/use-realtime'
+
+describe('TABLE_DOMAIN_MAP realtime settlement scoping', () => {
+  const ACTIVE_SETTLEMENT_ID = 'active-settlement'
+  const UNRELATED_SETTLEMENT_ID = 'unrelated-settlement'
+
+  const DENORMALIZED_JUNCTION_TABLES = [
+    'survivor_ability_impairment',
+    'survivor_cursed_gear',
+    'survivor_disorder',
+    'survivor_fighting_art',
+    'survivor_secret_fighting_art',
+    'gear_grid',
+    'hunt_monster_mood',
+    'hunt_monster_survivor_status',
+    'hunt_monster_trait',
+    'showdown_monster_mood',
+    'showdown_monster_survivor_status',
+    'showdown_monster_trait'
+  ] as const
+
+  it.each(DENORMALIZED_JUNCTION_TABLES)(
+    'filters %s by the active settlement_id',
+    (table) => {
+      const entry = TABLE_DOMAIN_MAP[table]
+      const filter = `${entry.filterColumn}=eq.${ACTIVE_SETTLEMENT_ID}`
+
+      expect(entry.filterColumn).toBe('settlement_id')
+      expect(filter).toBe(`settlement_id=eq.${ACTIVE_SETTLEMENT_ID}`)
+      expect(filter).not.toBe(`settlement_id=eq.${UNRELATED_SETTLEMENT_ID}`)
+    }
+  )
+})

--- a/__tests__/integration/rls/hunt-showdown-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/hunt-showdown-collaborator-crud.test.ts
@@ -370,7 +370,9 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
       // Pair the foreign monster with a catalog id reserved for the
       // stranger denial cases (seeded in beforeAll). The composite has
       // never existed in this table, so a 23505 unique-violation is
-      // impossible — only an RLS denial can produce a failure.
+      // impossible. The denormalized-settlement trigger may now surface the
+      // denial as the same generic 23503 parent reference used for missing
+      // parents.
       const insertRow: Record<string, unknown> = {
         [row.parentColumn]: row.parentMonsterId(),
         [row.catalogColumn]: row.strangerCatalogId()
@@ -380,7 +382,7 @@ describe('RLS: collaborator CRUD on hunt + showdown tables', () => {
         .insert(insertRow)
         .select('id')
       expect(data ?? []).toEqual([])
-      if (error) expect(error.code).toMatch(/PGRST|42501/)
+      if (error) expect(error.code).toMatch(/PGRST|42501|23503/)
     }
   )
 

--- a/__tests__/integration/rls/junction-settlement-scope.test.ts
+++ b/__tests__/integration/rls/junction-settlement-scope.test.ts
@@ -1,0 +1,157 @@
+import {
+  deleteCatalog,
+  seedCatalog,
+  seedSettlementFixture,
+  SettlementFixture
+} from '@/__tests__/integration/helpers/fixtures'
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  seedSettlement,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Denormalized Junction Settlement Scope
+ *
+ * Approach A from issue #189 stores `settlement_id` on the gameplay junctions
+ * that previously relied on unfiltered realtime subscriptions. These tests
+ * prove the migration backfills the existing fixture rows and the child
+ * triggers keep direct writes aligned with their parent rows.
+ */
+describe('RLS: denormalized junction settlement scope', () => {
+  let owner: TestUser
+  let catalog: SettlementFixture['catalogIds']
+  let fixture: SettlementFixture
+  let unrelatedSettlementId: string
+  let showdownSettlementId: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    catalog = await seedCatalog()
+    fixture = await seedSettlementFixture(owner, catalog)
+    unrelatedSettlementId = await seedSettlement(
+      owner.id,
+      'RLS Unrelated Settlement'
+    )
+
+    const { data, error } = await admin
+      .from('showdown_monster')
+      .select('settlement_id')
+      .eq('id', fixture.showdownMonsterId)
+      .single<{ settlement_id: string }>()
+    if (error || !data)
+      throw new Error(`resolve showdown settlement: ${error?.message}`)
+    showdownSettlementId = data.settlement_id
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteCatalog(catalog)
+  })
+
+  const SCOPED_ROWS = [
+    [
+      'survivor_ability_impairment',
+      () => fixture.survivorJunctionIds.survivor_ability_impairment,
+      () => fixture.settlementId
+    ],
+    [
+      'survivor_cursed_gear',
+      () => fixture.survivorJunctionIds.survivor_cursed_gear,
+      () => fixture.settlementId
+    ],
+    [
+      'survivor_disorder',
+      () => fixture.survivorJunctionIds.survivor_disorder,
+      () => fixture.settlementId
+    ],
+    [
+      'survivor_fighting_art',
+      () => fixture.survivorJunctionIds.survivor_fighting_art,
+      () => fixture.settlementId
+    ],
+    [
+      'survivor_secret_fighting_art',
+      () => fixture.survivorJunctionIds.survivor_secret_fighting_art,
+      () => fixture.settlementId
+    ],
+    [
+      'hunt_monster_mood',
+      () => fixture.monsterJunctionIds.hunt_monster_mood,
+      () => fixture.settlementId
+    ],
+    [
+      'hunt_monster_survivor_status',
+      () => fixture.monsterJunctionIds.hunt_monster_survivor_status,
+      () => fixture.settlementId
+    ],
+    [
+      'hunt_monster_trait',
+      () => fixture.monsterJunctionIds.hunt_monster_trait,
+      () => fixture.settlementId
+    ],
+    [
+      'showdown_monster_mood',
+      () => fixture.monsterJunctionIds.showdown_monster_mood,
+      () => showdownSettlementId
+    ],
+    [
+      'showdown_monster_survivor_status',
+      () => fixture.monsterJunctionIds.showdown_monster_survivor_status,
+      () => showdownSettlementId
+    ],
+    [
+      'showdown_monster_trait',
+      () => fixture.monsterJunctionIds.showdown_monster_trait,
+      () => showdownSettlementId
+    ]
+  ] as const
+
+  it.each(SCOPED_ROWS)(
+    'stores the parent settlement on %s',
+    async (table, rowId, settlementId) => {
+      const { data, error } = await admin
+        .from(table)
+        .select('id, settlement_id')
+        .eq('id', rowId())
+        .single<{ id: string; settlement_id: string }>()
+
+      expect(error).toBeNull()
+      expect(data?.settlement_id).toBe(settlementId())
+    }
+  )
+
+  it.each(SCOPED_ROWS)(
+    'repairs direct settlement_id changes on %s',
+    async (table, rowId, settlementId) => {
+      const { data, error } = await admin
+        .from(table)
+        .update({ settlement_id: unrelatedSettlementId })
+        .eq('id', rowId())
+        .select('id, settlement_id')
+        .single<{ id: string; settlement_id: string }>()
+
+      expect(error).toBeNull()
+      expect(data?.settlement_id).toBe(settlementId())
+    }
+  )
+
+  it('derives settlement_id for gear_grid from its survivor parent', async () => {
+    const { data, error } = await admin
+      .from('gear_grid')
+      .insert({
+        survivor_id: fixture.survivorId,
+        settlement_id: unrelatedSettlementId
+      })
+      .select('id, settlement_id')
+      .single<{ id: string; settlement_id: string }>()
+
+    expect(error).toBeNull()
+    expect(data?.settlement_id).toBe(fixture.settlementId)
+
+    if (data?.id) await admin.from('gear_grid').delete().eq('id', data.id)
+  })
+})

--- a/__tests__/integration/rls/junction-settlement-scope.test.ts
+++ b/__tests__/integration/rls/junction-settlement-scope.test.ts
@@ -23,15 +23,28 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
  */
 describe('RLS: denormalized junction settlement scope', () => {
   let owner: TestUser
+  let outsider: TestUser
   let catalog: SettlementFixture['catalogIds']
   let fixture: SettlementFixture
+  let gearGridId: string
   let unrelatedSettlementId: string
   let showdownSettlementId: string
 
   beforeAll(async () => {
     owner = await createTestUser()
+    outsider = await createTestUser()
     catalog = await seedCatalog()
     fixture = await seedSettlementFixture(owner, catalog)
+
+    const { data: gearGrid, error: gearGridError } = await admin
+      .from('gear_grid')
+      .insert({ survivor_id: fixture.survivorId })
+      .select('id')
+      .single<{ id: string }>()
+    if (gearGridError || !gearGrid)
+      throw new Error(`seed gear_grid: ${gearGridError?.message}`)
+    gearGridId = gearGrid.id
+
     unrelatedSettlementId = await seedSettlement(
       owner.id,
       'RLS Unrelated Settlement'
@@ -49,6 +62,7 @@ describe('RLS: denormalized junction settlement scope', () => {
 
   afterAll(async () => {
     await deleteTestUser(owner.id)
+    await deleteTestUser(outsider.id)
     await deleteCatalog(catalog)
   })
 
@@ -78,6 +92,7 @@ describe('RLS: denormalized junction settlement scope', () => {
       () => fixture.survivorJunctionIds.survivor_secret_fighting_art,
       () => fixture.settlementId
     ],
+    ['gear_grid', () => gearGridId, () => fixture.settlementId],
     [
       'hunt_monster_mood',
       () => fixture.monsterJunctionIds.hunt_monster_mood,
@@ -140,10 +155,22 @@ describe('RLS: denormalized junction settlement scope', () => {
   )
 
   it('derives settlement_id for gear_grid from its survivor parent', async () => {
+    const { data: survivor, error: survivorError } = await admin
+      .from('survivor')
+      .insert({
+        settlement_id: fixture.settlementId,
+        gender: 'MALE',
+        survivor_name: 'RLS Gear Grid Survivor'
+      })
+      .select('id')
+      .single<{ id: string }>()
+    if (survivorError || !survivor)
+      throw new Error(`seed gear_grid survivor: ${survivorError?.message}`)
+
     const { data, error } = await admin
       .from('gear_grid')
       .insert({
-        survivor_id: fixture.survivorId,
+        survivor_id: survivor.id,
         settlement_id: unrelatedSettlementId
       })
       .select('id, settlement_id')
@@ -153,5 +180,24 @@ describe('RLS: denormalized junction settlement scope', () => {
     expect(data?.settlement_id).toBe(fixture.settlementId)
 
     if (data?.id) await admin.from('gear_grid').delete().eq('id', data.id)
+    await admin.from('survivor').delete().eq('id', survivor.id)
+  })
+
+  it('uses the same parent reference error for missing and unauthorized parents', async () => {
+    const MISSING_SURVIVOR_ID = '00000000-0000-4000-8000-000000000001'
+
+    const [{ error: unauthorizedError }, { error: missingError }] =
+      await Promise.all([
+        outsider.client.from('gear_grid').insert({
+          survivor_id: fixture.survivorId
+        }),
+        outsider.client.from('gear_grid').insert({
+          survivor_id: MISSING_SURVIVOR_ID
+        })
+      ])
+
+    expect(unauthorizedError?.code).toBe('23503')
+    expect(missingError?.code).toBe('23503')
+    expect(unauthorizedError?.message).toBe(missingError?.message)
   })
 })

--- a/__tests__/integration/rls/survivor-collaborator-crud.test.ts
+++ b/__tests__/integration/rls/survivor-collaborator-crud.test.ts
@@ -282,8 +282,10 @@ describe('RLS: collaborator CRUD on survivor + survivor junctions + gear_grid', 
       const insertRow = buildJunctionInsertRow(table)
 
       // Make this test self-contained: remove the conflicting seeded row so
-      // the assertion exercises RLS denial instead of depending on execution
-      // order to avoid a 23505 unique-constraint error.
+      // the assertion exercises the write denial instead of depending on
+      // execution order to avoid a 23505 unique-constraint error. The
+      // denormalized-settlement trigger may now surface this as the same
+      // generic 23503 parent reference used for missing parents.
       const { error: deleteError } = await admin
         .from(table)
         .delete()
@@ -297,7 +299,7 @@ describe('RLS: collaborator CRUD on survivor + survivor junctions + gear_grid', 
           .select('id')
         expect(data ?? []).toEqual([])
         expect(error).not.toBeNull()
-        if (error) expect(error.code).toMatch(/PGRST|42501/)
+        if (error) expect(error.code).toMatch(/PGRST|42501|23503/)
       } finally {
         const { data: restored, error: restoreError } = await admin
           .from(table)
@@ -407,7 +409,7 @@ describe('RLS: collaborator CRUD on survivor + survivor junctions + gear_grid', 
         .insert({ survivor_id: fixture.survivorId })
         .select('id')
       expect(data ?? []).toEqual([])
-      if (error) expect(error.code).toMatch(/PGRST|42501/)
+      if (error) expect(error.code).toMatch(/PGRST|42501|23503/)
     })
   })
 })

--- a/__tests__/lib/dal/survivor-cursed-gear.test.ts
+++ b/__tests__/lib/dal/survivor-cursed-gear.test.ts
@@ -45,7 +45,7 @@ describe('getSurvivorCursedGear', () => {
     const result = await getSurvivorCursedGear('survivor-1')
 
     expect(mockSupabase.from).toHaveBeenCalledWith('survivor_cursed_gear')
-    expect(mockSelect).toHaveBeenCalledWith('id, gear_id')
+    expect(mockSelect).toHaveBeenCalledWith('id, gear_id, settlement_id')
     expect(mockEq).toHaveBeenCalledWith('survivor_id', 'survivor-1')
     expect(result).toEqual(mockData)
   })

--- a/__tests__/lib/dal/survivor-disorder.test.ts
+++ b/__tests__/lib/dal/survivor-disorder.test.ts
@@ -45,7 +45,7 @@ describe('getSurvivorDisorders', () => {
     const result = await getSurvivorDisorders('survivor-1')
 
     expect(mockSupabase.from).toHaveBeenCalledWith('survivor_disorder')
-    expect(mockSelect).toHaveBeenCalledWith('id, disorder_id')
+    expect(mockSelect).toHaveBeenCalledWith('id, disorder_id, settlement_id')
     expect(mockEq).toHaveBeenCalledWith('survivor_id', 'survivor-1')
     expect(result).toEqual(mockData)
   })

--- a/__tests__/lib/dal/survivor-fighting-art.test.ts
+++ b/__tests__/lib/dal/survivor-fighting-art.test.ts
@@ -45,7 +45,9 @@ describe('getSurvivorFightingArts', () => {
     const result = await getSurvivorFightingArts('survivor-1')
 
     expect(mockSupabase.from).toHaveBeenCalledWith('survivor_fighting_art')
-    expect(mockSelect).toHaveBeenCalledWith('id, fighting_art_id')
+    expect(mockSelect).toHaveBeenCalledWith(
+      'id, fighting_art_id, settlement_id'
+    )
     expect(mockEq).toHaveBeenCalledWith('survivor_id', 'survivor-1')
     expect(result).toEqual(mockData)
   })

--- a/__tests__/lib/dal/survivor-secret-fighting-art.test.ts
+++ b/__tests__/lib/dal/survivor-secret-fighting-art.test.ts
@@ -47,7 +47,9 @@ describe('getSurvivorSecretFightingArts', () => {
     expect(mockSupabase.from).toHaveBeenCalledWith(
       'survivor_secret_fighting_art'
     )
-    expect(mockSelect).toHaveBeenCalledWith('id, secret_fighting_art_id')
+    expect(mockSelect).toHaveBeenCalledWith(
+      'id, secret_fighting_art_id, settlement_id'
+    )
     expect(mockEq).toHaveBeenCalledWith('survivor_id', 'survivor-1')
     expect(result).toEqual(mockData)
   })

--- a/docs/adrs/realtime-junction-settlement-scope.md
+++ b/docs/adrs/realtime-junction-settlement-scope.md
@@ -1,0 +1,75 @@
+# Realtime Junction Settlement Scope
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #189 follows up on the realtime publication audit. Several gameplay
+junction tables did not carry `settlement_id`, so `hooks/use-realtime.tsx`
+subscribed to them without a row filter and relied on RLS to limit delivered
+events. That protected data visibility but still meant a user with access to
+multiple settlements could receive events for another accessible settlement and
+trigger unnecessary active-settlement refetches.
+
+## Challenge
+
+- Supabase realtime filters cannot express joins from a junction row back to
+  `survivor`, `hunt_monster`, or `showdown_monster`.
+- The affected rows still need direct RLS predicates, FK integrity, and safe
+  backfills for existing data.
+- Catalog tables intentionally keep the coarse subscription model because their
+  transitive visibility graph is broader and rules-text edits are rare.
+
+## Goals
+
+- Filter every gameplay junction realtime subscription by the active
+  `settlement_id`.
+- Keep `settlement_id` authoritative at the schema layer rather than relying on
+  callers to duplicate parent scope correctly.
+- Preserve collaborator CRUD behavior for settlement members.
+- Leave catalog-table realtime behavior unchanged.
+
+## Risks
+
+- Denormalized scope can drift if parent rows are moved without synchronizing
+  children.
+- Generated Supabase types may expose the new column to callers even though the
+  database derives it.
+- RLS rewrites can accidentally narrow collaborator access or widen stranger
+  access if the direct predicates are wrong.
+
+## Decision
+
+Use approach A from issue #189. Add `settlement_id` to every affected gameplay
+junction table, backfill it from the parent row, enforce a FK to `settlement`,
+and maintain parity with trigger functions. RLS policies on those tables use
+direct
+`is_settlement_owner(settlement_id) or is_settlement_collaborator(settlement_id)`
+predicates, and the realtime table map filters them by `settlement_id`.
+
+Affected tables:
+
+- `survivor_ability_impairment`
+- `survivor_cursed_gear`
+- `survivor_disorder`
+- `survivor_fighting_art`
+- `survivor_secret_fighting_art`
+- `gear_grid`
+- `hunt_monster_mood`
+- `hunt_monster_survivor_status`
+- `hunt_monster_trait`
+- `showdown_monster_mood`
+- `showdown_monster_survivor_status`
+- `showdown_monster_trait`
+
+## Consequences
+
+Gameplay realtime events are now scoped at the publication filter layer, so an
+unrelated accessible settlement does not cause a refetch of the active
+settlement's survivor, hunt, or showdown data. RLS predicates are simpler and
+match the direct settlement-scoped policy pattern used by the rest of the
+gameplay graph. Future gameplay junctions should include `settlement_id` when
+they need realtime filtering; catalog tables remain covered by the documented
+coarse subscription model.

--- a/docs/settlement-sharing-architecture.md
+++ b/docs/settlement-sharing-architecture.md
@@ -686,8 +686,9 @@ typical KDM session is low; LWW is fine.
 ### 8.1 What's Already in Place
 
 - `hooks/use-realtime.tsx` subscribes to a `settlement-{id}` channel filtered by
-  `settlement_id` for most settlement-child tables, and unfiltered (relying on
-  RLS) for survivor-owned junctions.
+  `settlement_id` for settlement-child gameplay tables, including the
+  survivor-owned and monster-owned junctions that denormalize the parent
+  settlement scope for realtime filtering.
 - 300ms debounce per domain (settlement, hunt, showdown, settlement phase,
   survivor) to batch rapid changes into a single re-fetch.
 - `LocalContext` holds `selectedSettlement: SettlementDetail` etc., refetched on

--- a/hooks/use-realtime.tsx
+++ b/hooks/use-realtime.tsx
@@ -50,7 +50,7 @@ interface TableDomainEntry {
    * The column to filter on for settlement-scoped changes.
    * - `'settlement_id'`: filter by `settlement_id=eq.{id}`
    * - `'id'`: filter by `id=eq.{id}` (for the settlement table itself)
-   * - `null`: no filter (RLS handles scoping)
+   * - `null`: no filter (catalog subscriptions rely on RLS)
    */
   filterColumn: 'settlement_id' | 'id' | null
 }
@@ -60,7 +60,7 @@ interface TableDomainEntry {
  *
  * Maps each subscribed table to its domain and filter configuration.
  */
-const TABLE_DOMAIN_MAP: Record<string, TableDomainEntry> = {
+export const TABLE_DOMAIN_MAP: Record<string, TableDomainEntry> = {
   // Settlement domain
   settlement: { domain: 'settlement', filterColumn: 'id' },
   settlement_collective_cognition_reward: {
@@ -113,21 +113,30 @@ const TABLE_DOMAIN_MAP: Record<string, TableDomainEntry> = {
   hunt_ai_deck: { domain: 'hunt', filterColumn: 'settlement_id' },
   hunt_hunt_board: { domain: 'hunt', filterColumn: 'settlement_id' },
   hunt_monster: { domain: 'hunt', filterColumn: 'settlement_id' },
-  hunt_monster_mood: { domain: 'hunt', filterColumn: null },
-  hunt_monster_survivor_status: { domain: 'hunt', filterColumn: null },
-  hunt_monster_trait: { domain: 'hunt', filterColumn: null },
+  hunt_monster_mood: { domain: 'hunt', filterColumn: 'settlement_id' },
+  hunt_monster_survivor_status: {
+    domain: 'hunt',
+    filterColumn: 'settlement_id'
+  },
+  hunt_monster_trait: { domain: 'hunt', filterColumn: 'settlement_id' },
   hunt_survivor: { domain: 'hunt', filterColumn: 'settlement_id' },
 
   // Showdown domain
   showdown: { domain: 'showdown', filterColumn: 'settlement_id' },
   showdown_ai_deck: { domain: 'showdown', filterColumn: 'settlement_id' },
   showdown_monster: { domain: 'showdown', filterColumn: 'settlement_id' },
-  showdown_monster_mood: { domain: 'showdown', filterColumn: null },
+  showdown_monster_mood: {
+    domain: 'showdown',
+    filterColumn: 'settlement_id'
+  },
   showdown_monster_survivor_status: {
     domain: 'showdown',
-    filterColumn: null
+    filterColumn: 'settlement_id'
   },
-  showdown_monster_trait: { domain: 'showdown', filterColumn: null },
+  showdown_monster_trait: {
+    domain: 'showdown',
+    filterColumn: 'settlement_id'
+  },
   showdown_survivor: { domain: 'showdown', filterColumn: 'settlement_id' },
 
   // Settlement Phase domain
@@ -142,12 +151,24 @@ const TABLE_DOMAIN_MAP: Record<string, TableDomainEntry> = {
 
   // Survivor domain
   survivor: { domain: 'survivor', filterColumn: 'settlement_id' },
-  survivor_ability_impairment: { domain: 'survivor', filterColumn: null },
-  survivor_cursed_gear: { domain: 'survivor', filterColumn: null },
-  survivor_disorder: { domain: 'survivor', filterColumn: null },
-  survivor_fighting_art: { domain: 'survivor', filterColumn: null },
-  survivor_secret_fighting_art: { domain: 'survivor', filterColumn: null },
-  gear_grid: { domain: 'survivor', filterColumn: null },
+  survivor_ability_impairment: {
+    domain: 'survivor',
+    filterColumn: 'settlement_id'
+  },
+  survivor_cursed_gear: {
+    domain: 'survivor',
+    filterColumn: 'settlement_id'
+  },
+  survivor_disorder: { domain: 'survivor', filterColumn: 'settlement_id' },
+  survivor_fighting_art: {
+    domain: 'survivor',
+    filterColumn: 'settlement_id'
+  },
+  survivor_secret_fighting_art: {
+    domain: 'survivor',
+    filterColumn: 'settlement_id'
+  },
+  gear_grid: { domain: 'survivor', filterColumn: 'settlement_id' },
 
   // Catalog domain — custom-content tables whose rules / definitions are
   // materialized into `SettlementDetail` (and its survivor / hunt /
@@ -368,21 +389,9 @@ export function useRealtimeSubscriptions(
           () => handleChange(domain)
         )
       } else {
-        // Junction tables that don't carry `settlement_id` directly. The
-        // realtime filter syntax doesn't support joins, so we subscribe
-        // unfiltered and rely on RLS to scope events to rows the user can
-        // read. This is the "coarse subscription" pattern from the sharing
-        // architecture doc §8.2.2 (option B).
-        //
-        // Trade-off: a user with multiple accessible settlements (owned or
-        // shared) will receive events for ALL of them, not just the active
-        // one. The hook fires the domain refetch for any such event,
-        // causing one extra refetch per unrelated mutation. The 300ms
-        // per-domain debounce bounds the blast radius — bursts of
-        // unrelated events collapse into a single refetch. Refining this
-        // to be strictly per-active-settlement requires either denormalising
-        // `settlement_id` onto each junction or threading parent-id
-        // lookups into this hook; tracked in #189.
+        // Catalog tables are subscribed unfiltered because realtime filters
+        // cannot express the transitive joins from catalog rows back to the
+        // active settlement. RLS still gates delivery to readable rows.
         channel = channel.on(
           'postgres_changes',
           {

--- a/lib/dal/survivor-cursed-gear.ts
+++ b/lib/dal/survivor-cursed-gear.ts
@@ -19,7 +19,7 @@ export async function getSurvivorCursedGear(
 
   const { data, error } = await supabase
     .from('survivor_cursed_gear')
-    .select('id, gear_id')
+    .select('id, gear_id, settlement_id')
     .eq('survivor_id', survivorId)
 
   if (error)

--- a/lib/dal/survivor-disorder.ts
+++ b/lib/dal/survivor-disorder.ts
@@ -19,7 +19,7 @@ export async function getSurvivorDisorders(
 
   const { data, error } = await supabase
     .from('survivor_disorder')
-    .select('id, disorder_id')
+    .select('id, disorder_id, settlement_id')
     .eq('survivor_id', survivorId)
 
   if (error)

--- a/lib/dal/survivor-fighting-art.ts
+++ b/lib/dal/survivor-fighting-art.ts
@@ -19,7 +19,7 @@ export async function getSurvivorFightingArts(
 
   const { data, error } = await supabase
     .from('survivor_fighting_art')
-    .select('id, fighting_art_id')
+    .select('id, fighting_art_id, settlement_id')
     .eq('survivor_id', survivorId)
 
   if (error)

--- a/lib/dal/survivor-secret-fighting-art.ts
+++ b/lib/dal/survivor-secret-fighting-art.ts
@@ -19,7 +19,7 @@ export async function getSurvivorSecretFightingArts(
 
   const { data, error } = await supabase
     .from('survivor_secret_fighting_art')
-    .select('id, secret_fighting_art_id')
+    .select('id, secret_fighting_art_id, settlement_id')
     .eq('survivor_id', survivorId)
 
   if (error)

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -476,6 +476,7 @@ export type Database = {
           pos_top_left: string | null
           pos_top_right: string | null
           selected_armor_set_id: string | null
+          settlement_id: string
           survivor_id: string
           updated_at: string
         }
@@ -492,6 +493,7 @@ export type Database = {
           pos_top_left?: string | null
           pos_top_right?: string | null
           selected_armor_set_id?: string | null
+          settlement_id?: string
           survivor_id: string
           updated_at?: string
         }
@@ -508,6 +510,7 @@ export type Database = {
           pos_top_left?: string | null
           pos_top_right?: string | null
           selected_armor_set_id?: string | null
+          settlement_id?: string
           survivor_id?: string
           updated_at?: string
         }
@@ -580,6 +583,13 @@ export type Database = {
             columns: ["selected_armor_set_id"]
             isOneToOne: false
             referencedRelation: "armor_set"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gear_grid_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
             referencedColumns: ["id"]
           },
           {
@@ -952,6 +962,7 @@ export type Database = {
           hunt_monster_id: string
           id: string
           mood_id: string
+          settlement_id: string
           updated_at: string
         }
         Insert: {
@@ -959,6 +970,7 @@ export type Database = {
           hunt_monster_id: string
           id?: string
           mood_id: string
+          settlement_id?: string
           updated_at?: string
         }
         Update: {
@@ -966,6 +978,7 @@ export type Database = {
           hunt_monster_id?: string
           id?: string
           mood_id?: string
+          settlement_id?: string
           updated_at?: string
         }
         Relationships: [
@@ -983,6 +996,13 @@ export type Database = {
             referencedRelation: "mood"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "hunt_monster_mood_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
+            referencedColumns: ["id"]
+          },
         ]
       }
       hunt_monster_survivor_status: {
@@ -990,6 +1010,7 @@ export type Database = {
           created_at: string
           hunt_monster_id: string
           id: string
+          settlement_id: string
           survivor_status_id: string
           updated_at: string
         }
@@ -997,6 +1018,7 @@ export type Database = {
           created_at?: string
           hunt_monster_id: string
           id?: string
+          settlement_id?: string
           survivor_status_id: string
           updated_at?: string
         }
@@ -1004,6 +1026,7 @@ export type Database = {
           created_at?: string
           hunt_monster_id?: string
           id?: string
+          settlement_id?: string
           survivor_status_id?: string
           updated_at?: string
         }
@@ -1013,6 +1036,13 @@ export type Database = {
             columns: ["hunt_monster_id"]
             isOneToOne: false
             referencedRelation: "hunt_monster"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "hunt_monster_survivor_status_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
             referencedColumns: ["id"]
           },
           {
@@ -1029,6 +1059,7 @@ export type Database = {
           created_at: string
           hunt_monster_id: string
           id: string
+          settlement_id: string
           trait_id: string
           updated_at: string
         }
@@ -1036,6 +1067,7 @@ export type Database = {
           created_at?: string
           hunt_monster_id: string
           id?: string
+          settlement_id?: string
           trait_id: string
           updated_at?: string
         }
@@ -1043,6 +1075,7 @@ export type Database = {
           created_at?: string
           hunt_monster_id?: string
           id?: string
+          settlement_id?: string
           trait_id?: string
           updated_at?: string
         }
@@ -1052,6 +1085,13 @@ export type Database = {
             columns: ["hunt_monster_id"]
             isOneToOne: false
             referencedRelation: "hunt_monster"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "hunt_monster_trait_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
             referencedColumns: ["id"]
           },
           {
@@ -3869,6 +3909,7 @@ export type Database = {
           created_at: string
           id: string
           mood_id: string
+          settlement_id: string
           showdown_monster_id: string
           updated_at: string
         }
@@ -3876,6 +3917,7 @@ export type Database = {
           created_at?: string
           id?: string
           mood_id: string
+          settlement_id?: string
           showdown_monster_id: string
           updated_at?: string
         }
@@ -3883,6 +3925,7 @@ export type Database = {
           created_at?: string
           id?: string
           mood_id?: string
+          settlement_id?: string
           showdown_monster_id?: string
           updated_at?: string
         }
@@ -3892,6 +3935,13 @@ export type Database = {
             columns: ["mood_id"]
             isOneToOne: false
             referencedRelation: "mood"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "showdown_monster_mood_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
             referencedColumns: ["id"]
           },
           {
@@ -3907,6 +3957,7 @@ export type Database = {
         Row: {
           created_at: string
           id: string
+          settlement_id: string
           showdown_monster_id: string
           survivor_status_id: string
           updated_at: string
@@ -3914,6 +3965,7 @@ export type Database = {
         Insert: {
           created_at?: string
           id?: string
+          settlement_id?: string
           showdown_monster_id: string
           survivor_status_id: string
           updated_at?: string
@@ -3921,11 +3973,19 @@ export type Database = {
         Update: {
           created_at?: string
           id?: string
+          settlement_id?: string
           showdown_monster_id?: string
           survivor_status_id?: string
           updated_at?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "showdown_monster_survivor_status_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "showdown_monster_survivor_status_showdown_monster_id_fkey"
             columns: ["showdown_monster_id"]
@@ -3946,6 +4006,7 @@ export type Database = {
         Row: {
           created_at: string
           id: string
+          settlement_id: string
           showdown_monster_id: string
           trait_id: string
           updated_at: string
@@ -3953,6 +4014,7 @@ export type Database = {
         Insert: {
           created_at?: string
           id?: string
+          settlement_id?: string
           showdown_monster_id: string
           trait_id: string
           updated_at?: string
@@ -3960,11 +4022,19 @@ export type Database = {
         Update: {
           created_at?: string
           id?: string
+          settlement_id?: string
           showdown_monster_id?: string
           trait_id?: string
           updated_at?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "showdown_monster_trait_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "showdown_monster_trait_showdown_monster_id_fkey"
             columns: ["showdown_monster_id"]
@@ -4594,6 +4664,7 @@ export type Database = {
           ability_impairment_id: string
           created_at: string
           id: string
+          settlement_id: string
           survivor_id: string
           updated_at: string
         }
@@ -4601,6 +4672,7 @@ export type Database = {
           ability_impairment_id: string
           created_at?: string
           id?: string
+          settlement_id?: string
           survivor_id: string
           updated_at?: string
         }
@@ -4608,6 +4680,7 @@ export type Database = {
           ability_impairment_id?: string
           created_at?: string
           id?: string
+          settlement_id?: string
           survivor_id?: string
           updated_at?: string
         }
@@ -4617,6 +4690,13 @@ export type Database = {
             columns: ["ability_impairment_id"]
             isOneToOne: false
             referencedRelation: "ability_impairment"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "survivor_ability_impairment_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
             referencedColumns: ["id"]
           },
           {
@@ -4633,6 +4713,7 @@ export type Database = {
           created_at: string
           gear_id: string
           id: string
+          settlement_id: string
           survivor_id: string
           updated_at: string
         }
@@ -4640,6 +4721,7 @@ export type Database = {
           created_at?: string
           gear_id: string
           id?: string
+          settlement_id?: string
           survivor_id: string
           updated_at?: string
         }
@@ -4647,6 +4729,7 @@ export type Database = {
           created_at?: string
           gear_id?: string
           id?: string
+          settlement_id?: string
           survivor_id?: string
           updated_at?: string
         }
@@ -4656,6 +4739,13 @@ export type Database = {
             columns: ["gear_id"]
             isOneToOne: false
             referencedRelation: "gear"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "survivor_cursed_gear_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
             referencedColumns: ["id"]
           },
           {
@@ -4672,6 +4762,7 @@ export type Database = {
           created_at: string
           disorder_id: string
           id: string
+          settlement_id: string
           survivor_id: string
           updated_at: string
         }
@@ -4679,6 +4770,7 @@ export type Database = {
           created_at?: string
           disorder_id: string
           id?: string
+          settlement_id?: string
           survivor_id: string
           updated_at?: string
         }
@@ -4686,6 +4778,7 @@ export type Database = {
           created_at?: string
           disorder_id?: string
           id?: string
+          settlement_id?: string
           survivor_id?: string
           updated_at?: string
         }
@@ -4695,6 +4788,13 @@ export type Database = {
             columns: ["disorder_id"]
             isOneToOne: false
             referencedRelation: "disorder"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "survivor_disorder_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
             referencedColumns: ["id"]
           },
           {
@@ -4711,6 +4811,7 @@ export type Database = {
           created_at: string
           fighting_art_id: string
           id: string
+          settlement_id: string
           survivor_id: string
           updated_at: string
         }
@@ -4718,6 +4819,7 @@ export type Database = {
           created_at?: string
           fighting_art_id: string
           id?: string
+          settlement_id?: string
           survivor_id: string
           updated_at?: string
         }
@@ -4725,6 +4827,7 @@ export type Database = {
           created_at?: string
           fighting_art_id?: string
           id?: string
+          settlement_id?: string
           survivor_id?: string
           updated_at?: string
         }
@@ -4734,6 +4837,13 @@ export type Database = {
             columns: ["fighting_art_id"]
             isOneToOne: false
             referencedRelation: "fighting_art"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "survivor_fighting_art_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
             referencedColumns: ["id"]
           },
           {
@@ -4750,6 +4860,7 @@ export type Database = {
           created_at: string
           id: string
           secret_fighting_art_id: string
+          settlement_id: string
           survivor_id: string
           updated_at: string
         }
@@ -4757,6 +4868,7 @@ export type Database = {
           created_at?: string
           id?: string
           secret_fighting_art_id: string
+          settlement_id?: string
           survivor_id: string
           updated_at?: string
         }
@@ -4764,6 +4876,7 @@ export type Database = {
           created_at?: string
           id?: string
           secret_fighting_art_id?: string
+          settlement_id?: string
           survivor_id?: string
           updated_at?: string
         }
@@ -4773,6 +4886,13 @@ export type Database = {
             columns: ["secret_fighting_art_id"]
             isOneToOne: false
             referencedRelation: "secret_fighting_art"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "survivor_secret_fighting_art_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlement"
             referencedColumns: ["id"]
           },
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.84.0",
+      "version": "0.84.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260612000000_junction_settlement_scope.sql
+++ b/supabase/migrations/20260612000000_junction_settlement_scope.sql
@@ -147,9 +147,14 @@ declare parent_settlement_id uuid;
 begin
 select sv.settlement_id into parent_settlement_id
 from public.survivor sv
-where sv.id = new.survivor_id;
-if parent_settlement_id is null then raise exception 'Survivor % does not exist',
-new.survivor_id using errcode = '23503';
+where sv.id = new.survivor_id
+  and (
+    auth.role() = 'service_role'
+    or auth.role() is null
+    or public.is_settlement_owner(sv.settlement_id)
+    or public.is_settlement_collaborator(sv.settlement_id)
+  );
+if parent_settlement_id is null then raise exception 'Invalid parent reference' using errcode = '23503';
 end if;
 new.settlement_id := parent_settlement_id;
 return new;
@@ -161,9 +166,14 @@ declare parent_settlement_id uuid;
 begin
 select hm.settlement_id into parent_settlement_id
 from public.hunt_monster hm
-where hm.id = new.hunt_monster_id;
-if parent_settlement_id is null then raise exception 'Hunt monster % does not exist',
-new.hunt_monster_id using errcode = '23503';
+where hm.id = new.hunt_monster_id
+  and (
+    auth.role() = 'service_role'
+    or auth.role() is null
+    or public.is_settlement_owner(hm.settlement_id)
+    or public.is_settlement_collaborator(hm.settlement_id)
+  );
+if parent_settlement_id is null then raise exception 'Invalid parent reference' using errcode = '23503';
 end if;
 new.settlement_id := parent_settlement_id;
 return new;
@@ -175,9 +185,14 @@ declare parent_settlement_id uuid;
 begin
 select sm.settlement_id into parent_settlement_id
 from public.showdown_monster sm
-where sm.id = new.showdown_monster_id;
-if parent_settlement_id is null then raise exception 'Showdown monster % does not exist',
-new.showdown_monster_id using errcode = '23503';
+where sm.id = new.showdown_monster_id
+  and (
+    auth.role() = 'service_role'
+    or auth.role() is null
+    or public.is_settlement_owner(sm.settlement_id)
+    or public.is_settlement_collaborator(sm.settlement_id)
+  );
+if parent_settlement_id is null then raise exception 'Invalid parent reference' using errcode = '23503';
 end if;
 new.settlement_id := parent_settlement_id;
 return new;

--- a/supabase/migrations/20260612000000_junction_settlement_scope.sql
+++ b/supabase/migrations/20260612000000_junction_settlement_scope.sql
@@ -5,7 +5,8 @@
 -- junctions previously carried only their parent FK, so the hook subscribed
 -- without a settlement filter and relied on RLS delivery. Add denormalized
 -- `settlement_id`, keep it synchronized with the parent row, and simplify RLS
--- to direct settlement membership checks.
+-- to direct settlement membership checks. Set REPLICA IDENTITY FULL so DELETE
+-- events also carry `settlement_id` for Supabase Realtime filter evaluation.
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- 1. Add and backfill settlement_id on every affected junction.
@@ -134,6 +135,10 @@ execute format(
     'Denormalized settlement scope derived from %s.settlement_id for realtime filtering and direct RLS checks.',
     spec.parent_table
   )
+);
+execute format(
+  'alter table public.%I replica identity full',
+  spec.child_table
 );
 end loop;
 end $$;

--- a/supabase/migrations/20260612000000_junction_settlement_scope.sql
+++ b/supabase/migrations/20260612000000_junction_settlement_scope.sql
@@ -1,0 +1,411 @@
+--------------------------------------------------------------------------------
+-- Scope Gameplay Junction Realtime By Settlement
+--
+-- Realtime can only filter on columns present on the changed table. These
+-- junctions previously carried only their parent FK, so the hook subscribed
+-- without a settlement filter and relied on RLS delivery. Add denormalized
+-- `settlement_id`, keep it synchronized with the parent row, and simplify RLS
+-- to direct settlement membership checks.
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- 1. Add and backfill settlement_id on every affected junction.
+--------------------------------------------------------------------------------
+do $$
+declare spec record;
+mismatch_count integer;
+begin for spec in
+select *
+from (
+    values (
+        'survivor_ability_impairment',
+        'survivor',
+        'survivor_id'
+      ),
+      (
+        'survivor_cursed_gear',
+        'survivor',
+        'survivor_id'
+      ),
+      ('survivor_disorder', 'survivor', 'survivor_id'),
+      (
+        'survivor_fighting_art',
+        'survivor',
+        'survivor_id'
+      ),
+      (
+        'survivor_secret_fighting_art',
+        'survivor',
+        'survivor_id'
+      ),
+      ('gear_grid', 'survivor', 'survivor_id'),
+      (
+        'hunt_monster_mood',
+        'hunt_monster',
+        'hunt_monster_id'
+      ),
+      (
+        'hunt_monster_survivor_status',
+        'hunt_monster',
+        'hunt_monster_id'
+      ),
+      (
+        'hunt_monster_trait',
+        'hunt_monster',
+        'hunt_monster_id'
+      ),
+      (
+        'showdown_monster_mood',
+        'showdown_monster',
+        'showdown_monster_id'
+      ),
+      (
+        'showdown_monster_survivor_status',
+        'showdown_monster',
+        'showdown_monster_id'
+      ),
+      (
+        'showdown_monster_trait',
+        'showdown_monster',
+        'showdown_monster_id'
+      )
+  ) as t (child_table, parent_table, parent_fk) loop execute format(
+    'alter table public.%I add column if not exists settlement_id uuid',
+    spec.child_table
+  );
+execute format(
+  $sql$
+  update public.%1$I child
+  set settlement_id = parent.settlement_id
+  from public.%2$I parent
+  where parent.id = child.%3$I
+    and child.settlement_id is distinct
+  from parent.settlement_id $sql$,
+    spec.child_table,
+    spec.parent_table,
+    spec.parent_fk
+);
+execute format(
+  $sql$
+  select count(*)
+  from public.%1$I child
+    join public.%2$I parent on parent.id = child.%3$I
+  where child.settlement_id is distinct
+  from parent.settlement_id $sql$,
+    spec.child_table,
+    spec.parent_table,
+    spec.parent_fk
+) into mismatch_count;
+if mismatch_count > 0 then raise exception 'settlement_id backfill mismatch on %: % row(s)',
+spec.child_table,
+mismatch_count;
+end if;
+execute format(
+  'alter table public.%I alter column settlement_id set not null',
+  spec.child_table
+);
+-- The trigger overwrites this sentinel before constraints/RLS checks run.
+-- Keeping a default makes generated Insert types optional for callers that
+-- still rely on schema-side derivation from the parent FK.
+execute format(
+  'alter table public.%I alter column settlement_id set default %L::uuid',
+  spec.child_table,
+  '00000000-0000-0000-0000-000000000000'
+);
+if not exists (
+  select 1
+  from pg_constraint
+  where conrelid = format('public.%I', spec.child_table)::regclass
+    and conname = format('%s_settlement_id_fkey', spec.child_table)
+) then execute format(
+  'alter table public.%I add constraint %I foreign key (settlement_id) references public.settlement(id) on delete cascade',
+  spec.child_table,
+  format('%s_settlement_id_fkey', spec.child_table)
+);
+end if;
+execute format(
+  'create index if not exists %I on public.%I(settlement_id)',
+  format('idx_%s_settlement', spec.child_table),
+  spec.child_table
+);
+execute format(
+  'comment on column public.%I.settlement_id is %L',
+  spec.child_table,
+  format(
+    'Denormalized settlement scope derived from %s.settlement_id for realtime filtering and direct RLS checks.',
+    spec.parent_table
+  )
+);
+end loop;
+end $$;
+--------------------------------------------------------------------------------
+-- 2. Child-side triggers derive settlement_id from the parent FK on insert and
+--    on any update that tries to move the row or settlement scope.
+--------------------------------------------------------------------------------
+create or replace function public.set_survivor_child_settlement_id() returns trigger language plpgsql security definer
+set search_path = '' as $$
+declare parent_settlement_id uuid;
+begin
+select sv.settlement_id into parent_settlement_id
+from public.survivor sv
+where sv.id = new.survivor_id;
+if parent_settlement_id is null then raise exception 'Survivor % does not exist',
+new.survivor_id using errcode = '23503';
+end if;
+new.settlement_id := parent_settlement_id;
+return new;
+end;
+$$;
+create or replace function public.set_hunt_monster_child_settlement_id() returns trigger language plpgsql security definer
+set search_path = '' as $$
+declare parent_settlement_id uuid;
+begin
+select hm.settlement_id into parent_settlement_id
+from public.hunt_monster hm
+where hm.id = new.hunt_monster_id;
+if parent_settlement_id is null then raise exception 'Hunt monster % does not exist',
+new.hunt_monster_id using errcode = '23503';
+end if;
+new.settlement_id := parent_settlement_id;
+return new;
+end;
+$$;
+create or replace function public.set_showdown_monster_child_settlement_id() returns trigger language plpgsql security definer
+set search_path = '' as $$
+declare parent_settlement_id uuid;
+begin
+select sm.settlement_id into parent_settlement_id
+from public.showdown_monster sm
+where sm.id = new.showdown_monster_id;
+if parent_settlement_id is null then raise exception 'Showdown monster % does not exist',
+new.showdown_monster_id using errcode = '23503';
+end if;
+new.settlement_id := parent_settlement_id;
+return new;
+end;
+$$;
+revoke all on function public.set_survivor_child_settlement_id()
+from public;
+revoke all on function public.set_hunt_monster_child_settlement_id()
+from public;
+revoke all on function public.set_showdown_monster_child_settlement_id()
+from public;
+do $$
+declare child_table text;
+begin foreach child_table in array array [
+    'survivor_ability_impairment',
+    'survivor_cursed_gear',
+    'survivor_disorder',
+    'survivor_fighting_art',
+    'survivor_secret_fighting_art',
+    'gear_grid'
+  ] loop execute format(
+  'drop trigger if exists set_settlement_id on public.%I',
+  child_table
+);
+execute format(
+  'create trigger set_settlement_id before insert or update of survivor_id, settlement_id on public.%I for each row execute function public.set_survivor_child_settlement_id()',
+  child_table
+);
+end loop;
+foreach child_table in array array [
+    'hunt_monster_mood',
+    'hunt_monster_survivor_status',
+    'hunt_monster_trait'
+  ] loop execute format(
+  'drop trigger if exists set_settlement_id on public.%I',
+  child_table
+);
+execute format(
+  'create trigger set_settlement_id before insert or update of hunt_monster_id, settlement_id on public.%I for each row execute function public.set_hunt_monster_child_settlement_id()',
+  child_table
+);
+end loop;
+foreach child_table in array array [
+    'showdown_monster_mood',
+    'showdown_monster_survivor_status',
+    'showdown_monster_trait'
+  ] loop execute format(
+  'drop trigger if exists set_settlement_id on public.%I',
+  child_table
+);
+execute format(
+  'create trigger set_settlement_id before insert or update of showdown_monster_id, settlement_id on public.%I for each row execute function public.set_showdown_monster_child_settlement_id()',
+  child_table
+);
+end loop;
+end $$;
+--------------------------------------------------------------------------------
+-- 3. Parent-side triggers keep denormalized rows synchronized if a parent row
+--    is moved to another settlement.
+--------------------------------------------------------------------------------
+create or replace function public.propagate_survivor_child_settlement_id() returns trigger language plpgsql security definer
+set search_path = '' as $$ begin
+update public.survivor_ability_impairment
+set settlement_id = new.settlement_id
+where survivor_id = new.id;
+update public.survivor_cursed_gear
+set settlement_id = new.settlement_id
+where survivor_id = new.id;
+update public.survivor_disorder
+set settlement_id = new.settlement_id
+where survivor_id = new.id;
+update public.survivor_fighting_art
+set settlement_id = new.settlement_id
+where survivor_id = new.id;
+update public.survivor_secret_fighting_art
+set settlement_id = new.settlement_id
+where survivor_id = new.id;
+update public.gear_grid
+set settlement_id = new.settlement_id
+where survivor_id = new.id;
+return new;
+end;
+$$;
+create or replace function public.propagate_hunt_monster_child_settlement_id() returns trigger language plpgsql security definer
+set search_path = '' as $$ begin
+update public.hunt_monster_mood
+set settlement_id = new.settlement_id
+where hunt_monster_id = new.id;
+update public.hunt_monster_survivor_status
+set settlement_id = new.settlement_id
+where hunt_monster_id = new.id;
+update public.hunt_monster_trait
+set settlement_id = new.settlement_id
+where hunt_monster_id = new.id;
+return new;
+end;
+$$;
+create or replace function public.propagate_showdown_monster_child_settlement_id() returns trigger language plpgsql security definer
+set search_path = '' as $$ begin
+update public.showdown_monster_mood
+set settlement_id = new.settlement_id
+where showdown_monster_id = new.id;
+update public.showdown_monster_survivor_status
+set settlement_id = new.settlement_id
+where showdown_monster_id = new.id;
+update public.showdown_monster_trait
+set settlement_id = new.settlement_id
+where showdown_monster_id = new.id;
+return new;
+end;
+$$;
+revoke all on function public.propagate_survivor_child_settlement_id()
+from public;
+revoke all on function public.propagate_hunt_monster_child_settlement_id()
+from public;
+revoke all on function public.propagate_showdown_monster_child_settlement_id()
+from public;
+drop trigger if exists propagate_child_settlement_id on public.survivor;
+create trigger propagate_child_settlement_id
+after
+update of settlement_id on public.survivor for each row
+  when (
+    old.settlement_id is distinct
+    from new.settlement_id
+  ) execute function public.propagate_survivor_child_settlement_id();
+drop trigger if exists propagate_child_settlement_id on public.hunt_monster;
+create trigger propagate_child_settlement_id
+after
+update of settlement_id on public.hunt_monster for each row
+  when (
+    old.settlement_id is distinct
+    from new.settlement_id
+  ) execute function public.propagate_hunt_monster_child_settlement_id();
+drop trigger if exists propagate_child_settlement_id on public.showdown_monster;
+create trigger propagate_child_settlement_id
+after
+update of settlement_id on public.showdown_monster for each row
+  when (
+    old.settlement_id is distinct
+    from new.settlement_id
+  ) execute function public.propagate_showdown_monster_child_settlement_id();
+--------------------------------------------------------------------------------
+-- 4. RLS now uses the denormalized settlement_id directly.
+--------------------------------------------------------------------------------
+do $$
+declare child_table text;
+begin foreach child_table in array array [
+    'survivor_ability_impairment',
+    'survivor_cursed_gear',
+    'survivor_disorder',
+    'survivor_fighting_art',
+    'survivor_secret_fighting_art',
+    'gear_grid',
+    'hunt_monster_mood',
+    'hunt_monster_survivor_status',
+    'hunt_monster_trait',
+    'showdown_monster_mood',
+    'showdown_monster_survivor_status',
+    'showdown_monster_trait'
+  ] loop execute format(
+  'drop policy if exists "Allow select for owner" on public.%I',
+  child_table
+);
+execute format(
+  'drop policy if exists "Allow select for shared" on public.%I',
+  child_table
+);
+execute format(
+  'drop policy if exists "Allow insert for owner" on public.%I',
+  child_table
+);
+execute format(
+  'drop policy if exists "Allow update for owner" on public.%I',
+  child_table
+);
+execute format(
+  'drop policy if exists "Allow delete for owner" on public.%I',
+  child_table
+);
+execute format(
+  'drop policy if exists "Allow select for member" on public.%I',
+  child_table
+);
+execute format(
+  'drop policy if exists "Allow insert for member" on public.%I',
+  child_table
+);
+execute format(
+  'drop policy if exists "Allow update for member" on public.%I',
+  child_table
+);
+execute format(
+  'drop policy if exists "Allow delete for member" on public.%I',
+  child_table
+);
+execute format(
+  $sql$create policy "Allow select for member" on public.%1$I for
+  select to authenticated using (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $sql$,
+    child_table
+);
+execute format(
+  $sql$create policy "Allow insert for member" on public.%1$I for
+  insert to authenticated with check (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $sql$,
+    child_table
+);
+execute format(
+  $sql$create policy "Allow update for member" on public.%1$I for
+  update to authenticated using (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) with check (
+      is_settlement_owner(settlement_id)
+      or is_settlement_collaborator(settlement_id)
+    ) $sql$,
+    child_table
+);
+execute format(
+  $sql$create policy "Allow delete for member" on public.%1$I for delete to authenticated using (
+    is_settlement_owner(settlement_id)
+    or is_settlement_collaborator(settlement_id)
+  ) $sql$,
+  child_table
+);
+end loop;
+end $$;


### PR DESCRIPTION
## Summary
- Add schema-side `settlement_id` scope to gameplay junction tables and keep it synchronized with parent rows.
- Update realtime subscriptions so affected survivor, hunt, and showdown junctions filter by the active settlement.
- Add ADR/docs, regenerated Supabase types, and focused unit/integration coverage.
- Bump the app version to `0.84.1`.

## Dependency Changes
- None.

## Issues
Closes #189.

## Verification
- `npx prettier --check package.json package-lock.json hooks/use-realtime.tsx __tests__/hooks/use-realtime.test.ts __tests__/integration/rls/junction-settlement-scope.test.ts docs/adrs/realtime-junction-settlement-scope.md docs/settlement-sharing-architecture.md lib/database.types.ts supabase/migrations/20260612000000_junction_settlement_scope.sql`
- `npx vitest run __tests__/hooks/use-realtime.test.ts --coverage.enabled=false`
- `npm run integration-test -- __tests__/integration/rls/junction-settlement-scope.test.ts __tests__/integration/realtime-publication.test.ts __tests__/integration/rls/settlement-scoped.test.ts __tests__/integration/rls/survivor-collaborator-crud.test.ts __tests__/integration/rls/hunt-showdown-collaborator-crud.test.ts`