### PR TITLE
Add UI auth session helpers

### DIFF
--- a/__tests__/ui/auth-session.test.ts
+++ b/__tests__/ui/auth-session.test.ts
@@ -1,0 +1,36 @@
+import {
+  assertAuthenticatedShell,
+  assertProtectedRouteRedirectsToLogin,
+  createAuthAccount,
+  createConfirmedAuthAccount,
+  logIn,
+  logOut
+} from '@/__tests__/ui/helpers/auth'
+import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import { test } from '@playwright/test'
+
+test.describe('auth session flow', () => {
+  const emailsToDelete = new Set<string>()
+
+  test.afterEach(async () => {
+    await deleteUsersByEmail(emailsToDelete)
+    emailsToDelete.clear()
+  })
+
+  test('logs in a confirmed user, persists the session, and logs out', async ({
+    page
+  }) => {
+    const account = createAuthAccount('session')
+    emailsToDelete.add(account.email)
+
+    await createConfirmedAuthAccount(account)
+    await assertProtectedRouteRedirectsToLogin(page)
+
+    await logIn(page, account)
+    await page.reload()
+    await assertAuthenticatedShell(page)
+
+    await logOut(page)
+    await assertProtectedRouteRedirectsToLogin(page)
+  })
+})

--- a/__tests__/ui/helpers/auth.ts
+++ b/__tests__/ui/helpers/auth.ts
@@ -1,0 +1,107 @@
+import {
+  createConfirmedUserFixture,
+  type ConfirmedUserFixture
+} from '@/__tests__/ui/helpers/supabase'
+import { expect, type Page } from '@playwright/test'
+import { type User } from '@supabase/supabase-js'
+
+/** Auth Account Fixture */
+export type AuthAccount = ConfirmedUserFixture
+
+/**
+ * Create Auth Account
+ *
+ * Builds a unique auth account fixture for UI tests.
+ *
+ * @param prefix Account Prefix
+ * @returns Auth Account Fixture
+ */
+export function createAuthAccount(prefix: string): AuthAccount {
+  const suffix = crypto.randomUUID().replaceAll('-', '').slice(0, 10)
+
+  return {
+    email: `e2e-${prefix}-${suffix}@example.test`,
+    password: 'ValidPass1!',
+    username: `${prefix}_${suffix}`.slice(0, 20)
+  }
+}
+
+/**
+ * Create Confirmed Auth Account
+ *
+ * Creates a confirmed auth user with the application default user rows.
+ *
+ * @param account Auth Account Fixture
+ * @returns Created Auth User
+ */
+export async function createConfirmedAuthAccount(
+  account: AuthAccount
+): Promise<User> {
+  return createConfirmedUserFixture(account)
+}
+
+/**
+ * Assert Login Page
+ *
+ * @param page Playwright Page
+ */
+export async function assertLoginPage(page: Page): Promise<void> {
+  await expect(page).toHaveURL(/\/auth\/login$/)
+  await expect(page.getByText('Welcome back, survivor.')).toBeVisible()
+}
+
+/**
+ * Log In
+ *
+ * Logs in through the public email/password login form.
+ *
+ * @param page Playwright Page
+ * @param account Auth Account Fixture
+ */
+export async function logIn(page: Page, account: AuthAccount): Promise<void> {
+  await page.goto('/auth/login')
+  await assertLoginPage(page)
+
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password').fill(account.password)
+  await page.getByRole('button', { name: /^Login$/ }).click()
+
+  await assertAuthenticatedShell(page)
+}
+
+/**
+ * Log Out
+ *
+ * Logs out through the sign-out route and verifies the login redirect.
+ *
+ * @param page Playwright Page
+ */
+export async function logOut(page: Page): Promise<void> {
+  await page.goto('/auth/sign-out')
+  await assertLoginPage(page)
+}
+
+/**
+ * Assert Authenticated Shell
+ *
+ * Verifies that the authenticated app shell has rendered for a user with no
+ * selected settlement.
+ *
+ * @param page Playwright Page
+ */
+export async function assertAuthenticatedShell(page: Page): Promise<void> {
+  await expect(page).toHaveURL(/\/$/)
+  await expect(page.getByText('The lantern is unlit.')).toBeVisible()
+}
+
+/**
+ * Assert Protected Route Redirects To Login
+ *
+ * @param page Playwright Page
+ */
+export async function assertProtectedRouteRedirectsToLogin(
+  page: Page
+): Promise<void> {
+  await page.goto('/')
+  await assertLoginPage(page)
+}

--- a/docs/ui-tests.md
+++ b/docs/ui-tests.md
@@ -45,6 +45,10 @@ The pilot spec in `__tests__/ui/auth-sign-up.test.ts` covers:
 - Confirmed-email conflicts returned by Supabase Auth.
 - Supabase RPC failures surfaced in the inline form alert.
 
+The session spec in `__tests__/ui/auth-session.test.ts` covers confirmed-user
+login, authenticated shell rendering, session persistence across reload, logout,
+and protected-route redirects.
+
 ## CI
 
 The `UI Tests (Playwright)` job in


### PR DESCRIPTION
## Summary

- add reusable Playwright auth helpers for confirmed account setup, login, logout, authenticated shell assertions, and protected-route redirect assertions
- add a browser session test covering confirmed-user login, reload persistence, logout, and anonymous redirect behavior
- document the new auth session UI coverage

## Tests

- npx prettier --check __tests__/ui/helpers/auth.ts __tests__/ui/auth-session.test.ts docs/ui-tests.md
- git diff --check
- npm run ui-test -- __tests__/ui/auth-session.test.ts --project=desktop-chromium

Closes #272