### PR TITLE
Fix shared catalog realtime refresh for linked content

### DIFF
--- a/__tests__/hooks/use-realtime.test.ts
+++ b/__tests__/hooks/use-realtime.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { TABLE_DOMAIN_MAP } from '@/hooks/use-realtime'
+import {
+  shouldRefreshCatalogForLinkedContentChange,
+  TABLE_DOMAIN_MAP
+} from '@/hooks/use-realtime'
 
 describe('TABLE_DOMAIN_MAP realtime settlement scoping', () => {
   const ACTIVE_SETTLEMENT_ID = 'active-settlement'
@@ -32,4 +35,94 @@ describe('TABLE_DOMAIN_MAP realtime settlement scoping', () => {
       expect(filter).not.toBe(`settlement_id=eq.${UNRELATED_SETTLEMENT_ID}`)
     }
   )
+})
+
+describe('shouldRefreshCatalogForLinkedContentChange', () => {
+  it('refreshes catalog data when a survivor neurosis link appears', () => {
+    expect(
+      shouldRefreshCatalogForLinkedContentChange('survivor', {
+        eventType: 'UPDATE',
+        new: { id: 'survivor-1', neurosis_id: 'neurosis-1' },
+        old: { id: 'survivor-1' }
+      })
+    ).toBe(true)
+  })
+
+  it('refreshes catalog data when a survivor direct catalog link changes', () => {
+    const snapshots = new Map<string, Record<string, unknown>>()
+
+    expect(
+      shouldRefreshCatalogForLinkedContentChange(
+        'survivor',
+        {
+          eventType: 'UPDATE',
+          new: { id: 'survivor-1', neurosis_id: 'neurosis-1' },
+          old: { id: 'survivor-1' }
+        },
+        snapshots
+      )
+    ).toBe(true)
+
+    expect(
+      shouldRefreshCatalogForLinkedContentChange(
+        'survivor',
+        {
+          eventType: 'UPDATE',
+          new: { id: 'survivor-1', neurosis_id: 'neurosis-1' },
+          old: { id: 'survivor-1' }
+        },
+        snapshots
+      )
+    ).toBe(false)
+
+    expect(
+      shouldRefreshCatalogForLinkedContentChange(
+        'survivor',
+        {
+          eventType: 'UPDATE',
+          new: { id: 'survivor-1', neurosis_id: 'neurosis-2' },
+          old: { id: 'survivor-1' }
+        },
+        snapshots
+      )
+    ).toBe(true)
+  })
+
+  it('does not refresh catalog data for ordinary survivor updates', () => {
+    expect(
+      shouldRefreshCatalogForLinkedContentChange('survivor', {
+        eventType: 'UPDATE',
+        new: { id: 'survivor-1', courage: 2 },
+        old: { id: 'survivor-1' }
+      })
+    ).toBe(false)
+  })
+
+  it('refreshes catalog data for survivor catalog junction changes', () => {
+    expect(
+      shouldRefreshCatalogForLinkedContentChange('survivor_disorder', {
+        eventType: 'INSERT',
+        new: {
+          id: 'junction-1',
+          survivor_id: 'survivor-1',
+          disorder_id: 'disorder-1'
+        },
+        old: {}
+      })
+    ).toBe(true)
+  })
+
+  it('refreshes catalog data for monster catalog junction changes', () => {
+    expect(
+      shouldRefreshCatalogForLinkedContentChange('hunt_monster_trait', {
+        eventType: 'INSERT',
+        new: {
+          id: 'junction-1',
+          hunt_monster_id: 'monster-1',
+          trait_id: 'trait-1'
+        },
+        old: {}
+      })
+    ).toBe(true)
+  })
 })

--- a/__tests__/hooks/use-realtime.test.ts
+++ b/__tests__/hooks/use-realtime.test.ts
@@ -98,6 +98,26 @@ describe('shouldRefreshCatalogForLinkedContentChange', () => {
     ).toBe(false)
   })
 
+  it('refreshes catalog data when a direct catalog link is cleared as the first observed event', () => {
+    expect(
+      shouldRefreshCatalogForLinkedContentChange('survivor', {
+        eventType: 'UPDATE',
+        new: { id: 'survivor-1', neurosis_id: null },
+        old: { id: 'survivor-1' }
+      })
+    ).toBe(true)
+  })
+
+  it('refreshes catalog data when a direct catalog-link row is deleted before a snapshot exists', () => {
+    expect(
+      shouldRefreshCatalogForLinkedContentChange('survivor', {
+        eventType: 'DELETE',
+        new: {},
+        old: { id: 'survivor-1' }
+      })
+    ).toBe(true)
+  })
+
   it('refreshes catalog data for survivor catalog junction changes', () => {
     expect(
       shouldRefreshCatalogForLinkedContentChange('survivor_disorder', {

--- a/hooks/use-realtime.tsx
+++ b/hooks/use-realtime.tsx
@@ -257,6 +257,165 @@ export const TABLE_DOMAIN_MAP: Record<string, TableDomainEntry> = {
   nemesis_timeline_year: { domain: 'catalog', filterColumn: null }
 }
 
+/** Realtime Postgres Change Event Type */
+type RealtimeChangeEvent = 'INSERT' | 'UPDATE' | 'DELETE'
+
+/** Minimal shape used from Supabase realtime payloads. */
+interface RealtimeChangePayload {
+  /** Event Type */
+  eventType: RealtimeChangeEvent
+  /** New Row */
+  new: Record<string, unknown>
+  /** Old Row */
+  old: Partial<Record<string, unknown>>
+}
+
+/** Direct catalog foreign-key fields stored on gameplay rows. */
+const DIRECT_CATALOG_LINK_FIELDS_BY_TABLE: Record<string, readonly string[]> = {
+  gear_grid: ['selected_armor_set_id'],
+  survivor: [
+    'knowledge_1_id',
+    'knowledge_2_id',
+    'neurosis_id',
+    'philosophy_id',
+    'tenet_knowledge_id',
+    'weapon_type_id'
+  ]
+}
+
+/** Gameplay junctions whose rows reveal or hide catalog content. */
+const CATALOG_LINK_JUNCTION_TABLES = new Set([
+  'hunt_monster_mood',
+  'hunt_monster_survivor_status',
+  'hunt_monster_trait',
+  'showdown_monster_mood',
+  'showdown_monster_survivor_status',
+  'showdown_monster_trait',
+  'survivor_ability_impairment',
+  'survivor_cursed_gear',
+  'survivor_disorder',
+  'survivor_fighting_art',
+  'survivor_secret_fighting_art'
+])
+
+/** Snapshot of direct catalog-link fields for one gameplay row. */
+type CatalogLinkSnapshot = Record<string, unknown>
+
+/** Catalog-link field snapshots keyed by `table:id`. */
+type CatalogLinkSnapshots = Map<string, CatalogLinkSnapshot>
+
+/**
+ * Get Catalog Link Row Key
+ *
+ * Builds a stable key for direct gameplay rows whose catalog-link fields need
+ * old/new comparison. Realtime UPDATE payloads often carry only the primary key
+ * in `old`, so the hook keeps a per-subscription snapshot after the first
+ * event for each row.
+ *
+ * @param table Table Name
+ * @param payload Realtime Payload
+ * @returns Snapshot Key, or `null` when no row id is available
+ */
+function getCatalogLinkRowKey(
+  table: string,
+  payload: RealtimeChangePayload
+): string | null {
+  const id =
+    typeof payload.new.id === 'string'
+      ? payload.new.id
+      : typeof payload.old.id === 'string'
+        ? payload.old.id
+        : null
+
+  return id ? `${table}:${id}` : null
+}
+
+/**
+ * Pick Catalog Link Fields
+ *
+ * Extracts only the catalog-link fields for a table from a row-shaped object.
+ *
+ * @param table Table Name
+ * @param row Row Data
+ * @returns Link Field Snapshot
+ */
+function pickCatalogLinkFields(
+  table: string,
+  row: Partial<Record<string, unknown>>
+): CatalogLinkSnapshot {
+  const fields = DIRECT_CATALOG_LINK_FIELDS_BY_TABLE[table] ?? []
+  return Object.fromEntries(fields.map((field) => [field, row[field] ?? null]))
+}
+
+/**
+ * Has Any Catalog Link Value
+ *
+ * @param snapshot Direct Link Snapshot
+ * @returns Whether any catalog-link field is populated
+ */
+function hasAnyCatalogLinkValue(snapshot: CatalogLinkSnapshot): boolean {
+  return Object.values(snapshot).some((value) => value != null)
+}
+
+/**
+ * Did Catalog Link Snapshot Change
+ *
+ * @param previous Previous Link Snapshot
+ * @param next Next Link Snapshot
+ * @returns Whether any tracked catalog-link field changed
+ */
+function didCatalogLinkSnapshotChange(
+  previous: CatalogLinkSnapshot,
+  next: CatalogLinkSnapshot
+): boolean {
+  return Object.keys(next).some((field) => previous[field] !== next[field])
+}
+
+/**
+ * Should Refresh Catalog For Linked Content Change
+ *
+ * Returns `true` when a gameplay-table event may have revealed or hidden a
+ * custom catalog row for the active settlement. This plugs the race where a
+ * collaborator misses the original catalog INSERT because the row is not
+ * transitively visible until a survivor / monster / gear-grid link is written.
+ *
+ * @param table Changed Table Name
+ * @param payload Realtime Payload
+ * @param snapshots Direct Link Snapshots
+ * @returns Whether the catalog fan-out should run
+ */
+export function shouldRefreshCatalogForLinkedContentChange(
+  table: string,
+  payload: RealtimeChangePayload,
+  snapshots: CatalogLinkSnapshots = new Map()
+): boolean {
+  if (CATALOG_LINK_JUNCTION_TABLES.has(table)) return true
+
+  if (!DIRECT_CATALOG_LINK_FIELDS_BY_TABLE[table]) return false
+
+  const rowKey = getCatalogLinkRowKey(table, payload)
+  const next = pickCatalogLinkFields(table, payload.new)
+  const previous = rowKey ? snapshots.get(rowKey) : undefined
+  const old = pickCatalogLinkFields(table, payload.old)
+  const oldHasPayloadValues = Object.keys(old).some((field) =>
+    Object.prototype.hasOwnProperty.call(payload.old, field)
+  )
+  const previousSnapshot = oldHasPayloadValues ? old : previous
+
+  if (payload.eventType === 'DELETE') {
+    if (rowKey) snapshots.delete(rowKey)
+    return hasAnyCatalogLinkValue(previousSnapshot ?? old)
+  }
+
+  if (rowKey) snapshots.set(rowKey, next)
+
+  if (payload.eventType === 'INSERT') return hasAnyCatalogLinkValue(next)
+
+  if (!previousSnapshot) return hasAnyCatalogLinkValue(next)
+
+  return didCatalogLinkSnapshotChange(previousSnapshot, next)
+}
+
 /** Debounce delay in milliseconds for batching rapid changes. */
 const DEBOUNCE_MS = 300
 
@@ -327,6 +486,7 @@ export function useRealtimeSubscriptions(
       RealtimeDomain,
       ReturnType<typeof setTimeout>
     >()
+    const catalogLinkSnapshots: CatalogLinkSnapshots = new Map()
 
     /**
      * Handles a Realtime Change
@@ -370,6 +530,37 @@ export function useRealtimeSubscriptions(
       )
     }
 
+    /**
+     * Handles a Postgres Realtime Payload
+     *
+     * Dispatches the table's normal domain and, for gameplay rows that link to
+     * catalog content, also dispatches the catalog fan-out. This refreshes the
+     * materialized catalog state when a custom row becomes visible only after it
+     * is attached to the active settlement.
+     *
+     * @param table Changed Table Name
+     * @param domain Table Domain
+     * @param payload Realtime Payload
+     */
+    const handlePostgresChange = (
+      table: string,
+      domain: RealtimeDomain,
+      payload: RealtimeChangePayload
+    ) => {
+      handleChange(domain)
+
+      if (
+        domain !== 'catalog' &&
+        shouldRefreshCatalogForLinkedContentChange(
+          table,
+          payload,
+          catalogLinkSnapshots
+        )
+      ) {
+        handleChange('catalog')
+      }
+    }
+
     // Create a single channel for all gameplay subscriptions scoped to this
     // settlement. Each table gets its own listener with an appropriate filter.
     let channel = supabase.channel(`settlement-${settlementId}`)
@@ -386,7 +577,7 @@ export function useRealtimeSubscriptions(
             table,
             filter: `${filterColumn}=eq.${settlementId}`
           },
-          () => handleChange(domain)
+          (payload) => handlePostgresChange(table, domain, payload)
         )
       } else {
         // Catalog tables are subscribed unfiltered because realtime filters
@@ -399,7 +590,7 @@ export function useRealtimeSubscriptions(
             schema: 'public',
             table
           },
-          () => handleChange(domain)
+          (payload) => handlePostgresChange(table, domain, payload)
         )
       }
     }
@@ -411,6 +602,7 @@ export function useRealtimeSubscriptions(
     return () => {
       debounceTimers.forEach(clearTimeout)
       debounceTimers.clear()
+      catalogLinkSnapshots.clear()
       supabase.removeChannel(channel)
     }
   }, [options.enabled, options.settlementId])

--- a/hooks/use-realtime.tsx
+++ b/hooks/use-realtime.tsx
@@ -348,6 +348,22 @@ function pickCatalogLinkFields(
 }
 
 /**
+ * Has Any Catalog Link Field
+ *
+ * @param table Table Name
+ * @param row Row Data
+ * @returns Whether the payload carries at least one tracked link field
+ */
+function hasAnyCatalogLinkField(
+  table: string,
+  row: Partial<Record<string, unknown>>
+): boolean {
+  return (DIRECT_CATALOG_LINK_FIELDS_BY_TABLE[table] ?? []).some((field) =>
+    Object.prototype.hasOwnProperty.call(row, field)
+  )
+}
+
+/**
  * Has Any Catalog Link Value
  *
  * @param snapshot Direct Link Snapshot
@@ -397,21 +413,23 @@ export function shouldRefreshCatalogForLinkedContentChange(
   const next = pickCatalogLinkFields(table, payload.new)
   const previous = rowKey ? snapshots.get(rowKey) : undefined
   const old = pickCatalogLinkFields(table, payload.old)
-  const oldHasPayloadValues = Object.keys(old).some((field) =>
-    Object.prototype.hasOwnProperty.call(payload.old, field)
-  )
+  const newHasPayloadValues = hasAnyCatalogLinkField(table, payload.new)
+  const oldHasPayloadValues = hasAnyCatalogLinkField(table, payload.old)
   const previousSnapshot = oldHasPayloadValues ? old : previous
 
   if (payload.eventType === 'DELETE') {
     if (rowKey) snapshots.delete(rowKey)
-    return hasAnyCatalogLinkValue(previousSnapshot ?? old)
+    if (previousSnapshot) return hasAnyCatalogLinkValue(previousSnapshot)
+    return !oldHasPayloadValues
   }
+
+  if (!newHasPayloadValues) return false
 
   if (rowKey) snapshots.set(rowKey, next)
 
   if (payload.eventType === 'INSERT') return hasAnyCatalogLinkValue(next)
 
-  if (!previousSnapshot) return hasAnyCatalogLinkValue(next)
+  if (!previousSnapshot) return true
 
   return didCatalogLinkSnapshotChange(previousSnapshot, next)
 }
@@ -533,10 +551,10 @@ export function useRealtimeSubscriptions(
     /**
      * Handles a Postgres Realtime Payload
      *
-     * Dispatches the table's normal domain and, for gameplay rows that link to
-     * catalog content, also dispatches the catalog fan-out. This refreshes the
-     * materialized catalog state when a custom row becomes visible only after it
-     * is attached to the active settlement.
+     * Dispatches the table's normal domain unless the gameplay row links to
+     * catalog content. Linked-content changes dispatch only the catalog fan-out,
+     * which already refreshes the materialized settlement / survivor / hunt /
+     * showdown state.
      *
      * @param table Changed Table Name
      * @param domain Table Domain
@@ -547,10 +565,12 @@ export function useRealtimeSubscriptions(
       domain: RealtimeDomain,
       payload: RealtimeChangePayload
     ) => {
-      handleChange(domain)
+      if (domain === 'catalog') {
+        handleChange('catalog')
+        return
+      }
 
       if (
-        domain !== 'catalog' &&
         shouldRefreshCatalogForLinkedContentChange(
           table,
           payload,
@@ -558,7 +578,10 @@ export function useRealtimeSubscriptions(
         )
       ) {
         handleChange('catalog')
+        return
       }
+
+      handleChange(domain)
     }
 
     // Create a single channel for all gameplay subscriptions scoped to this

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.84.1",
+  "version": "0.84.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.84.1",
+      "version": "0.84.2",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.84.1",
+  "version": "0.84.2",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary
- Refresh catalog-backed materialized state when gameplay rows link or unlink catalog content that may have just become visible through shared settlement access.
- Covers survivor direct catalog fields including neurosis, knowledges, philosophy, and weapon type, plus survivor and monster catalog junction tables.
- Adds focused realtime hook tests for the neurosis reveal path and related catalog-link classes.
- Bumps the app version from `0.84.1` to `0.84.2`.

## Dependencies
- No dependency changes.

## Related Issues
- Closes #226

## Verification
- `npx vitest run __tests__/hooks/use-realtime.test.ts --coverage.enabled=false`
- `npx prettier --check hooks/use-realtime.tsx __tests__/hooks/use-realtime.test.ts package.json package-lock.json`
- Editor diagnostics checked for `hooks/use-realtime.tsx` and `__tests__/hooks/use-realtime.test.ts`