### PR TITLE
Add UI password reset flow coverage

### DIFF
--- a/__tests__/ui/auth-password-reset.test.ts
+++ b/__tests__/ui/auth-password-reset.test.ts
@@ -1,0 +1,63 @@
+import {
+  assertAuthErrorPage,
+  assertLoginFailure,
+  createAuthAccount,
+  createConfirmedAuthAccount,
+  logIn,
+  logOut,
+  requestPasswordReset,
+  updatePassword
+} from '@/__tests__/ui/helpers/auth'
+import {
+  clearMailpitMessages,
+  extractRecoveryUrl,
+  waitForMessageTo
+} from '@/__tests__/ui/helpers/mailpit'
+import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import { expect, test } from '@playwright/test'
+
+test.describe('password reset flow', () => {
+  const emailsToDelete = new Set<string>()
+
+  test.beforeEach(async () => {
+    await clearMailpitMessages()
+  })
+
+  test.afterEach(async () => {
+    await deleteUsersByEmail(emailsToDelete)
+    emailsToDelete.clear()
+    await clearMailpitMessages()
+  })
+
+  test('sends a recovery email, updates the password, and rejects a reused link', async ({
+    page
+  }) => {
+    const account = createAuthAccount('recovery')
+    const updatedAccount = { ...account, password: 'NewValidPass1!' }
+    emailsToDelete.add(account.email)
+
+    await createConfirmedAuthAccount(account)
+
+    await requestPasswordReset(page, account.email)
+    const message = await waitForMessageTo(account.email, {
+      subjectIncludes: 'Reset Your Password'
+    })
+    const recoveryUrl = extractRecoveryUrl(message.detail)
+
+    expect(JSON.stringify(message.detail)).toContain('Reset password')
+    expect(recoveryUrl).toContain('/auth/v1/verify')
+    expect(decodeURIComponent(recoveryUrl)).toContain('type=recovery')
+    expect(decodeURIComponent(recoveryUrl)).toContain('/auth/update-password')
+
+    await page.goto(recoveryUrl)
+    await updatePassword(page, updatedAccount.password)
+    await logOut(page)
+
+    await assertLoginFailure(page, account, 'Invalid login credentials')
+    await logIn(page, updatedAccount)
+    await logOut(page)
+
+    await page.goto(recoveryUrl)
+    await assertAuthErrorPage(page)
+  })
+})

--- a/__tests__/ui/helpers/auth.ts
+++ b/__tests__/ui/helpers/auth.ts
@@ -51,6 +51,18 @@ export async function assertLoginPage(page: Page): Promise<void> {
 }
 
 /**
+ * Assert Auth Error Page
+ *
+ * @param page Playwright Page
+ */
+export async function assertAuthErrorPage(page: Page): Promise<void> {
+  await expect(page).toHaveURL(/\/auth\/error/)
+  await expect(
+    page.getByText('The darkness swallows your words. Please try again.')
+  ).toBeVisible()
+}
+
+/**
  * Log In
  *
  * Logs in through the public email/password login form.
@@ -70,6 +82,31 @@ export async function logIn(page: Page, account: AuthAccount): Promise<void> {
 }
 
 /**
+ * Assert Login Failure
+ *
+ * @param page Playwright Page
+ * @param account Auth Account Fixture
+ * @param expectedMessage Expected Error Message
+ */
+export async function assertLoginFailure(
+  page: Page,
+  account: AuthAccount,
+  expectedMessage: string | RegExp
+): Promise<void> {
+  await page.goto('/auth/login')
+  await assertLoginPage(page)
+
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password').fill(account.password)
+  await page.getByRole('button', { name: /^Login$/ }).click()
+
+  await expect(page).toHaveURL(/\/auth\/login$/)
+  await expect(page.locator('[data-slot="alert"]')).toContainText(
+    expectedMessage
+  )
+}
+
+/**
  * Log Out
  *
  * Logs out through the sign-out route and verifies the login redirect.
@@ -79,6 +116,48 @@ export async function logIn(page: Page, account: AuthAccount): Promise<void> {
 export async function logOut(page: Page): Promise<void> {
   await page.goto('/auth/sign-out')
   await assertLoginPage(page)
+}
+
+/**
+ * Request Password Reset
+ *
+ * Requests a password reset email through the public forgot-password form.
+ *
+ * @param page Playwright Page
+ * @param email Email Address
+ */
+export async function requestPasswordReset(
+  page: Page,
+  email: string
+): Promise<void> {
+  await page.goto('/auth/forgot-password')
+  await expect(page.getByText('Reset your password')).toBeVisible()
+
+  await page.getByLabel('Email').fill(email)
+  await page.getByRole('button', { name: 'Send reset email' }).click()
+
+  await expect(page.getByText('Check your email')).toBeVisible()
+}
+
+/**
+ * Update Password
+ *
+ * Submits a new password through the update-password page.
+ *
+ * @param page Playwright Page
+ * @param password New Password
+ */
+export async function updatePassword(
+  page: Page,
+  password: string
+): Promise<void> {
+  await expect(page).toHaveURL(/\/auth\/update-password/)
+  await expect(page.getByText('Choose a new password')).toBeVisible()
+
+  await page.getByLabel('New password').fill(password)
+  await page.getByRole('button', { name: 'Save new password' }).click()
+
+  await assertAuthenticatedShell(page)
 }
 
 /**

--- a/__tests__/ui/helpers/mailpit.ts
+++ b/__tests__/ui/helpers/mailpit.ts
@@ -62,15 +62,67 @@ export async function waitForMessageTo(
  * @returns Supabase Confirmation URL
  */
 export function extractConfirmationUrl(message: unknown): string {
+  return extractAuthActionUrl(
+    message,
+    (url) => url.includes('/auth/v1/verify') || url.includes('/auth/confirm'),
+    'Confirmation URL not found in email'
+  )
+}
+
+/**
+ * Extract Recovery URL
+ *
+ * @param message Captured Mail Message
+ * @returns Supabase Password Recovery URL
+ */
+export function extractRecoveryUrl(message: unknown): string {
+  return extractAuthActionUrl(
+    message,
+    (url) => {
+      const decodedUrl = decodeUrl(url)
+      return (
+        decodedUrl.includes('/auth/v1/verify') &&
+        decodedUrl.includes('type=recovery')
+      )
+    },
+    'Recovery URL not found in email'
+  )
+}
+
+/**
+ * Extract Auth Action URL
+ *
+ * @param message Captured Mail Message
+ * @param predicate URL Match Predicate
+ * @param errorMessage Error Message
+ * @returns Matching Auth Action URL
+ */
+function extractAuthActionUrl(
+  message: unknown,
+  predicate: (url: string) => boolean,
+  errorMessage: string
+): string {
   const content = JSON.stringify(message).replaceAll('&amp;', '&')
   const urls = content.match(/https?:\/\/[^"'<>\\\s]+/g) ?? []
-  const confirmationUrl = urls.find(
-    (url) => url.includes('/auth/v1/verify') || url.includes('/auth/confirm')
-  )
+  const actionUrl = urls.find(predicate)
 
-  if (!confirmationUrl) throw new Error('Confirmation URL not found in email')
+  if (!actionUrl) throw new Error(errorMessage)
 
-  return confirmationUrl
+  return actionUrl
+}
+
+/**
+ * Decode URL
+ *
+ * @param url URL
+ * @returns Decoded URL, falling back to the original value if decoding fails
+ */
+function decodeUrl(url: string): string {
+  try {
+    return decodeURIComponent(url)
+  } catch {
+    return url
+  }
 }
 
 /**

--- a/app/auth/update-password/page.tsx
+++ b/app/auth/update-password/page.tsx
@@ -1,5 +1,6 @@
 import { AuthLayout } from '@/components/auth/auth-layout'
 import { UpdatePasswordForm } from '@/components/update-password-form'
+import { redirect } from 'next/navigation'
 
 /**
  * Update Password Page
@@ -10,7 +11,20 @@ import { UpdatePasswordForm } from '@/components/update-password-form'
  *
  * @returns Update Password Page Component
  */
-export default function Page() {
+export default async function Page({
+  searchParams
+}: {
+  searchParams: Promise<{
+    error?: string
+    error_code?: string
+    error_description?: string
+  }>
+}) {
+  const params = await searchParams
+  const error = params.error_description ?? params.error_code ?? params.error
+
+  if (error) redirect(`/auth/error?error=${encodeURIComponent(error)}`)
+
   return (
     <AuthLayout>
       <UpdatePasswordForm />

--- a/docs/ui-tests.md
+++ b/docs/ui-tests.md
@@ -49,6 +49,10 @@ The session spec in `__tests__/ui/auth-session.test.ts` covers confirmed-user
 login, authenticated shell rendering, session persistence across reload, logout,
 and protected-route redirects.
 
+The password reset spec in `__tests__/ui/auth-password-reset.test.ts` covers the
+forgot-password form, Mailpit recovery email capture, update-password form,
+old/new password login behavior, and reused recovery-link failure.
+
 ## CI
 
 The `UI Tests (Playwright)` job in

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   testMatch: '*.test.ts',
   fullyParallel: false,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   reporter: process.env.CI
     ? [['github'], ['html', { open: 'never' }]]
     : [['list']],


### PR DESCRIPTION
## Summary

- add Playwright coverage for the forgot-password and update-password flow using Mailpit recovery emails
- add auth helper coverage for login failures, auth error pages, password reset requests, and password updates
- route failed/reused recovery callbacks from update-password to the shared auth error page
- keep UI tests serial locally and in CI because the suite shares a local Supabase/Mailpit stack

## Tests

- npx prettier --check app/auth/update-password/page.tsx playwright.config.ts __tests__/ui/helpers/mailpit.ts __tests__/ui/helpers/auth.ts __tests__/ui/auth-password-reset.test.ts docs/ui-tests.md
- git diff --check
- npm run ui-test -- __tests__/ui/auth-password-reset.test.ts --project=desktop-chromium
- npm run ui-test -- --project=desktop-chromium
- npm run ui-test -- --project=mobile-chromium

Closes #273
Closes #264