### PR TITLE
Add UI settlement creation matrix

### DIFF
--- a/__tests__/ui/helpers/settlement.ts
+++ b/__tests__/ui/helpers/settlement.ts
@@ -1,0 +1,185 @@
+import { admin } from '@/__tests__/ui/helpers/supabase'
+
+/** Settlement Creation Summary */
+export interface SettlementCreationSummary {
+  /** Campaign Type */
+  campaign_type: string
+  /** Settlement ID */
+  id: string
+  /** Quarry Names */
+  quarryNames: string[]
+  /** Nemesis Names */
+  nemesisNames: string[]
+  /** Settlement Name */
+  settlement_name: string
+  /** Survivor Count */
+  survivorCount: number
+  /** Survivor Type */
+  survivor_type: string
+  /** Timeline Entries By Year */
+  timelineEntriesByYear: Record<number, string[]>
+  /** Uses Scouts */
+  uses_scouts: boolean
+}
+
+/**
+ * Wait For Settlement Creation Summary
+ *
+ * Polls until a settlement with the supplied name exists for the user, then
+ * returns the persisted campaign defaults used by the UI creation matrix.
+ *
+ * @param userId User ID
+ * @param settlementName Settlement Name
+ * @returns Settlement Creation Summary
+ */
+export async function waitForSettlementCreationSummary(
+  userId: string,
+  settlementName: string
+): Promise<SettlementCreationSummary> {
+  const timeoutAt = Date.now() + 10_000
+
+  while (Date.now() < timeoutAt) {
+    const settlement = await findSettlementByName(userId, settlementName)
+    if (settlement) return getSettlementCreationSummary(settlement)
+
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for settlement ${settlementName}`)
+}
+
+/**
+ * Count Settlements For User
+ *
+ * @param userId User ID
+ * @returns Owned Settlement Count
+ */
+export async function countSettlementsForUser(userId: string): Promise<number> {
+  const { count, error } = await admin
+    .from('settlement')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId)
+
+  if (error) throw new Error(`settlement count failed: ${error.message}`)
+
+  return count ?? 0
+}
+
+interface SettlementRow {
+  campaign_type: string
+  id: string
+  settlement_name: string
+  survivor_type: string
+  uses_scouts: boolean
+}
+
+async function findSettlementByName(
+  userId: string,
+  settlementName: string
+): Promise<SettlementRow | null> {
+  const { data, error } = await admin
+    .from('settlement')
+    .select('id, settlement_name, campaign_type, survivor_type, uses_scouts')
+    .eq('user_id', userId)
+    .eq('settlement_name', settlementName)
+    .maybeSingle()
+
+  if (error) throw new Error(`settlement lookup failed: ${error.message}`)
+
+  return data
+}
+
+async function getSettlementCreationSummary(
+  settlement: SettlementRow
+): Promise<SettlementCreationSummary> {
+  const [quarryNames, nemesisNames, survivorCount, timelineEntriesByYear] =
+    await Promise.all([
+      getRelatedMonsterNames({
+        junctionTable: 'settlement_quarry',
+        targetTable: 'quarry',
+        targetIdColumn: 'quarry_id',
+        settlementId: settlement.id
+      }),
+      getRelatedMonsterNames({
+        junctionTable: 'settlement_nemesis',
+        targetTable: 'nemesis',
+        targetIdColumn: 'nemesis_id',
+        settlementId: settlement.id
+      }),
+      countSurvivors(settlement.id),
+      getTimelineEntriesByYear(settlement.id)
+    ])
+
+  return {
+    ...settlement,
+    quarryNames,
+    nemesisNames,
+    survivorCount,
+    timelineEntriesByYear
+  }
+}
+
+async function getRelatedMonsterNames({
+  junctionTable,
+  targetTable,
+  targetIdColumn,
+  settlementId
+}: {
+  junctionTable: 'settlement_quarry' | 'settlement_nemesis'
+  targetTable: 'quarry' | 'nemesis'
+  targetIdColumn: 'quarry_id' | 'nemesis_id'
+  settlementId: string
+}): Promise<string[]> {
+  const { data: junctionRows, error: junctionError } = await admin
+    .from(junctionTable)
+    .select(targetIdColumn)
+    .eq('settlement_id', settlementId)
+
+  if (junctionError)
+    throw new Error(`${junctionTable} lookup failed: ${junctionError.message}`)
+
+  const monsterIds = (junctionRows ?? [])
+    .map((row) => (row as Record<string, unknown>)[targetIdColumn])
+    .filter((id): id is string => typeof id === 'string')
+
+  if (monsterIds.length === 0) return []
+
+  const { data: monsterRows, error: monsterError } = await admin
+    .from(targetTable)
+    .select('monster_name')
+    .in('id', monsterIds)
+
+  if (monsterError)
+    throw new Error(`${targetTable} lookup failed: ${monsterError.message}`)
+
+  return (monsterRows ?? [])
+    .map((row) => row.monster_name)
+    .filter((name): name is string => typeof name === 'string')
+    .sort((a, b) => a.localeCompare(b))
+}
+
+async function countSurvivors(settlementId: string): Promise<number> {
+  const { count, error } = await admin
+    .from('survivor')
+    .select('id', { count: 'exact', head: true })
+    .eq('settlement_id', settlementId)
+
+  if (error) throw new Error(`survivor count failed: ${error.message}`)
+
+  return count ?? 0
+}
+
+async function getTimelineEntriesByYear(
+  settlementId: string
+): Promise<Record<number, string[]>> {
+  const { data, error } = await admin
+    .from('settlement_timeline_year')
+    .select('year_number, entries')
+    .eq('settlement_id', settlementId)
+
+  if (error) throw new Error(`timeline lookup failed: ${error.message}`)
+
+  return Object.fromEntries(
+    (data ?? []).map((row) => [row.year_number, row.entries ?? []])
+  )
+}

--- a/__tests__/ui/settlement-creation.test.ts
+++ b/__tests__/ui/settlement-creation.test.ts
@@ -1,0 +1,254 @@
+import {
+  assertAuthenticatedShell,
+  createAuthAccount,
+  createConfirmedAuthAccount,
+  logIn
+} from '@/__tests__/ui/helpers/auth'
+import {
+  countSettlementsForUser,
+  waitForSettlementCreationSummary
+} from '@/__tests__/ui/helpers/settlement'
+import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import {
+  CampaignType,
+  DatabaseCampaignType,
+  DatabaseSurvivorType,
+  SurvivorType
+} from '@/lib/enums'
+import { expect, type Locator, type Page, test } from '@playwright/test'
+
+interface SettlementCreationScenario {
+  campaign: CampaignType
+  expectedNemeses: string[]
+  expectedQuarries: string[]
+  expectedSurvivorCount?: number
+  expectedSurvivorType: SurvivorType
+  expectedTimelineEntries?: Record<number, string[]>
+  locksMonsterSelection?: boolean
+  locksScoutSelection?: boolean
+  locksSurvivorType?: boolean
+  name: string
+  usesScouts: boolean
+}
+
+const SETTLEMENT_CREATION_SCENARIOS: SettlementCreationScenario[] = [
+  {
+    campaign: CampaignType.PEOPLE_OF_THE_LANTERN,
+    expectedNemeses: [
+      'Butcher',
+      'Gold Smoke Knight',
+      "King's Man",
+      'The Hand',
+      'Watcher'
+    ],
+    expectedQuarries: ['Phoenix', 'Screaming Antelope', 'White Lion'],
+    expectedSurvivorType: SurvivorType.CORE,
+    name: 'lantern',
+    usesScouts: false
+  },
+  {
+    campaign: CampaignType.PEOPLE_OF_THE_SUN,
+    expectedNemeses: [
+      'Butcher',
+      "King's Man",
+      'The Great Devourer (Sunstalker)',
+      'The Hand'
+    ],
+    expectedQuarries: ['Phoenix', 'Screaming Antelope', 'White Lion'],
+    expectedSurvivorType: SurvivorType.CORE,
+    name: 'sun',
+    usesScouts: false
+  },
+  {
+    campaign: CampaignType.PEOPLE_OF_THE_STARS,
+    expectedNemeses: [
+      'Butcher',
+      'Dying God (Dragon King)',
+      "King's Man",
+      'The Hand',
+      'The Tyrant'
+    ],
+    expectedQuarries: ['Phoenix', 'Screaming Antelope', 'White Lion'],
+    expectedSurvivorType: SurvivorType.CORE,
+    name: 'stars',
+    usesScouts: false
+  },
+  {
+    campaign: CampaignType.PEOPLE_OF_THE_DREAM_KEEPER,
+    expectedNemeses: [
+      'Atnas the Child Eater',
+      'Butcher',
+      'Gambler',
+      'Godhand',
+      'The Hand'
+    ],
+    expectedQuarries: ['Crimson Crocodile', 'King', 'Smog Singers'],
+    expectedSurvivorType: SurvivorType.ARC,
+    expectedTimelineEntries: { 23: ['Wanderer - Luck'] },
+    locksScoutSelection: true,
+    locksSurvivorType: true,
+    name: 'dream',
+    usesScouts: true
+  },
+  {
+    campaign: CampaignType.SQUIRES_OF_THE_CITADEL,
+    expectedNemeses: [],
+    expectedQuarries: [],
+    expectedSurvivorCount: 4,
+    expectedSurvivorType: SurvivorType.CORE,
+    locksMonsterSelection: true,
+    locksScoutSelection: true,
+    locksSurvivorType: true,
+    name: 'squires',
+    usesScouts: false
+  },
+  {
+    campaign: CampaignType.CUSTOM,
+    expectedNemeses: [],
+    expectedQuarries: [],
+    expectedSurvivorType: SurvivorType.CORE,
+    name: 'custom',
+    usesScouts: false
+  }
+]
+
+test.describe('settlement creation flow', () => {
+  const emailsToDelete = new Set<string>()
+
+  test.afterEach(async () => {
+    await deleteUsersByEmail(emailsToDelete)
+    emailsToDelete.clear()
+  })
+
+  for (const scenario of SETTLEMENT_CREATION_SCENARIOS) {
+    test(`creates a ${scenario.campaign} settlement with campaign defaults`, async ({
+      page
+    }) => {
+      const { account, user } = await createTestUser(scenario.name)
+      emailsToDelete.add(account.email)
+      const settlementName = `E2E ${scenario.name} ${crypto.randomUUID().slice(0, 8)}`
+
+      await logIn(page, account)
+      await openSettlementForm(page)
+      await selectCampaign(page, scenario.campaign)
+      await assertCampaignFormState(page, scenario)
+
+      await page.getByPlaceholder('Settlement Name').fill(settlementName)
+      await page.getByRole('button', { name: 'Light the lantern' }).click()
+
+      const summary = await waitForSettlementCreationSummary(
+        user.id,
+        settlementName
+      )
+      await expect(page.getByText('Choose the campaign')).toBeHidden()
+
+      expect(summary.campaign_type).toBe(
+        DatabaseCampaignType[scenario.campaign]
+      )
+      expect(summary.survivor_type).toBe(
+        DatabaseSurvivorType[scenario.expectedSurvivorType]
+      )
+      expect(summary.uses_scouts).toBe(scenario.usesScouts)
+      expect(summary.quarryNames).toEqual([...scenario.expectedQuarries].sort())
+      expect(summary.nemesisNames).toEqual([...scenario.expectedNemeses].sort())
+
+      if (scenario.expectedSurvivorCount !== undefined)
+        expect(summary.survivorCount).toBe(scenario.expectedSurvivorCount)
+
+      for (const [year, expectedEntries] of Object.entries(
+        scenario.expectedTimelineEntries ?? {}
+      ))
+        expect(summary.timelineEntriesByYear[Number(year)]).toEqual(
+          expect.arrayContaining(expectedEntries)
+        )
+    })
+  }
+
+  test('surfaces validation feedback for a nameless settlement', async ({
+    page
+  }) => {
+    const { account, user } = await createTestUser('nameless')
+    emailsToDelete.add(account.email)
+
+    await logIn(page, account)
+    await openSettlementForm(page)
+    await page.getByRole('button', { name: 'Light the lantern' }).click()
+
+    await expect(
+      page.getByText('A nameless settlement cannot be recorded.')
+    ).toBeVisible()
+    await expect(page.getByText('Found a settlement').first()).toBeVisible()
+    await expect.poll(() => countSettlementsForUser(user.id)).toBe(0)
+  })
+})
+
+async function createTestUser(prefix: string) {
+  const account = createAuthAccount(`settle_${prefix}`.slice(0, 20))
+  const user = await createConfirmedAuthAccount(account)
+  return { account, user }
+}
+
+async function openSettlementForm(page: Page): Promise<void> {
+  await assertAuthenticatedShell(page)
+  await page.getByRole('button', { name: 'Found a settlement' }).click()
+  await expect(page.getByText('Choose the campaign')).toBeVisible()
+}
+
+async function selectCampaign(
+  page: Page,
+  campaign: CampaignType
+): Promise<void> {
+  const campaignCombobox = settlementForm(page).getByRole('combobox').nth(0)
+
+  await campaignCombobox.click()
+  await page
+    .locator('[data-slot="command-item"]')
+    .filter({ hasText: campaign })
+    .click()
+  await expect(campaignCombobox).toContainText(campaign)
+}
+
+async function assertCampaignFormState(
+  page: Page,
+  scenario: SettlementCreationScenario
+): Promise<void> {
+  const form = settlementForm(page)
+  const survivorTypeCombobox = form.getByRole('combobox').nth(1)
+  const wanderersCombobox = form.getByRole('combobox').nth(2)
+  const firstMonsterNodeCombobox = form.getByRole('combobox').nth(3)
+  const scoutsSwitch = form.getByRole('switch')
+
+  await expect(survivorTypeCombobox).toContainText(
+    scenario.expectedSurvivorType
+  )
+  await expect(scoutsSwitch).toHaveAttribute(
+    'data-state',
+    scenario.usesScouts ? 'checked' : 'unchecked'
+  )
+
+  await assertDisabledState(
+    survivorTypeCombobox,
+    scenario.locksSurvivorType ?? false
+  )
+  await assertDisabledState(scoutsSwitch, scenario.locksScoutSelection ?? false)
+  await assertDisabledState(
+    wanderersCombobox,
+    scenario.locksMonsterSelection ?? false
+  )
+  await assertDisabledState(
+    firstMonsterNodeCombobox,
+    scenario.locksMonsterSelection ?? false
+  )
+}
+
+async function assertDisabledState(
+  locator: Locator,
+  disabled: boolean
+): Promise<void> {
+  if (disabled) await expect(locator).toBeDisabled()
+  else await expect(locator).toBeEnabled()
+}
+
+function settlementForm(page: Page): Locator {
+  return page.locator('form')
+}


### PR DESCRIPTION
## Summary

- add a Playwright settlement creation matrix covering People of the Lantern, People of the Sun, People of the Stars, People of the Dream Keeper, Squires of the Citadel, and Custom campaigns
- add service-role settlement UI helpers for persisted campaign default assertions
- verify empty settlement names surface validation feedback and do not create a settlement

## Dependency check

- Based on latest `main` after PR #299 merged
- This branch only adds settlement UI test files and has no file overlap with the previous password-reset branch

## Tests

- npx prettier --check __tests__/ui/helpers/settlement.ts __tests__/ui/settlement-creation.test.ts
- git diff --check
- npm run ui-test -- __tests__/ui/settlement-creation.test.ts --project=desktop-chromium
- npm run ui-test -- __tests__/ui/settlement-creation.test.ts --project=mobile-chromium
- npm run ui-test -- --project=desktop-chromium
- npm run ui-test -- --project=mobile-chromium

Closes #274