### PR TITLE
Add UI sharing collaboration coverage

### DIFF
--- a/__tests__/ui/helpers/settlement.ts
+++ b/__tests__/ui/helpers/settlement.ts
@@ -88,6 +88,86 @@ export async function shareSettlementFixture(args: {
   if (error) throw new Error(`share settlement failed: ${error.message}`)
 }
 
+/** Settlement Share Exists */
+export async function settlementShareExists(args: {
+  settlementId: string
+  sharedUserId: string
+  ownerId?: string
+}): Promise<boolean> {
+  let query = admin
+    .from('settlement_shared_user')
+    .select('settlement_id')
+    .eq('settlement_id', args.settlementId)
+    .eq('shared_user_id', args.sharedUserId)
+
+  if (args.ownerId) query = query.eq('user_id', args.ownerId)
+
+  const { data, error } = await query.maybeSingle()
+
+  if (error) throw new Error(`share lookup failed: ${error.message}`)
+
+  return Boolean(data)
+}
+
+/** Create Attached Custom Knowledge Fixture */
+export async function createAttachedCustomKnowledgeFixture(args: {
+  settlementId: string
+  authorUserId: string
+  name: string
+}): Promise<string> {
+  const { data, error } = await admin
+    .from('knowledge')
+    .insert({
+      custom: true,
+      knowledge_name: args.name,
+      rules: 'A collaborator-authored ember.',
+      user_id: args.authorUserId
+    })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`create custom knowledge failed: ${error.message}`)
+
+  const { error: attachError } = await admin
+    .from('settlement_knowledge')
+    .insert({ knowledge_id: data.id, settlement_id: args.settlementId })
+
+  if (attachError)
+    throw new Error(`attach custom knowledge failed: ${attachError.message}`)
+
+  return data.id
+}
+
+/** Get Settlement Notes */
+export async function getSettlementNotes(
+  settlementId: string
+): Promise<string> {
+  const { data, error } = await admin
+    .from('settlement')
+    .select('notes')
+    .eq('id', settlementId)
+    .single()
+
+  if (error) throw new Error(`settlement notes lookup failed: ${error.message}`)
+
+  return data.notes
+}
+
+/** Wait For Settlement Notes */
+export async function waitForSettlementNotes(
+  settlementId: string,
+  expected: string
+): Promise<void> {
+  const timeoutAt = Date.now() + 10_000
+
+  while (Date.now() < timeoutAt) {
+    if ((await getSettlementNotes(settlementId)) === expected) return
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for settlement notes ${expected}`)
+}
+
 /**
  * Set Subscription Plan Fixture
  *

--- a/__tests__/ui/settlement-sharing.test.ts
+++ b/__tests__/ui/settlement-sharing.test.ts
@@ -1,0 +1,348 @@
+import {
+  assertLoginPage,
+  createAuthAccount,
+  createConfirmedAuthAccount,
+  logIn
+} from '@/__tests__/ui/helpers/auth'
+import {
+  createAttachedCustomKnowledgeFixture,
+  createSettlementFixture,
+  setSubscriptionPlanFixture,
+  settlementShareExists,
+  shareSettlementFixture,
+  waitForSettlementNotes
+} from '@/__tests__/ui/helpers/settlement'
+import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import { LOCAL_STORAGE_KEY } from '@/lib/common'
+import { TabType } from '@/lib/enums'
+import {
+  SETTLEMENT_SHARE_DUPLICATE_INVITE_MESSAGE,
+  SETTLEMENT_SHARE_REVOKE_BLOCKED_MESSAGE,
+  SETTLEMENT_SHARE_SELF_INVITE_MESSAGE,
+  SETTLEMENT_SHARE_USERNAME_NOT_FOUND_MESSAGE,
+  USERNAME_INVALID_FORMAT_MESSAGE
+} from '@/lib/messages'
+import { expect, test, type Page } from '@playwright/test'
+import { type User } from '@supabase/supabase-js'
+
+test.describe('settlement sharing flow', () => {
+  const emailsToDelete = new Set<string>()
+
+  test.afterEach(async () => {
+    await deleteUsersByEmail(emailsToDelete)
+    emailsToDelete.clear()
+  })
+
+  test('paid owner invites a collaborator who sees the shared settlement without reload', async ({
+    browser,
+    page
+  }) => {
+    const {
+      collaborator,
+      collaboratorAccount,
+      owner,
+      ownerAccount,
+      settlementId
+    } = await createSharingFixture('invite')
+    emailsToDelete.add(ownerAccount.email)
+    emailsToDelete.add(collaboratorAccount.email)
+
+    const collaboratorContext = await browser.newContext()
+    const collaboratorPage = await collaboratorContext.newPage()
+
+    try {
+      await logIn(collaboratorPage, collaboratorAccount)
+      await expect(collaboratorPage.getByText('E2E Shared invite')).toBeHidden()
+
+      await openSharingTab(page, ownerAccount, settlementId)
+      await inviteCollaborator(page, collaboratorAccount.username)
+
+      await expect(
+        page.getByText(`@${collaboratorAccount.username}`)
+      ).toBeVisible()
+      await expect
+        .poll(() =>
+          settlementShareExists({
+            settlementId,
+            ownerId: owner.id,
+            sharedUserId: collaborator.id
+          })
+        )
+        .toBe(true)
+
+      await openSettlementSwitcher(collaboratorPage)
+      await expect(
+        collaboratorPage.getByRole('menuitem', { name: /E2E Shared invite/ })
+      ).toBeVisible()
+    } finally {
+      await collaboratorContext.close()
+    }
+  })
+
+  test('surfaces sharing negative paths and paywall affordance', async ({
+    page
+  }) => {
+    const { collaborator, collaboratorAccount, ownerAccount, settlementId } =
+      await createSharingFixture('negative')
+    emailsToDelete.add(ownerAccount.email)
+    emailsToDelete.add(collaboratorAccount.email)
+
+    await openSharingTab(page, ownerAccount, settlementId)
+    await inviteCollaborator(page, 'bad name')
+    await expect(
+      page.getByText(USERNAME_INVALID_FORMAT_MESSAGE())
+    ).toBeVisible()
+
+    await inviteCollaborator(page, 'missing_user')
+    await expect(
+      page.getByText(SETTLEMENT_SHARE_USERNAME_NOT_FOUND_MESSAGE())
+    ).toBeVisible()
+
+    await inviteCollaborator(page, ownerAccount.username)
+    await expect(
+      page.getByText(SETTLEMENT_SHARE_SELF_INVITE_MESSAGE())
+    ).toBeVisible()
+
+    await inviteCollaborator(page, collaboratorAccount.username)
+    await expect(
+      page.getByText(`@${collaboratorAccount.username}`)
+    ).toBeVisible()
+    await expect
+      .poll(() =>
+        settlementShareExists({ settlementId, sharedUserId: collaborator.id })
+      )
+      .toBe(true)
+
+    await inviteCollaborator(page, collaboratorAccount.username)
+    await expect(
+      page.getByText(SETTLEMENT_SHARE_DUPLICATE_INVITE_MESSAGE())
+    ).toBeVisible()
+
+    const freeAccount = createAuthAccount('share_free')
+    emailsToDelete.add(freeAccount.email)
+    const freeOwner = await createConfirmedAuthAccount(freeAccount)
+    const freeSettlementId = await createSettlementFixture({
+      name: 'E2E Shared free',
+      userId: freeOwner.id
+    })
+
+    await openSharingTab(page, freeAccount, freeSettlementId)
+    await expect(page.getByText('Your lantern burns alone.')).toBeVisible()
+    await expect(page.getByLabel('Username')).toBeHidden()
+    await page
+      .getByRole('button', { name: /^Invite$/ })
+      .last()
+      .click()
+    await expect(
+      page.getByText('Sharing this settlement requires lighting a new lantern.')
+    ).toBeVisible()
+  })
+
+  test('revokes collaborators and blocks revokes with attached custom content', async ({
+    page
+  }) => {
+    const {
+      collaborator,
+      collaboratorAccount,
+      owner,
+      ownerAccount,
+      settlementId
+    } = await createSharingFixture('revoke')
+    emailsToDelete.add(ownerAccount.email)
+    emailsToDelete.add(collaboratorAccount.email)
+    await shareSettlementFixture({
+      settlementId,
+      ownerId: owner.id,
+      sharedUserId: collaborator.id
+    })
+
+    await openSharingTab(page, ownerAccount, settlementId)
+    await expect(
+      page.getByText(`@${collaboratorAccount.username}`)
+    ).toBeVisible()
+
+    await page
+      .getByRole('button', {
+        name: `Revoke share with @${collaboratorAccount.username}`
+      })
+      .click()
+    await expect(
+      page.getByText(`@${collaboratorAccount.username}`)
+    ).toBeHidden()
+    await expect
+      .poll(() =>
+        settlementShareExists({ settlementId, sharedUserId: collaborator.id })
+      )
+      .toBe(false)
+
+    await shareSettlementFixture({
+      settlementId,
+      ownerId: owner.id,
+      sharedUserId: collaborator.id
+    })
+    await createAttachedCustomKnowledgeFixture({
+      settlementId,
+      authorUserId: collaborator.id,
+      name: 'E2E Shared Knowledge'
+    })
+
+    await page.reload()
+    await expect(
+      page.getByText(`@${collaboratorAccount.username}`)
+    ).toBeVisible()
+    await page
+      .getByRole('button', {
+        name: `Revoke share with @${collaboratorAccount.username}`
+      })
+      .click()
+
+    await expect(
+      page.getByRole('heading', {
+        name: SETTLEMENT_SHARE_REVOKE_BLOCKED_MESSAGE()
+      })
+    ).toBeVisible()
+    await expect(page.getByText('E2E Shared Knowledge')).toBeVisible()
+    await expect
+      .poll(() =>
+        settlementShareExists({ settlementId, sharedUserId: collaborator.id })
+      )
+      .toBe(true)
+  })
+
+  test('collaborators can edit gameplay notes but cannot manage owner-only sharing or settings', async ({
+    page
+  }) => {
+    const {
+      collaborator,
+      collaboratorAccount,
+      owner,
+      ownerAccount,
+      settlementId
+    } = await createSharingFixture('permissions')
+    emailsToDelete.add(ownerAccount.email)
+    emailsToDelete.add(collaboratorAccount.email)
+    await shareSettlementFixture({
+      settlementId,
+      ownerId: owner.id,
+      sharedUserId: collaborator.id
+    })
+
+    await openTab(page, collaboratorAccount, settlementId, TabType.NOTES)
+    const note = `A shared note ${crypto.randomUUID().slice(0, 8)}`
+    await page.getByPlaceholder('Add notes about your settlement...').fill(note)
+    await page.getByRole('button', { name: 'Save Notes' }).click()
+    await waitForSettlementNotes(settlementId, note)
+
+    await openTab(
+      page,
+      collaboratorAccount,
+      settlementId,
+      TabType.SETTLEMENT_SETTINGS
+    )
+    await expect(page.getByText('Settlement Settings')).toBeHidden()
+    await expect(page.getByText('Danger Zone')).toBeHidden()
+
+    await openTab(page, collaboratorAccount, settlementId, TabType.SHARING)
+    await expect(page.getByText('Light another lantern')).toBeHidden()
+  })
+})
+
+async function createSharingFixture(prefix: string): Promise<{
+  collaborator: User
+  collaboratorAccount: { email: string; password: string; username: string }
+  owner: User
+  ownerAccount: { email: string; password: string; username: string }
+  settlementId: string
+}> {
+  const ownerAccount = createAuthAccount(`share_owner_${prefix}`.slice(0, 20))
+  const collaboratorAccount = createAuthAccount(
+    `share_guest_${prefix}`.slice(0, 20)
+  )
+  const owner = await createConfirmedAuthAccount(ownerAccount)
+  const collaborator = await createConfirmedAuthAccount(collaboratorAccount)
+  await setSubscriptionPlanFixture(owner.id, 'lantern_hoard')
+  const settlementId = await createSettlementFixture({
+    name: `E2E Shared ${prefix}`,
+    userId: owner.id
+  })
+
+  return {
+    ownerAccount,
+    owner,
+    collaboratorAccount,
+    collaborator,
+    settlementId
+  }
+}
+
+async function openSharingTab(
+  page: Page,
+  account: { email: string; password: string; username: string },
+  settlementId: string
+): Promise<void> {
+  await openTab(page, account, settlementId, TabType.SHARING)
+  await expect(page.getByText('Light another lantern')).toBeVisible()
+}
+
+async function openTab(
+  page: Page,
+  account: { email: string; password: string; username: string },
+  settlementId: string,
+  selectedTab: TabType
+): Promise<void> {
+  await page.goto('/auth/login')
+  await page.evaluate(
+    (storageKey) => localStorage.removeItem(storageKey),
+    LOCAL_STORAGE_KEY
+  )
+  await assertLoginPage(page)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password').fill(account.password)
+  await page.getByRole('button', { name: /^Login$/ }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await page.evaluate(
+    ({ selectedSettlementId, selectedTab, storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          selectedHuntId: null,
+          selectedHuntMonsterIndex: 0,
+          selectedSettlementId,
+          selectedSettlementPhaseId: null,
+          selectedShowdownId: null,
+          selectedShowdownMonsterIndex: 0,
+          selectedSurvivorId: null,
+          selectedTab
+        })
+      )
+    },
+    {
+      selectedSettlementId: settlementId,
+      selectedTab,
+      storageKey: LOCAL_STORAGE_KEY
+    }
+  )
+  await page.goto('/')
+}
+
+async function inviteCollaborator(page: Page, username: string): Promise<void> {
+  await page.getByLabel('Username').fill(username)
+  await page
+    .locator('form')
+    .getByRole('button', { name: /^Invite$/ })
+    .click()
+}
+
+async function openSettlementSwitcher(page: Page): Promise<void> {
+  const mobileSidebarIsClosed =
+    (page.viewportSize()?.width ?? 0) < 768 &&
+    (await page.getByRole('dialog').count()) === 0
+
+  if (mobileSidebarIsClosed) await page.locator('header button').first().click()
+
+  await page
+    .locator('[data-slot="sidebar-header"]')
+    .getByRole('button')
+    .first()
+    .click()
+}

--- a/components/settlement/sharing/collaborators-panel.tsx
+++ b/components/settlement/sharing/collaborators-panel.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/dal/user'
 import {
   ERROR_MESSAGE,
+  SETTLEMENT_SHARE_DUPLICATE_INVITE_MESSAGE,
   SETTLEMENT_SHARE_PAYWALL_MESSAGE,
   SETTLEMENT_SHARE_REVOKE_BLOCKED_MESSAGE,
   SETTLEMENT_SHARE_REVOKE_SUCCESS_MESSAGE,
@@ -259,7 +260,10 @@ function CollaboratorsPanelContent({
           return
         }
 
-        if (collaborators.some((c) => c.shared_user_id === targetUserId)) return
+        if (collaborators.some((c) => c.shared_user_id === targetUserId)) {
+          toast.error(SETTLEMENT_SHARE_DUPLICATE_INVITE_MESSAGE())
+          return
+        }
 
         // Optimistic insert. The real `created_at` comes from the server;
         // an optimistic `now()` is close enough for the "Joined: just now"
@@ -390,10 +394,7 @@ function CollaboratorsPanelContent({
   )
 
   const trimmedUsername = username.trim()
-  const submitDisabled =
-    isInviting ||
-    trimmedUsername.length === 0 ||
-    !USERNAME_PATTERN.test(trimmedUsername)
+  const submitDisabled = isInviting || trimmedUsername.length === 0
 
   return (
     <Card className="p-0">
@@ -402,7 +403,7 @@ function CollaboratorsPanelContent({
       </CardHeader>
       <CardContent className="p-4 pt-0 space-y-4">
         {canShare ? (
-          <form onSubmit={handleInvite}>
+          <form onSubmit={handleInvite} noValidate>
             <div className="grid gap-2">
               <Label htmlFor="invite-username" className="sr-only">
                 Username

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -452,6 +452,14 @@ export const SETTLEMENT_SHARE_SELF_INVITE_MESSAGE = () =>
   'You already keep watch over this settlement.'
 
 /**
+ * Settlement Share Duplicate Invite Rejected
+ *
+ * @returns Settlement Share Duplicate Invite Rejected Message
+ */
+export const SETTLEMENT_SHARE_DUPLICATE_INVITE_MESSAGE = () =>
+  'Their lantern already burns beside yours.'
+
+/**
  * Settlement Share Revoke Succeeded
  *
  * @returns Settlement Share Revoke Succeeded Message


### PR DESCRIPTION
## Summary

- add Playwright coverage for paid owner invites, collaborator realtime visibility, sharing paywall, sharing negative paths, revoke success/blockers, and collaborator permissions
- add sharing-oriented fixture helpers for share rows, attached custom knowledge blockers, and settlement notes assertions
- surface duplicate collaborator invite feedback and allow invalid usernames to hit the themed validation toast path

## Tests

- npx prettier --check lib/messages.ts components/settlement/sharing/collaborators-panel.tsx __tests__/ui/helpers/settlement.ts __tests__/ui/settlement-sharing.test.ts
- git diff --check
- npm run ui-test -- __tests__/ui/settlement-sharing.test.ts --project=desktop-chromium
- npm run ui-test -- __tests__/ui/settlement-sharing.test.ts --project=mobile-chromium
- npm run ui-test -- --project=desktop-chromium
- npm run ui-test -- --project=mobile-chromium

Closes #277
Closes #280
Closes #281
Closes #282
Closes #266