### PR TITLE
Add UI settlement lifecycle coverage

### DIFF
--- a/__tests__/ui/helpers/settlement.ts
+++ b/__tests__/ui/helpers/settlement.ts
@@ -1,5 +1,19 @@
 import { admin } from '@/__tests__/ui/helpers/supabase'
 
+/** Settlement Fixture Options */
+export interface SettlementFixtureOptions {
+  /** Campaign Type */
+  campaignType?: string
+  /** Settlement Name */
+  name: string
+  /** Survivor Type */
+  survivorType?: string
+  /** Uses Scouts */
+  usesScouts?: boolean
+  /** User ID */
+  userId: string
+}
+
 /** Settlement Creation Summary */
 export interface SettlementCreationSummary {
   /** Campaign Type */
@@ -20,6 +34,239 @@ export interface SettlementCreationSummary {
   timelineEntriesByYear: Record<number, string[]>
   /** Uses Scouts */
   uses_scouts: boolean
+}
+
+/**
+ * Create Settlement Fixture
+ *
+ * Creates a minimal owned settlement directly through the service-role client.
+ *
+ * @param options Settlement Fixture Options
+ * @returns Settlement ID
+ */
+export async function createSettlementFixture(
+  options: SettlementFixtureOptions
+): Promise<string> {
+  const { data, error } = await admin
+    .from('settlement')
+    .insert({
+      campaign_type: options.campaignType ?? 'PEOPLE_OF_THE_LANTERN',
+      settlement_name: options.name,
+      survivor_type: options.survivorType ?? 'CORE',
+      uses_scouts: options.usesScouts ?? false,
+      user_id: options.userId
+    })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`create settlement failed: ${error.message}`)
+
+  return data.id
+}
+
+/**
+ * Share Settlement Fixture
+ *
+ * @param args Share Fixture Data
+ */
+export async function shareSettlementFixture(args: {
+  settlementId: string
+  sharedUserId: string
+  ownerId: string
+}): Promise<void> {
+  const { error } = await admin.from('settlement_shared_user').insert({
+    settlement_id: args.settlementId,
+    shared_user_id: args.sharedUserId,
+    user_id: args.ownerId
+  })
+
+  if (error) throw new Error(`share settlement failed: ${error.message}`)
+}
+
+/**
+ * Set Subscription Plan Fixture
+ *
+ * @param userId User ID
+ * @param planId Plan ID
+ */
+export async function setSubscriptionPlanFixture(
+  userId: string,
+  planId: string
+): Promise<void> {
+  const { error } = await admin
+    .from('user_subscription')
+    .update({ plan_id: planId, status: 'active' })
+    .eq('user_id', userId)
+
+  if (error) throw new Error(`update subscription failed: ${error.message}`)
+}
+
+/**
+ * Create Settlement List Fixtures
+ *
+ * @param userId User ID
+ * @param prefix Settlement Name Prefix
+ * @param count Number Of Settlements To Create
+ * @returns Created Settlement IDs
+ */
+export async function createSettlementListFixtures(
+  userId: string,
+  prefix: string,
+  count: number
+): Promise<string[]> {
+  const settlementIds: string[] = []
+
+  for (let index = 1; index <= count; index += 1) {
+    const id = await createSettlementFixture({
+      name: `${prefix} ${index}`,
+      userId
+    })
+    settlementIds.push(id)
+  }
+
+  return settlementIds
+}
+
+/** Create Hunt Fixture */
+export async function createHuntFixture(settlementId: string): Promise<string> {
+  const { data, error } = await admin
+    .from('hunt')
+    .insert({ monster_level: 1, settlement_id: settlementId })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`create hunt failed: ${error.message}`)
+
+  return data.id
+}
+
+/** Create Showdown Fixture */
+export async function createShowdownFixture(
+  settlementId: string
+): Promise<string> {
+  const { data, error } = await admin
+    .from('showdown')
+    .insert({ monster_level: 1, settlement_id: settlementId })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`create showdown failed: ${error.message}`)
+
+  return data.id
+}
+
+/** Create Settlement Phase Fixture */
+export async function createSettlementPhaseFixture(
+  settlementId: string
+): Promise<string> {
+  const { data, error } = await admin
+    .from('settlement_phase')
+    .insert({ settlement_id: settlementId })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`create settlement phase failed: ${error.message}`)
+
+  return data.id
+}
+
+/**
+ * Settlement Exists
+ *
+ * @param settlementId Settlement ID
+ * @returns Whether Settlement Exists
+ */
+export async function settlementExists(settlementId: string): Promise<boolean> {
+  const { data, error } = await admin
+    .from('settlement')
+    .select('id')
+    .eq('id', settlementId)
+    .maybeSingle()
+
+  if (error) throw new Error(`settlement lookup failed: ${error.message}`)
+
+  return Boolean(data)
+}
+
+/** Hunt Exists */
+export async function huntExists(huntId: string): Promise<boolean> {
+  const { data, error } = await admin
+    .from('hunt')
+    .select('id')
+    .eq('id', huntId)
+    .maybeSingle()
+
+  if (error) throw new Error(`hunt lookup failed: ${error.message}`)
+
+  return Boolean(data)
+}
+
+/** Showdown Exists */
+export async function showdownExists(showdownId: string): Promise<boolean> {
+  const { data, error } = await admin
+    .from('showdown')
+    .select('id')
+    .eq('id', showdownId)
+    .maybeSingle()
+
+  if (error) throw new Error(`showdown lookup failed: ${error.message}`)
+
+  return Boolean(data)
+}
+
+/** Settlement Phase Exists */
+export async function settlementPhaseExists(
+  settlementPhaseId: string
+): Promise<boolean> {
+  const { data, error } = await admin
+    .from('settlement_phase')
+    .select('id')
+    .eq('id', settlementPhaseId)
+    .maybeSingle()
+
+  if (error) throw new Error(`settlement phase lookup failed: ${error.message}`)
+
+  return Boolean(data)
+}
+
+/**
+ * Get Settlement Uses Scouts
+ *
+ * @param settlementId Settlement ID
+ * @returns Uses Scouts
+ */
+export async function getSettlementUsesScouts(
+  settlementId: string
+): Promise<boolean> {
+  const { data, error } = await admin
+    .from('settlement')
+    .select('uses_scouts')
+    .eq('id', settlementId)
+    .single()
+
+  if (error) throw new Error(`scout setting lookup failed: ${error.message}`)
+
+  return data.uses_scouts
+}
+
+/**
+ * Wait For Settlement Uses Scouts
+ *
+ * @param settlementId Settlement ID
+ * @param expected Expected Uses Scouts Value
+ */
+export async function waitForSettlementUsesScouts(
+  settlementId: string,
+  expected: boolean
+): Promise<void> {
+  const timeoutAt = Date.now() + 10_000
+
+  while (Date.now() < timeoutAt) {
+    if ((await getSettlementUsesScouts(settlementId)) === expected) return
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for uses_scouts=${expected}`)
 }
 
 /**

--- a/__tests__/ui/helpers/settlement.ts
+++ b/__tests__/ui/helpers/settlement.ts
@@ -1,13 +1,18 @@
 import { admin } from '@/__tests__/ui/helpers/supabase'
+import { type Database } from '@/lib/database.types'
+import { type PlanSlug } from '@/lib/types'
+
+type DatabaseCampaignType = Database['public']['Enums']['campaign_type']
+type DatabaseSurvivorType = Database['public']['Enums']['survivor_type']
 
 /** Settlement Fixture Options */
 export interface SettlementFixtureOptions {
   /** Campaign Type */
-  campaignType?: string
+  campaignType?: DatabaseCampaignType
   /** Settlement Name */
   name: string
   /** Survivor Type */
-  survivorType?: string
+  survivorType?: DatabaseSurvivorType
   /** Uses Scouts */
   usesScouts?: boolean
   /** User ID */
@@ -17,7 +22,7 @@ export interface SettlementFixtureOptions {
 /** Settlement Creation Summary */
 export interface SettlementCreationSummary {
   /** Campaign Type */
-  campaign_type: string
+  campaign_type: DatabaseCampaignType
   /** Settlement ID */
   id: string
   /** Quarry Names */
@@ -29,7 +34,7 @@ export interface SettlementCreationSummary {
   /** Survivor Count */
   survivorCount: number
   /** Survivor Type */
-  survivor_type: string
+  survivor_type: DatabaseSurvivorType
   /** Timeline Entries By Year */
   timelineEntriesByYear: Record<number, string[]>
   /** Uses Scouts */
@@ -91,7 +96,7 @@ export async function shareSettlementFixture(args: {
  */
 export async function setSubscriptionPlanFixture(
   userId: string,
-  planId: string
+  planId: PlanSlug
 ): Promise<void> {
   const { error } = await admin
     .from('user_subscription')
@@ -313,10 +318,10 @@ export async function countSettlementsForUser(userId: string): Promise<number> {
 }
 
 interface SettlementRow {
-  campaign_type: string
+  campaign_type: DatabaseCampaignType
   id: string
   settlement_name: string
-  survivor_type: string
+  survivor_type: DatabaseSurvivorType
   uses_scouts: boolean
 }
 

--- a/__tests__/ui/helpers/supabase.ts
+++ b/__tests__/ui/helpers/supabase.ts
@@ -157,7 +157,26 @@ export async function deleteUsersByEmail(
   }
 
   for (const userId of userIdsToDelete) {
+    await deleteUserOwnedData(userId)
+
     const { error } = await admin.auth.admin.deleteUser(userId)
     if (error) throw new Error(`deleteUser failed: ${error.message}`)
   }
+}
+
+async function deleteUserOwnedData(userId: string): Promise<void> {
+  const { error: shareError } = await admin
+    .from('settlement_shared_user')
+    .delete()
+    .or(`user_id.eq.${userId},shared_user_id.eq.${userId}`)
+
+  if (shareError) throw new Error(`delete shares failed: ${shareError.message}`)
+
+  const { error: settlementError } = await admin
+    .from('settlement')
+    .delete()
+    .eq('user_id', userId)
+
+  if (settlementError)
+    throw new Error(`delete settlements failed: ${settlementError.message}`)
 }

--- a/__tests__/ui/settlement-settings.test.ts
+++ b/__tests__/ui/settlement-settings.test.ts
@@ -1,0 +1,211 @@
+import {
+  createAuthAccount,
+  createConfirmedAuthAccount,
+  logIn
+} from '@/__tests__/ui/helpers/auth'
+import {
+  createHuntFixture,
+  createSettlementFixture,
+  createSettlementPhaseFixture,
+  createShowdownFixture,
+  getSettlementUsesScouts,
+  huntExists,
+  settlementExists,
+  settlementPhaseExists,
+  showdownExists,
+  waitForSettlementUsesScouts
+} from '@/__tests__/ui/helpers/settlement'
+import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import { expect, type Page, test } from '@playwright/test'
+
+const ERROR_MESSAGE = 'The darkness swallows your words. Please try again.'
+
+test.describe('settlement settings flow', () => {
+  const emailsToDelete = new Set<string>()
+
+  test.afterEach(async () => {
+    await deleteUsersByEmail(emailsToDelete)
+    emailsToDelete.clear()
+  })
+
+  test('toggles scout usage and rolls back failed updates', async ({
+    page
+  }) => {
+    const { account, settlementId } = await createSettingsFixture('scouts')
+    emailsToDelete.add(account.email)
+
+    await openSettlementSettings(page, account, settlementId)
+
+    const scoutsSwitch = page.getByRole('switch', { name: 'Uses Scouts' })
+    await expect(scoutsSwitch).toHaveAttribute('data-state', 'unchecked')
+
+    await scoutsSwitch.click()
+    await expect(scoutsSwitch).toHaveAttribute('data-state', 'checked')
+    await waitForSettlementUsesScouts(settlementId, true)
+
+    await failNextSettlementUpdate(page)
+    await scoutsSwitch.click()
+
+    await expect(page.getByText(ERROR_MESSAGE)).toBeVisible()
+    await expect(scoutsSwitch).toHaveAttribute('data-state', 'checked')
+    await expect.poll(() => getSettlementUsesScouts(settlementId)).toBe(true)
+  })
+
+  test('requires confirmation before deleting an active hunt', async ({
+    page
+  }) => {
+    const { account, settlementId } = await createSettingsFixture('hunt')
+    emailsToDelete.add(account.email)
+    const huntId = await createHuntFixture(settlementId)
+
+    await openSettlementSettings(page, account, settlementId)
+    await expect(page.getByText('Active Hunt')).toBeVisible()
+
+    await expectConfirmedDeletion({
+      page,
+      triggerName: 'Delete Hunt',
+      dialogTitle: 'Delete Hunt',
+      exists: () => huntExists(huntId)
+    })
+    await expect(page.getByText('Active Hunt')).toBeHidden()
+  })
+
+  test('requires confirmation before deleting an active showdown', async ({
+    page
+  }) => {
+    const { account, settlementId } = await createSettingsFixture('showdown')
+    emailsToDelete.add(account.email)
+    const showdownId = await createShowdownFixture(settlementId)
+
+    await openSettlementSettings(page, account, settlementId)
+    await expect(page.getByText('Active Showdown')).toBeVisible()
+
+    await expectConfirmedDeletion({
+      page,
+      triggerName: 'Delete Showdown',
+      dialogTitle: 'Delete Showdown',
+      exists: () => showdownExists(showdownId)
+    })
+    await expect(page.getByText('Active Showdown')).toBeHidden()
+  })
+
+  test('requires confirmation before deleting an active settlement phase', async ({
+    page
+  }) => {
+    const { account, settlementId } = await createSettingsFixture('phase')
+    emailsToDelete.add(account.email)
+    const settlementPhaseId = await createSettlementPhaseFixture(settlementId)
+
+    await openSettlementSettings(page, account, settlementId)
+    await expect(page.getByText('Active Settlement Phase')).toBeVisible()
+
+    await expectConfirmedDeletion({
+      page,
+      triggerName: 'Delete Settlement Phase',
+      dialogTitle: 'Delete Settlement Phase',
+      exists: () => settlementPhaseExists(settlementPhaseId)
+    })
+    await expect(page.getByText('Active Settlement Phase')).toBeHidden()
+  })
+
+  test('requires confirmation before deleting a settlement', async ({
+    page
+  }) => {
+    const { account, settlementId, settlementName } =
+      await createSettingsFixture('delete')
+    emailsToDelete.add(account.email)
+
+    await openSettlementSettings(page, account, settlementId)
+
+    await expectConfirmedDeletion({
+      page,
+      triggerName: `Delete ${settlementName}`,
+      dialogTitle: 'Delete Settlement',
+      exists: () => settlementExists(settlementId)
+    })
+    await expect(page.getByText('No Settlement Selected')).toBeVisible()
+  })
+})
+
+async function createSettingsFixture(prefix: string) {
+  const account = createAuthAccount(`settings_${prefix}`.slice(0, 20))
+  const user = await createConfirmedAuthAccount(account)
+  const settlementName = `E2E Settings ${prefix} ${crypto.randomUUID().slice(0, 8)}`
+  const settlementId = await createSettlementFixture({
+    name: settlementName,
+    userId: user.id
+  })
+
+  return { account, settlementId, settlementName }
+}
+
+async function openSettlementSettings(
+  page: Page,
+  account: { email: string; password: string; username: string },
+  settlementId: string
+): Promise<void> {
+  await logIn(page, account)
+  await page.evaluate((selectedSettlementId) => {
+    localStorage.setItem(
+      'kdm-archivist-local',
+      JSON.stringify({
+        selectedHuntId: null,
+        selectedHuntMonsterIndex: 0,
+        selectedSettlementId,
+        selectedSettlementPhaseId: null,
+        selectedShowdownId: null,
+        selectedShowdownMonsterIndex: 0,
+        selectedSurvivorId: null,
+        selectedTab: 'settlementSettings'
+      })
+    )
+  }, settlementId)
+  await page.goto('/')
+  await expect(page.getByText('Settlement Settings')).toBeVisible()
+}
+
+async function failNextSettlementUpdate(page: Page): Promise<void> {
+  let failed = false
+
+  await page.route('**/rest/v1/settlement*', async (route) => {
+    if (!failed && route.request().method() === 'PATCH') {
+      failed = true
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'E2E settlement update failure' })
+      })
+      return
+    }
+
+    await route.continue()
+  })
+}
+
+async function expectConfirmedDeletion({
+  page,
+  triggerName,
+  dialogTitle,
+  exists
+}: {
+  page: Page
+  triggerName: string
+  dialogTitle: string
+  exists: () => Promise<boolean>
+}): Promise<void> {
+  await page.getByRole('button', { name: triggerName }).click()
+  const dialog = page.getByRole('alertdialog')
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByRole('heading', { name: dialogTitle })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Cancel' }).click()
+  await expect.poll(exists).toBe(true)
+
+  await page.getByRole('button', { name: triggerName }).click()
+  await page
+    .getByRole('alertdialog')
+    .getByRole('button', { name: triggerName })
+    .click()
+
+  await expect.poll(exists).toBe(false)
+}

--- a/__tests__/ui/settlement-settings.test.ts
+++ b/__tests__/ui/settlement-settings.test.ts
@@ -16,9 +16,10 @@ import {
   waitForSettlementUsesScouts
 } from '@/__tests__/ui/helpers/settlement'
 import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import { LOCAL_STORAGE_KEY } from '@/lib/common'
+import { TabType } from '@/lib/enums'
+import { ERROR_MESSAGE } from '@/lib/messages'
 import { expect, type Page, test } from '@playwright/test'
-
-const ERROR_MESSAGE = 'The darkness swallows your words. Please try again.'
 
 test.describe('settlement settings flow', () => {
   const emailsToDelete = new Set<string>()
@@ -46,7 +47,7 @@ test.describe('settlement settings flow', () => {
     await failNextSettlementUpdate(page)
     await scoutsSwitch.click()
 
-    await expect(page.getByText(ERROR_MESSAGE)).toBeVisible()
+    await expect(page.getByText(ERROR_MESSAGE())).toBeVisible()
     await expect(scoutsSwitch).toHaveAttribute('data-state', 'checked')
     await expect.poll(() => getSettlementUsesScouts(settlementId)).toBe(true)
   })
@@ -145,21 +146,28 @@ async function openSettlementSettings(
   settlementId: string
 ): Promise<void> {
   await logIn(page, account)
-  await page.evaluate((selectedSettlementId) => {
-    localStorage.setItem(
-      'kdm-archivist-local',
-      JSON.stringify({
-        selectedHuntId: null,
-        selectedHuntMonsterIndex: 0,
-        selectedSettlementId,
-        selectedSettlementPhaseId: null,
-        selectedShowdownId: null,
-        selectedShowdownMonsterIndex: 0,
-        selectedSurvivorId: null,
-        selectedTab: 'settlementSettings'
-      })
-    )
-  }, settlementId)
+  await page.evaluate(
+    ({ selectedSettlementId, selectedTab, storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          selectedHuntId: null,
+          selectedHuntMonsterIndex: 0,
+          selectedSettlementId,
+          selectedSettlementPhaseId: null,
+          selectedShowdownId: null,
+          selectedShowdownMonsterIndex: 0,
+          selectedSurvivorId: null,
+          selectedTab
+        })
+      )
+    },
+    {
+      selectedSettlementId: settlementId,
+      selectedTab: TabType.SETTLEMENT_SETTINGS,
+      storageKey: LOCAL_STORAGE_KEY
+    }
+  )
   await page.goto('/')
   await expect(page.getByText('Settlement Settings')).toBeVisible()
 }

--- a/__tests__/ui/settlement-switcher.test.ts
+++ b/__tests__/ui/settlement-switcher.test.ts
@@ -1,0 +1,145 @@
+import {
+  createAuthAccount,
+  createConfirmedAuthAccount,
+  logIn
+} from '@/__tests__/ui/helpers/auth'
+import {
+  countSettlementsForUser,
+  createSettlementFixture,
+  createSettlementListFixtures,
+  setSubscriptionPlanFixture,
+  shareSettlementFixture
+} from '@/__tests__/ui/helpers/settlement'
+import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import { FREE_TIER_SETTLEMENT_LIMIT } from '@/lib/common'
+import { FREE_TIER_SETTLEMENT_LIMIT_MESSAGE } from '@/lib/messages'
+import { expect, type Page, test } from '@playwright/test'
+
+test.describe('settlement switcher flow', () => {
+  const emailsToDelete = new Set<string>()
+
+  test.afterEach(async () => {
+    await deleteUsersByEmail(emailsToDelete)
+    emailsToDelete.clear()
+  })
+
+  test('selects owned settlements and distinguishes shared settlements', async ({
+    page
+  }) => {
+    const ownerAccount = createAuthAccount('switch_owner')
+    const collaboratorAccount = createAuthAccount('switch_guest')
+    emailsToDelete.add(ownerAccount.email)
+    emailsToDelete.add(collaboratorAccount.email)
+
+    const owner = await createConfirmedAuthAccount(ownerAccount)
+    const collaborator = await createConfirmedAuthAccount(collaboratorAccount)
+    await createSettlementFixture({
+      name: 'E2E Owned Lantern',
+      userId: collaborator.id
+    })
+    await createSettlementFixture({
+      name: 'E2E Owned Sun',
+      userId: collaborator.id,
+      campaignType: 'PEOPLE_OF_THE_SUN'
+    })
+    const sharedSettlementId = await createSettlementFixture({
+      name: 'E2E Shared Lantern',
+      userId: owner.id
+    })
+    await shareSettlementFixture({
+      settlementId: sharedSettlementId,
+      ownerId: owner.id,
+      sharedUserId: collaborator.id
+    })
+
+    await logIn(page, collaboratorAccount)
+    await openSettlementSwitcher(page)
+
+    await expect(
+      page.getByRole('menuitem', { name: /E2E Owned Lantern/ })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('menuitem', { name: /E2E Owned Sun/ })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('menuitem', { name: /E2E Shared Lantern/ })
+    ).toBeVisible()
+    await expect(
+      page.getByLabel(`Shared by @${ownerAccount.username}`)
+    ).toBeVisible()
+
+    await page.getByRole('menuitem', { name: /E2E Owned Sun/ }).click()
+    await expect(settlementSwitcherTrigger(page)).toContainText('E2E Owned Sun')
+
+    await openSettlementSwitcher(page)
+    await page.getByRole('menuitem', { name: /E2E Shared Lantern/ }).click()
+    await expect(settlementSwitcherTrigger(page)).toContainText(
+      'E2E Shared Lantern'
+    )
+  })
+
+  test('blocks free users at the settlement limit', async ({ page }) => {
+    const account = createAuthAccount('limit_free')
+    emailsToDelete.add(account.email)
+    const user = await createConfirmedAuthAccount(account)
+
+    await createSettlementListFixtures(
+      user.id,
+      'E2E Free Limit',
+      FREE_TIER_SETTLEMENT_LIMIT
+    )
+
+    await logIn(page, account)
+
+    const foundSettlement = page.getByRole('button', {
+      name: 'Found a settlement'
+    })
+    await expect(foundSettlement).toBeDisabled()
+    await foundSettlement.hover({ force: true })
+    await expect(
+      page.getByText(
+        FREE_TIER_SETTLEMENT_LIMIT_MESSAGE(FREE_TIER_SETTLEMENT_LIMIT)
+      )
+    ).toBeVisible()
+    await expect
+      .poll(() => countSettlementsForUser(user.id))
+      .toBe(FREE_TIER_SETTLEMENT_LIMIT)
+  })
+
+  test('allows paid users to create beyond the free settlement limit', async ({
+    page
+  }) => {
+    const account = createAuthAccount('limit_paid')
+    emailsToDelete.add(account.email)
+    const user = await createConfirmedAuthAccount(account)
+
+    await createSettlementListFixtures(
+      user.id,
+      'E2E Paid Limit',
+      FREE_TIER_SETTLEMENT_LIMIT
+    )
+    await setSubscriptionPlanFixture(user.id, 'lantern')
+
+    await logIn(page, account)
+    await page.getByRole('button', { name: 'Found a settlement' }).click()
+
+    await expect(page.getByText('Choose the campaign')).toBeVisible()
+  })
+})
+
+async function openSettlementSwitcher(page: Page): Promise<void> {
+  const mobileSidebarIsClosed =
+    (page.viewportSize()?.width ?? 0) < 768 &&
+    (await page.getByRole('dialog').count()) === 0
+
+  if (mobileSidebarIsClosed) await page.locator('header button').first().click()
+
+  await settlementSwitcherTrigger(page).click()
+}
+
+function settlementSwitcherTrigger(page: Page) {
+  return page
+    .locator('[data-slot="sidebar-header"]')
+    .getByRole('button')
+    .first()
+}

--- a/components/settings/settlement-settings-card.tsx
+++ b/components/settings/settlement-settings-card.tsx
@@ -306,10 +306,29 @@ export function SettlementSettingsCard({
                   End the hunt and return survivors to the settlement.
                 </div>
               </div>
-              <Button variant="outline" size="sm" onClick={handleDeleteHunt}>
-                <XIcon className="h-4 w-4 mr-2" />
-                Delete Hunt
-              </Button>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    <XIcon className="h-4 w-4 mr-2" />
+                    Delete Hunt
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Delete Hunt</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      The current hunt will be erased. Survivors and settlement
+                      records remain, but this action cannot be undone.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleDeleteHunt}>
+                      Delete Hunt
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </div>
           </CardContent>
         </Card>
@@ -332,13 +351,30 @@ export function SettlementSettingsCard({
                   End the showdown and return survivors to the settlement.
                 </div>
               </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleDeleteShowdown}>
-                <XIcon className="h-4 w-4 mr-2" />
-                Delete Showdown
-              </Button>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    <XIcon className="h-4 w-4 mr-2" />
+                    Delete Showdown
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Delete Showdown</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      The current showdown will be erased. Survivors and
+                      settlement records remain, but this action cannot be
+                      undone.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleDeleteShowdown}>
+                      Delete Showdown
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </div>
           </CardContent>
         </Card>
@@ -362,13 +398,30 @@ export function SettlementSettingsCard({
                   settlement.
                 </div>
               </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleDeleteSettlementPhase}>
-                <XIcon className="h-4 w-4 mr-2" />
-                Delete Settlement Phase
-              </Button>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    <XIcon className="h-4 w-4 mr-2" />
+                    Delete Settlement Phase
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Delete Settlement Phase</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      The current settlement phase will be erased. Survivors and
+                      settlement records remain, but this action cannot be
+                      undone.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction onClick={handleDeleteSettlementPhase}>
+                      Delete Settlement Phase
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary

- add Playwright coverage for settlement switcher owned/shared selection, shared badges, free-tier creation limits, and paid-tier creation affordances
- add settlement settings coverage for scout toggles, failed update rollback, and confirmation-gated deletion of hunts, showdowns, settlement phases, and settlements
- add service-role settlement fixtures for seeded UI lifecycle scenarios and strengthen UI test teardown for shared settlements
- require confirmation before deleting active hunts, showdowns, and settlement phases from settlement settings

## Tests

- npx prettier --check __tests__/ui/helpers/settlement.ts __tests__/ui/settlement-creation.test.ts __tests__/ui/settlement-switcher.test.ts __tests__/ui/settlement-settings.test.ts __tests__/ui/helpers/supabase.ts components/settings/settlement-settings-card.tsx
- git diff --check
- npm run ui-test -- __tests__/ui/settlement-switcher.test.ts --project=desktop-chromium
- npm run ui-test -- __tests__/ui/settlement-switcher.test.ts --project=mobile-chromium
- npm run ui-test -- __tests__/ui/settlement-settings.test.ts --project=desktop-chromium
- npm run ui-test -- __tests__/ui/settlement-settings.test.ts --project=mobile-chromium
- npm run ui-test -- --project=desktop-chromium
- npm run ui-test -- --project=mobile-chromium

Closes #275
Closes #276
Closes #265