### PR TITLE
feat: implement weapon proficiency rules and update survivor types

### DIFF
--- a/.agents/skills/supabase-postgres-best-practices/SKILL.md
+++ b/.agents/skills/supabase-postgres-best-practices/SKILL.md
@@ -54,7 +54,7 @@ Reference these guidelines when:
 
 Read individual rule files for detailed explanations and SQL examples:
 
-```
+```plain
 references/query-missing-indexes.md
 references/query-partial-indexes.md
 references/_sections.md

--- a/.agents/skills/supabase/SKILL.md
+++ b/.agents/skills/supabase/SKILL.md
@@ -98,28 +98,34 @@ Supabase-specific security traps that silently create vulnerabilities:
     `auth.role() = 'authenticated'` breaks silently when anonymous sign-ins are
     enabled, because anonymous users carry the `authenticated` Postgres role and
     pass the check regardless of whether the user is genuinely signed in.
+
     ```sql
     -- Deprecated (do not use)
     create policy "example" on table_name for select
     using ( auth.role() = 'authenticated' );
     ```
+
   - **`TO authenticated` alone is authentication without authorization (BOLA /
     IDOR).** Using `TO authenticated` only checks the role — it does not
     restrict which rows a user can access. The correct pattern combines
     `TO authenticated` with an ownership predicate in `USING`:
+
     ```sql
     create policy "example" on table_name for select
     to authenticated
     using ( (select auth.uid()) = user_id );
     ```
+
   - **UPDATE policies require both `USING` and `WITH CHECK`.** Without
     `WITH CHECK`, a user can reassign a row's `user_id` to another user:
+
     ```sql
     create policy "example" on table_name for update
     to authenticated
     using ( (select auth.uid()) = user_id )
     with check ( (select auth.uid()) = user_id );
     ```
+
   - **`SECURITY DEFINER` functions bypass RLS.** A `SECURITY DEFINER` function
     runs with its creator's privileges — typically a role with `bypassrls`
     (e.g., `postgres`). Never add `SECURITY DEFINER` to resolve a permission
@@ -180,11 +186,11 @@ For setup instructions, server URL, and configuration, see the
    is expected (no token) and means the server is up. Timeout or "connection
    refused" means it may be down.
 
-2. **Check `.mcp.json` configuration:** Verify the project root has a valid
+1. **Check `.mcp.json` configuration:** Verify the project root has a valid
    `.mcp.json` with the correct server URL. If missing, create one pointing to
    `https://mcp.supabase.com/mcp`.
 
-3. **Authenticate the MCP server:** If the server is reachable and `.mcp.json`
+1. **Authenticate the MCP server:** If the server is reachable and `.mcp.json`
    is correct but tools aren't visible, the user needs to authenticate. The
    Supabase MCP server uses OAuth 2.1 — tell the user to trigger the auth flow
    in their agent, complete it in the browser, and reload the session.
@@ -195,9 +201,9 @@ Before implementing any Supabase feature, find the relevant documentation. Use
 these methods in priority order:
 
 1. **MCP `search_docs` tool** (preferred — returns relevant snippets directly)
-2. **Fetch docs pages as markdown** — any docs page can be fetched by appending
+1. **Fetch docs pages as markdown** — any docs page can be fetched by appending
    `.md` to the URL path.
-3. **Web search** for Supabase-specific topics when you don't know which page to
+1. **Web search** for Supabase-specific topics when you don't know which page to
    look at.
 
 ## Making and Committing Schema Changes
@@ -216,15 +222,8 @@ If you use it, you'll be stuck with whatever SQL you passed on the first try.
 
 1. **Run advisors** → `supabase db advisors` (CLI v2.81.3+) or MCP
    `get_advisors`. Fix any issues.
-2. **Review the Security Checklist above** if your changes involve views,
+1. **Review the Security Checklist above** if your changes involve views,
    functions, triggers, or storage.
-3. **Generate the migration** →
+1. **Generate the migration** →
    `supabase db pull <descriptive-name> --local --yes`
-4. **Verify** → `supabase migration list --local`
-
-## Reference Guides
-
-- **Skill Feedback** →
-  [references/skill-feedback.md](references/skill-feedback.md) **MUST read
-  when** the user reports that this skill gave incorrect guidance or is missing
-  information.
+1. **Verify** → `supabase migration list --local`

--- a/__tests__/components/survivor/weapon-proficiency-card.test.tsx
+++ b/__tests__/components/survivor/weapon-proficiency-card.test.tsx
@@ -1,0 +1,151 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/custom/custom-rules-sheet', () => ({
+  CustomWeaponTypeRulesIconButton: () => null
+}))
+
+vi.mock('@/components/generic/safe-markdown-editor', () => ({
+  SafeMarkdownPreview: ({ source }: { source: string }) => <div>{source}</div>
+}))
+
+vi.mock('@/components/menu/select-weapon-type', () => ({
+  SelectWeaponType: ({ value }: { value?: string | null }) => (
+    <span>{value ?? 'Select Type'}</span>
+  )
+}))
+
+vi.mock('@/lib/dal/survivor', () => ({
+  updateSurvivor: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() }
+}))
+
+import {
+  getVisibleWeaponProficiencyRules,
+  WeaponProficiencyCard
+} from '@/components/survivor/weapon-proficiency/weapon-proficiency-card'
+import { SurvivorDetail, SurvivorsStateSetter } from '@/lib/types'
+
+const axe = {
+  id: 'axe',
+  custom: false,
+  weapon_type_name: 'Axe',
+  specialist_proficiency_rules: 'Axe specialist rules',
+  master_proficiency_rules: 'Axe master rules',
+  author_user_id: null,
+  author_username: null,
+  author_avatar_url: null
+} satisfies NonNullable<SurvivorDetail['weapon_type']>
+
+const bow = {
+  id: 'bow',
+  custom: false,
+  weapon_type_name: 'Bow',
+  specialist_proficiency_rules: 'Bow specialist rules',
+  master_proficiency_rules: 'Bow master rules',
+  author_user_id: null,
+  author_username: null,
+  author_avatar_url: null
+} satisfies NonNullable<SurvivorDetail['weapon_type']>
+
+function survivor(
+  id: string,
+  weaponTypeId: string | null,
+  weaponProficiency: number,
+  weaponType: SurvivorDetail['weapon_type'] = null
+): SurvivorDetail {
+  return {
+    id,
+    weapon_type_id: weaponTypeId,
+    weapon_proficiency: weaponProficiency,
+    weapon_type: weaponType
+  } as SurvivorDetail
+}
+
+describe('getVisibleWeaponProficiencyRules', () => {
+  it('grants specialist rules from another survivor with matching mastery', () => {
+    const rules = getVisibleWeaponProficiencyRules({
+      selectedSurvivorId: 'new-blood',
+      survivors: [survivor('master', 'axe', 8)],
+      weaponProficiency: 0,
+      weaponTypeId: 'axe',
+      weaponType: axe
+    })
+
+    expect(rules).toEqual([
+      {
+        label: 'Specialist',
+        source: 'Settlement mastery',
+        rules: 'Axe specialist rules'
+      }
+    ])
+  })
+
+  it('does not grant specialist rules from mastery of a different weapon', () => {
+    const rules = getVisibleWeaponProficiencyRules({
+      selectedSurvivorId: 'new-blood',
+      survivors: [survivor('master', 'bow', 8)],
+      weaponProficiency: 0,
+      weaponTypeId: 'axe',
+      weaponType: axe
+    })
+
+    expect(rules).toEqual([])
+  })
+
+  it('shows specialist and master rules when the survivor reaches mastery', () => {
+    const rules = getVisibleWeaponProficiencyRules({
+      selectedSurvivorId: 'master',
+      survivors: [survivor('master', 'axe', 8)],
+      weaponProficiency: 8,
+      weaponTypeId: 'axe',
+      weaponType: axe
+    })
+
+    expect(rules).toEqual([
+      {
+        label: 'Specialist',
+        source: 'Rank III',
+        rules: 'Axe specialist rules'
+      },
+      { label: 'Master', source: 'Rank VIII', rules: 'Axe master rules' }
+    ])
+  })
+
+  it('ignores blank proficiency rules', () => {
+    const weaponType = {
+      ...bow,
+      specialist_proficiency_rules: '   ',
+      master_proficiency_rules: null
+    }
+
+    const rules = getVisibleWeaponProficiencyRules({
+      selectedSurvivorId: 'new-blood',
+      survivors: [survivor('master', 'bow', 8)],
+      weaponProficiency: 8,
+      weaponTypeId: 'bow',
+      weaponType
+    })
+
+    expect(rules).toEqual([])
+  })
+})
+
+describe('WeaponProficiencyCard', () => {
+  it('renders settlement mastery specialist rules for the selected weapon', () => {
+    const html = renderToStaticMarkup(
+      <WeaponProficiencyCard
+        selectedSurvivor={survivor('new-blood', 'axe', 0, axe)}
+        setSurvivors={vi.fn() as unknown as SurvivorsStateSetter}
+        survivors={[survivor('master', 'axe', 8)]}
+      />
+    )
+
+    expect(html).toContain('Settlement mastery')
+    expect(html).toContain('Axe specialist rules')
+    expect(html).not.toContain('Axe master rules')
+  })
+})

--- a/__tests__/lib/dal/survivor.test.ts
+++ b/__tests__/lib/dal/survivor.test.ts
@@ -169,7 +169,8 @@ describe('getSurvivor', () => {
       knowledge_2: null,
       neurosis: null,
       philosophy: null,
-      tenet_knowledge: null
+      tenet_knowledge: null,
+      weapon_type: null
     }
     const mockMaybeSingle = vi
       .fn()
@@ -191,8 +192,12 @@ describe('getSurvivor', () => {
       neurosis: null,
       philosophy: null,
       secret_fighting_arts: [],
-      tenet_knowledge: null
+      tenet_knowledge: null,
+      weapon_type: null
     })
+    expect(mockSelect).toHaveBeenCalledWith(
+      expect.stringContaining('weapon_type(')
+    )
   })
 })
 
@@ -242,7 +247,8 @@ describe('getSurvivors', () => {
       knowledge_2: null,
       neurosis: null,
       philosophy: null,
-      tenet_knowledge: null
+      tenet_knowledge: null,
+      weapon_type: null
     }
     const mockReturns = vi
       .fn()
@@ -260,7 +266,8 @@ describe('getSurvivors', () => {
       disorders: [],
       embarked: false,
       fighting_arts: [],
-      secret_fighting_arts: []
+      secret_fighting_arts: [],
+      weapon_type: null
     })
   })
 
@@ -315,7 +322,15 @@ describe('getSurvivors', () => {
       knowledge_2: null,
       neurosis: null,
       philosophy: null,
-      tenet_knowledge: null
+      tenet_knowledge: null,
+      weapon_type: {
+        id: 'wt-1',
+        custom: true,
+        user_id: 'author-1',
+        weapon_type_name: 'Axe',
+        specialist_proficiency_rules: 'Axe specialist rules',
+        master_proficiency_rules: 'Axe master rules'
+      }
     }
 
     const mockReturns = vi
@@ -358,6 +373,12 @@ describe('getSurvivors', () => {
     expect(result![0].knowledge_1?.author_avatar_url).toBe(
       'https://a/ashen.png'
     )
+    expect(result![0].weapon_type?.author_username).toBe('ashen.veil')
+    expect(result![0].weapon_type?.author_user_id).toBe('author-1')
+    expect(result![0].weapon_type?.author_avatar_url).toBe(
+      'https://a/ashen.png'
+    )
+    expect(result![0].weapon_type).not.toHaveProperty('user_id')
     expect(mockSupabase.rpc).toHaveBeenCalledWith(
       'get_settlement_member_usernames',
       { target_settlement: 'set-1' }
@@ -387,7 +408,8 @@ describe('getSurvivors', () => {
       knowledge_2: null,
       neurosis: null,
       philosophy: null,
-      tenet_knowledge: null
+      tenet_knowledge: null,
+      weapon_type: null
     }
 
     const mockReturns = vi

--- a/components/menu/select-weapon-type.tsx
+++ b/components/menu/select-weapon-type.tsx
@@ -31,7 +31,7 @@ export interface SelectWeaponTypeProps {
   /** Disabled State */
   disabled?: boolean
   /** OnChange Handler */
-  onChange?: (value: string) => void
+  onChange?: (value: string, weaponType?: WeaponTypeDetail | null) => void
   /** Value */
   value?: string | null
 }
@@ -83,7 +83,8 @@ export function SelectWeaponType({
    * @param type Selected Weapon Type
    */
   const handleTypeSelect = (type: string) => {
-    onChange?.(type === value ? '' : type)
+    const nextTypeId = type === value ? '' : type
+    onChange?.(nextTypeId, nextTypeId ? weaponTypes[nextTypeId] : null)
     setOpen(false)
   }
 
@@ -130,7 +131,7 @@ export function SelectWeaponType({
         })
 
         setWeaponTypes((prev) => ({ ...prev, [newType.id]: newType }))
-        onChange?.(newType.id)
+        onChange?.(newType.id, newType)
         setSearch('')
         setCreateDialogOpen(false)
       } catch (error) {

--- a/components/survivor/survivor-card.tsx
+++ b/components/survivor/survivor-card.tsx
@@ -136,6 +136,7 @@ export function SurvivorCard({
             <WeaponProficiencyCard
               selectedSurvivor={selectedSurvivor}
               setSurvivors={setSurvivors}
+              survivors={survivors}
             />
             <CourageUnderstandingCard
               selectedSettlement={selectedSettlement}

--- a/components/survivor/weapon-proficiency/weapon-proficiency-card.tsx
+++ b/components/survivor/weapon-proficiency/weapon-proficiency-card.tsx
@@ -1,14 +1,150 @@
 'use client'
 
 import { CustomWeaponTypeRulesIconButton } from '@/components/custom/custom-rules-sheet'
+import { SafeMarkdownPreview } from '@/components/generic/safe-markdown-editor'
 import { SelectWeaponType } from '@/components/menu/select-weapon-type'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import { updateSurvivor } from '@/lib/dal/survivor'
 import { ERROR_MESSAGE } from '@/lib/messages'
-import { SurvivorDetail, SurvivorsStateSetter } from '@/lib/types'
+import {
+  SurvivorDetail,
+  SurvivorsStateSetter,
+  WeaponTypeDetail
+} from '@/lib/types'
+import { cn } from '@/lib/utils'
 import { ReactElement, useCallback, useState } from 'react'
 import { toast } from 'sonner'
+
+const SPECIALIST_PROFICIENCY_RANK = 3
+const MASTER_PROFICIENCY_RANK = 8
+
+const RULES_MARKDOWN_CLASS = cn(
+  'bg-transparent !text-xs !leading-relaxed',
+  '[&_p]:!text-xs [&_p]:!leading-relaxed [&_p]:!my-1',
+  '[&_p:first-child]:!mt-0 [&_p:last-child]:!mb-0',
+  '[&_strong]:!font-semibold [&_strong]:!text-foreground',
+  '[&_ul]:!my-1 [&_ul]:!pl-4 [&_ul]:!list-disc',
+  '[&_ol]:!my-1 [&_ol]:!pl-4 [&_ol]:!list-decimal',
+  '[&_li]:!text-xs [&_li]:!leading-relaxed [&_li]:!my-0.5'
+)
+
+type SelectedWeaponType = Pick<
+  WeaponTypeDetail,
+  | 'id'
+  | 'custom'
+  | 'weapon_type_name'
+  | 'specialist_proficiency_rules'
+  | 'master_proficiency_rules'
+> &
+  Partial<
+    Pick<
+      NonNullable<SurvivorDetail['weapon_type']>,
+      'author_user_id' | 'author_username' | 'author_avatar_url'
+    >
+  >
+
+interface VisibleWeaponProficiencyRule {
+  /** Rule Label */
+  label: 'Specialist' | 'Master'
+  /** Source Label */
+  source: string
+  /** Rule Markdown */
+  rules: string
+}
+
+interface VisibleWeaponProficiencyRuleInput {
+  /** Selected Survivor ID */
+  selectedSurvivorId: string | null | undefined
+  /** Settlement Survivors */
+  survivors: SurvivorDetail[]
+  /** Weapon Proficiency Rank */
+  weaponProficiency: number
+  /** Selected Weapon Type ID */
+  weaponTypeId: string | null
+  /** Selected Weapon Type */
+  weaponType: SelectedWeaponType | null
+}
+
+function hasRules(rules: string | null | undefined): rules is string {
+  return !!rules?.trim()
+}
+
+/**
+ * Get Visible Weapon Proficiency Rules
+ *
+ * Determines which proficiency rules apply to the selected survivor. Specialist
+ * rules are visible at rank III or when another settlement survivor has mastery
+ * of the same weapon. Master rules are visible only at rank VIII.
+ *
+ * @param input Weapon proficiency state
+ * @returns Visible proficiency rule blocks
+ */
+export function getVisibleWeaponProficiencyRules({
+  selectedSurvivorId,
+  survivors,
+  weaponProficiency,
+  weaponTypeId,
+  weaponType
+}: VisibleWeaponProficiencyRuleInput): VisibleWeaponProficiencyRule[] {
+  if (!weaponTypeId || !weaponType || weaponType.id !== weaponTypeId) return []
+
+  const rules: VisibleWeaponProficiencyRule[] = []
+  const hasOwnSpecialist = weaponProficiency >= SPECIALIST_PROFICIENCY_RANK
+  const hasOwnMastery = weaponProficiency >= MASTER_PROFICIENCY_RANK
+  const hasSettlementMastery = survivors.some(
+    (survivor) =>
+      survivor.id !== selectedSurvivorId &&
+      survivor.weapon_type_id === weaponTypeId &&
+      survivor.weapon_proficiency >= MASTER_PROFICIENCY_RANK
+  )
+
+  if (
+    hasRules(weaponType.specialist_proficiency_rules) &&
+    (hasOwnSpecialist || hasSettlementMastery)
+  ) {
+    rules.push({
+      label: 'Specialist',
+      source: hasOwnSpecialist ? 'Rank III' : 'Settlement mastery',
+      rules: weaponType.specialist_proficiency_rules
+    })
+  }
+
+  if (hasRules(weaponType.master_proficiency_rules) && hasOwnMastery) {
+    rules.push({
+      label: 'Master',
+      source: 'Rank VIII',
+      rules: weaponType.master_proficiency_rules
+    })
+  }
+
+  return rules
+}
+
+function WeaponProficiencyRulesBlock({
+  rule
+}: {
+  rule: VisibleWeaponProficiencyRule
+}): ReactElement {
+  return (
+    <section className="flex flex-col gap-1.5 rounded-md border border-border/60 bg-muted/30 px-3 py-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-foreground">
+          {rule.label}
+        </h4>
+        <Badge variant="secondary" className="text-[10px] font-normal">
+          {rule.source}
+        </Badge>
+      </div>
+      <SafeMarkdownPreview
+        source={rule.rules}
+        className={RULES_MARKDOWN_CLASS}
+        style={{ backgroundColor: 'transparent' }}
+      />
+    </section>
+  )
+}
 
 /**
  * Weapon Proficiency Card Properties
@@ -18,6 +154,8 @@ interface WeaponProficiencyCardProps {
   selectedSurvivor: SurvivorDetail | null
   /** Set Survivors */
   setSurvivors: SurvivorsStateSetter
+  /** Settlement Survivors */
+  survivors: SurvivorDetail[]
 }
 
 /**
@@ -33,7 +171,8 @@ interface WeaponProficiencyCardProps {
  */
 export function WeaponProficiencyCard({
   selectedSurvivor,
-  setSurvivors
+  setSurvivors,
+  survivors
 }: WeaponProficiencyCardProps): ReactElement {
   const [prevSurvivor, setPrevSurvivor] = useState(selectedSurvivor)
 
@@ -43,12 +182,24 @@ export function WeaponProficiencyCard({
   const [weaponTypeId, setWeaponTypeId] = useState<string | null>(
     selectedSurvivor?.weapon_type_id ?? null
   )
+  const [weaponType, setWeaponType] = useState<SelectedWeaponType | null>(
+    selectedSurvivor?.weapon_type ?? null
+  )
 
   if (prevSurvivor !== selectedSurvivor) {
     setPrevSurvivor(selectedSurvivor)
     setWeaponProficiency(selectedSurvivor?.weapon_proficiency ?? 0)
     setWeaponTypeId(selectedSurvivor?.weapon_type_id ?? null)
+    setWeaponType(selectedSurvivor?.weapon_type ?? null)
   }
+
+  const visibleRules = getVisibleWeaponProficiencyRules({
+    selectedSurvivorId: selectedSurvivor?.id,
+    survivors,
+    weaponProficiency,
+    weaponTypeId,
+    weaponType
+  })
 
   /**
    * Handle Weapon Proficiency Level Checkbox Change
@@ -98,11 +249,13 @@ export function WeaponProficiencyCard({
    * @param type Selected weapon type
    */
   const handleWeaponTypeChange = useCallback(
-    (type: string) => {
+    (type: string, selectedWeaponType?: WeaponTypeDetail | null) => {
       const oldWeaponTypeId = weaponTypeId
       const oldProficiency = weaponProficiency
+      const oldWeaponType = weaponType
 
       setWeaponTypeId(type || null)
+      setWeaponType(selectedWeaponType ?? null)
       setWeaponProficiency(0)
 
       setSurvivors((prev) =>
@@ -123,6 +276,7 @@ export function WeaponProficiencyCard({
         weapon_proficiency: 0
       }).catch((error) => {
         setWeaponTypeId(oldWeaponTypeId)
+        setWeaponType(oldWeaponType)
         setWeaponProficiency(oldProficiency)
         setSurvivors((prev) =>
           prev.map((s) =>
@@ -140,7 +294,13 @@ export function WeaponProficiencyCard({
         toast.error(ERROR_MESSAGE())
       })
     },
-    [weaponProficiency, weaponTypeId, selectedSurvivor?.id, setSurvivors]
+    [
+      weaponProficiency,
+      weaponType,
+      weaponTypeId,
+      selectedSurvivor?.id,
+      setSurvivors
+    ]
   )
 
   return (
@@ -204,6 +364,17 @@ export function WeaponProficiencyCard({
             </div>
           </div>
         </div>
+
+        {visibleRules.length > 0 && (
+          <div className="mt-3 grid gap-2">
+            {visibleRules.map((rule) => (
+              <WeaponProficiencyRulesBlock
+                key={`${rule.label}-${rule.source}`}
+                rule={rule}
+              />
+            ))}
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/lib/dal/survivor.ts
+++ b/lib/dal/survivor.ts
@@ -55,7 +55,8 @@ const SURVIVOR_SELECT = `
   knowledge_2:knowledge!survivor_knowledge_2_id_fkey(id, custom, user_id, knowledge_name, rules, observation_conditions, observation_rank_up_milestone),
   neurosis(id, custom, user_id, neurosis_name, rules),
   philosophy(id, custom, user_id, philosophy_name, hunt_xp_milestones, tenet_knowledge_id, tier),
-  tenet_knowledge:knowledge!survivor_tenet_knowledge_id_fkey(id, custom, user_id, knowledge_name, rules, observation_conditions, observation_rank_up_milestone)
+  tenet_knowledge:knowledge!survivor_tenet_knowledge_id_fkey(id, custom, user_id, knowledge_name, rules, observation_conditions, observation_rank_up_milestone),
+  weapon_type(id, custom, user_id, weapon_type_name, specialist_proficiency_rules, master_proficiency_rules)
 `
 
 /**
@@ -127,6 +128,9 @@ type SurvivorRow = Tables<'survivor'> & {
   tenet_knowledge: WithAuthorship<
     Omit<NonNullable<SurvivorDetail['tenet_knowledge']>, AuthorshipKeys>
   > | null
+  weapon_type: WithAuthorship<
+    Omit<NonNullable<SurvivorDetail['weapon_type']>, AuthorshipKeys>
+  > | null
 }
 
 /**
@@ -192,6 +196,7 @@ function mapSurvivorRow(
     neurosis,
     philosophy,
     tenet_knowledge,
+    weapon_type,
     ...survivor
   } = row
 
@@ -251,6 +256,9 @@ function mapSurvivorRow(
       ),
     tenet_knowledge: tenet_knowledge
       ? withAuthorUsername(tenet_knowledge, memberProfiles)
+      : null,
+    weapon_type: weapon_type
+      ? withAuthorUsername(weapon_type, memberProfiles)
       : null
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1557,6 +1557,30 @@ export type SurvivorDetail = Tables<'survivor'> & {
     /** Author Avatar URL (null for built-ins / ghost / no avatar) */
     author_avatar_url: string | null
   } | null
+  /**
+   * Weapon Type.
+   *
+   * Carries the selected weapon type's specialist/mastery rules so survivor
+   * cards can render proficiency bonuses without a second catalog lookup.
+   */
+  weapon_type: {
+    /** Weapon Type ID */
+    id: string
+    /** Weapon Type Name */
+    weapon_type_name: string
+    /** Custom */
+    custom: boolean
+    /** Specialist Proficiency Rules */
+    specialist_proficiency_rules: string | null
+    /** Master Proficiency Rules */
+    master_proficiency_rules: string | null
+    /** Author User ID (null for built-ins / non-custom rows) */
+    author_user_id: string | null
+    /** Author Username (null for built-ins / ghost authors) */
+    author_username: string | null
+    /** Author Avatar URL (null for built-ins / ghost / no avatar) */
+    author_avatar_url: string | null
+  } | null
 }
 
 /**


### PR DESCRIPTION
This pull request introduces a significant enhancement to the weapon proficiency feature for survivors, focusing on displaying weapon proficiency rules based on survivor status and settlement mastery. It also updates the data access layer and related components to support these new capabilities, including test coverage and type/interface adjustments.

Closes https://github.com/ncalteen/kdm-app/issues/91