### PR TITLE
Add UI survivor management coverage

### DIFF
--- a/__tests__/ui/helpers/settlement.ts
+++ b/__tests__/ui/helpers/settlement.ts
@@ -13,6 +13,8 @@ export interface SettlementFixtureOptions {
   name: string
   /** Survivor Type */
   survivorType?: DatabaseSurvivorType
+  /** Survival Limit */
+  survivalLimit?: number
   /** Uses Scouts */
   usesScouts?: boolean
   /** User ID */
@@ -57,6 +59,7 @@ export async function createSettlementFixture(
     .insert({
       campaign_type: options.campaignType ?? 'PEOPLE_OF_THE_LANTERN',
       settlement_name: options.name,
+      survival_limit: options.survivalLimit ?? 1,
       survivor_type: options.survivorType ?? 'CORE',
       uses_scouts: options.usesScouts ?? false,
       user_id: options.userId

--- a/__tests__/ui/helpers/survivor.ts
+++ b/__tests__/ui/helpers/survivor.ts
@@ -1,0 +1,157 @@
+import { admin } from '@/__tests__/ui/helpers/supabase'
+
+/** Survivor Fixture Options */
+export interface SurvivorFixtureOptions {
+  /** Settlement ID */
+  settlementId: string
+  /** Survivor Name */
+  name: string
+  /** Gender */
+  gender?: 'MALE' | 'FEMALE'
+  /** Survival */
+  survival?: number
+}
+
+/** Create Survivor Fixture */
+export async function createSurvivorFixture(
+  options: SurvivorFixtureOptions
+): Promise<string> {
+  const { data, error } = await admin
+    .from('survivor')
+    .insert({
+      gender: options.gender ?? 'FEMALE',
+      settlement_id: options.settlementId,
+      survivor_name: options.name,
+      survival: options.survival ?? 1
+    })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`create survivor failed: ${error.message}`)
+
+  return data.id
+}
+
+/** Find Survivor By Name */
+export async function findSurvivorByName(
+  settlementId: string,
+  survivorName: string
+) {
+  const { data, error } = await admin
+    .from('survivor')
+    .select('*')
+    .eq('settlement_id', settlementId)
+    .eq('survivor_name', survivorName)
+    .maybeSingle()
+
+  if (error) throw new Error(`survivor lookup failed: ${error.message}`)
+
+  return data
+}
+
+/** Wait For Survivor By Name */
+export async function waitForSurvivorByName(
+  settlementId: string,
+  survivorName: string
+) {
+  const timeoutAt = Date.now() + 10_000
+
+  while (Date.now() < timeoutAt) {
+    const survivor = await findSurvivorByName(settlementId, survivorName)
+    if (survivor) return survivor
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for survivor ${survivorName}`)
+}
+
+/** Get Survivor Row */
+export async function getSurvivorRow(survivorId: string) {
+  const { data, error } = await admin
+    .from('survivor')
+    .select('*')
+    .eq('id', survivorId)
+    .single()
+
+  if (error) throw new Error(`survivor row lookup failed: ${error.message}`)
+
+  return data
+}
+
+/** Wait For Survivor Field */
+export async function waitForSurvivorField<T>(
+  survivorId: string,
+  field: string,
+  expected: T
+): Promise<void> {
+  const timeoutAt = Date.now() + 10_000
+
+  while (Date.now() < timeoutAt) {
+    const survivor = await getSurvivorRow(survivorId)
+    if ((survivor as Record<string, unknown>)[field] === expected) return
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for survivor ${field}=${String(expected)}`)
+}
+
+/** Add Settlement Gear Fixture */
+export async function addSettlementGearFixture(
+  settlementId: string,
+  gearName: string,
+  quantity = 1
+): Promise<string> {
+  const { data: gear, error: gearError } = await admin
+    .from('gear')
+    .select('id')
+    .eq('gear_name', gearName)
+    .eq('custom', false)
+    .limit(1)
+    .single()
+
+  if (gearError) throw new Error(`gear lookup failed: ${gearError.message}`)
+
+  const { error } = await admin.from('settlement_gear').insert({
+    gear_id: gear.id,
+    quantity,
+    settlement_id: settlementId
+  })
+
+  if (error) throw new Error(`settlement gear insert failed: ${error.message}`)
+
+  return gear.id
+}
+
+/** Get Survivor Gear Grid */
+export async function getSurvivorGearGrid(survivorId: string) {
+  const { data, error } = await admin
+    .from('gear_grid')
+    .select('*')
+    .eq('survivor_id', survivorId)
+    .maybeSingle()
+
+  if (error) throw new Error(`gear grid lookup failed: ${error.message}`)
+
+  return data
+}
+
+/** Wait For Gear Grid Slot */
+export async function waitForGearGridSlot(
+  survivorId: string,
+  slotColumn: string,
+  expectedGearId: string | null
+): Promise<void> {
+  const timeoutAt = Date.now() + 10_000
+
+  while (Date.now() < timeoutAt) {
+    const grid = await getSurvivorGearGrid(survivorId)
+    if (
+      ((grid as Record<string, unknown> | null)?.[slotColumn] ?? null) ===
+      expectedGearId
+    )
+      return
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for ${slotColumn}=${expectedGearId}`)
+}

--- a/__tests__/ui/survivor-management.test.ts
+++ b/__tests__/ui/survivor-management.test.ts
@@ -1,0 +1,230 @@
+import {
+  assertLoginPage,
+  createAuthAccount,
+  createConfirmedAuthAccount
+} from '@/__tests__/ui/helpers/auth'
+import { createSettlementFixture } from '@/__tests__/ui/helpers/settlement'
+import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import {
+  addSettlementGearFixture,
+  createSurvivorFixture,
+  getSurvivorRow,
+  waitForGearGridSlot,
+  waitForSurvivorByName,
+  waitForSurvivorField
+} from '@/__tests__/ui/helpers/survivor'
+import { LOCAL_STORAGE_KEY } from '@/lib/common'
+import { TabType } from '@/lib/enums'
+import { expect, type Page, test } from '@playwright/test'
+
+test.describe('survivor management flow', () => {
+  const emailsToDelete = new Set<string>()
+
+  test.afterEach(async () => {
+    await deleteUsersByEmail(emailsToDelete)
+    emailsToDelete.clear()
+  })
+
+  test('creates core and arc survivors through the UI', async ({ page }) => {
+    const { account, coreSettlementId, arcSettlementId } =
+      await createSurvivorScenario('create')
+    emailsToDelete.add(account.email)
+
+    await openSurvivorsTab(page, account, coreSettlementId)
+    await createNamedSurvivor(page, 'E2E Core Survivor', 'Male')
+    const coreSurvivor = await waitForSurvivorByName(
+      coreSettlementId,
+      'E2E Core Survivor'
+    )
+    expect(coreSurvivor.gender).toBe('MALE')
+    expect(coreSurvivor.survival).toBe(1)
+
+    await openSurvivorsTab(page, account, arcSettlementId)
+    await createNamedSurvivor(page, 'E2E Arc Survivor', 'Female')
+    const arcSurvivor = await waitForSurvivorByName(
+      arcSettlementId,
+      'E2E Arc Survivor'
+    )
+    expect(arcSurvivor.gender).toBe('FEMALE')
+    expect(arcSurvivor.lumi).toBe(0)
+    expect(arcSurvivor.systemic_pressure).toBe(0)
+    await expect(page.getByText('Systemic')).toBeVisible()
+  })
+
+  test('creates a wanderer survivor through the UI', async ({ page }) => {
+    const { account, coreSettlementId } =
+      await createSurvivorScenario('wanderer')
+    emailsToDelete.add(account.email)
+
+    await openSurvivorsTab(page, account, coreSettlementId)
+    await page.getByRole('button', { name: 'New Survivor' }).click()
+    await page.getByRole('tab', { name: 'Wanderer' }).click()
+    await page.getByRole('combobox').click()
+    await page.getByRole('option', { name: 'Aenas' }).click()
+    await page.getByRole('button', { name: 'Raise your lantern' }).click()
+
+    const wanderer = await waitForSurvivorByName(coreSettlementId, 'Aenas')
+    expect(wanderer.wanderer).toBe(true)
+    expect(wanderer.aenas_state).toBe('Hungry')
+    await expect(
+      page.getByRole('row', { name: /Aenas Wanderer/ })
+    ).toBeVisible()
+  })
+
+  test('edits representative survivor fields and blocks invalid numeric changes', async ({
+    page
+  }) => {
+    const { account, coreSettlementId } = await createSurvivorScenario('edit')
+    emailsToDelete.add(account.email)
+    const survivorId = await createSurvivorFixture({
+      settlementId: coreSettlementId,
+      name: 'E2E Editable Survivor'
+    })
+
+    await openSurvivorsTab(page, account, coreSettlementId, survivorId)
+
+    await page.getByLabel('Dead').click()
+    await waitForSurvivorField(survivorId, 'dead', true)
+
+    await setNumericCardValue(page, 'Survival', 2)
+    await waitForSurvivorField(survivorId, 'survival', 2)
+
+    await setNumericCardValue(page, 'Head Armor', 1)
+    await waitForSurvivorField(survivorId, 'head_armor', 1)
+
+    await page
+      .getByRole('spinbutton', { exact: true, name: 'Survival' })
+      .click()
+    const survivalDialog = page.getByRole('dialog')
+    await expect(
+      survivalDialog.getByRole('button', { name: 'Increase Survival' })
+    ).toBeDisabled()
+    await survivalDialog.getByRole('button', { name: 'Save' }).click()
+    await expect
+      .poll(async () => (await getSurvivorRow(survivorId)).survival)
+      .toBe(2)
+  })
+
+  test('equips and unequips settlement gear through the gear grid', async ({
+    page
+  }) => {
+    const { account, coreSettlementId } = await createSurvivorScenario('gear')
+    emailsToDelete.add(account.email)
+    const survivorId = await createSurvivorFixture({
+      settlementId: coreSettlementId,
+      name: 'E2E Gear Survivor'
+    })
+    const gearId = await addSettlementGearFixture(
+      coreSettlementId,
+      'Founding Stone'
+    )
+
+    await openSurvivorsTab(page, account, coreSettlementId, survivorId)
+    await page.getByRole('button', { name: 'Equip Top Left' }).click()
+    await page.getByPlaceholder('Search gear...').fill('Founding Stone')
+    await page
+      .locator('[data-slot="command-item"]')
+      .filter({ hasText: 'Founding Stone' })
+      .click()
+    await page.getByRole('button', { name: 'Equip' }).click()
+    await waitForGearGridSlot(survivorId, 'pos_top_left', gearId)
+
+    await page
+      .getByRole('button', { name: 'View Top Left: Founding Stone' })
+      .click()
+    await page.getByRole('button', { name: 'Unequip' }).click()
+    await waitForGearGridSlot(survivorId, 'pos_top_left', null)
+  })
+})
+
+async function createSurvivorScenario(prefix: string) {
+  const account = createAuthAccount(`survivor_${prefix}`.slice(0, 20))
+  const user = await createConfirmedAuthAccount(account)
+  const coreSettlementId = await createSettlementFixture({
+    name: `E2E Core ${prefix}`,
+    survivalLimit: 2,
+    userId: user.id,
+    survivorType: 'CORE'
+  })
+  const arcSettlementId = await createSettlementFixture({
+    name: `E2E Arc ${prefix}`,
+    survivalLimit: 2,
+    userId: user.id,
+    survivorType: 'ARC'
+  })
+
+  return { account, coreSettlementId, arcSettlementId }
+}
+
+async function openSurvivorsTab(
+  page: Page,
+  account: { email: string; password: string; username: string },
+  settlementId: string,
+  selectedSurvivorId: string | null = null
+): Promise<void> {
+  await page.goto('/auth/login')
+  await page.evaluate(
+    (storageKey) => localStorage.removeItem(storageKey),
+    LOCAL_STORAGE_KEY
+  )
+  await assertLoginPage(page)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password').fill(account.password)
+  await page.getByRole('button', { name: /^Login$/ }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await page.evaluate(
+    ({ selectedSettlementId, selectedSurvivorId, selectedTab, storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          selectedHuntId: null,
+          selectedHuntMonsterIndex: 0,
+          selectedSettlementId,
+          selectedSettlementPhaseId: null,
+          selectedShowdownId: null,
+          selectedShowdownMonsterIndex: 0,
+          selectedSurvivorId,
+          selectedTab
+        })
+      )
+    },
+    {
+      selectedSettlementId: settlementId,
+      selectedSurvivorId,
+      selectedTab: TabType.SURVIVORS,
+      storageKey: LOCAL_STORAGE_KEY
+    }
+  )
+  await page.goto('/')
+  await expect(page.getByRole('button', { name: 'New Survivor' })).toBeVisible()
+}
+
+async function createNamedSurvivor(
+  page: Page,
+  survivorName: string,
+  gender: 'Male' | 'Female'
+): Promise<void> {
+  await page.getByRole('button', { name: 'New Survivor' }).click()
+  await page.getByPlaceholder('Survivor name...').fill(survivorName)
+  await page.getByRole('radio', { exact: true, name: gender }).click()
+  await page.getByRole('button', { name: 'Raise your lantern' }).click()
+  await expect(page.getByText(survivorName).first()).toBeVisible()
+}
+
+async function setNumericCardValue(
+  page: Page,
+  title: string,
+  desiredValue: number
+): Promise<void> {
+  await page.getByRole('spinbutton', { exact: true, name: title }).click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog.getByRole('heading', { name: title })).toBeVisible()
+
+  const value = dialog.getByRole('spinbutton', { name: `${title} value` })
+  while (Number(await value.inputValue()) < desiredValue)
+    await dialog.getByRole('button', { name: `Increase ${title}` }).click()
+  while (Number(await value.inputValue()) > desiredValue)
+    await dialog.getByRole('button', { name: `Decrease ${title}` }).click()
+
+  await dialog.getByRole('button', { name: 'Save' }).click()
+}

--- a/components/menu/numeric-input.tsx
+++ b/components/menu/numeric-input.tsx
@@ -126,6 +126,7 @@ export function NumericInput({
   return disabled ? (
     <Input
       type="number"
+      aria-label={label}
       value={value}
       disabled={disabled}
       className={cn('text-center no-spinners', className)}
@@ -141,6 +142,7 @@ export function NumericInput({
       <DialogTrigger asChild>
         <Input
           type="number"
+          aria-label={label}
           value={value}
           className={cn('text-center no-spinners', className)}
           readOnly
@@ -158,6 +160,7 @@ export function NumericInput({
         <div className="flex items-center justify-center gap-4">
           {/* Decrement Button */}
           <Button
+            aria-label={`Decrease ${label}`}
             variant="outline"
             size="icon"
             onClick={handleDecrement}
@@ -172,6 +175,7 @@ export function NumericInput({
           {/* Current Value Display */}
           <Input
             type="number"
+            aria-label={`${label} value`}
             value={draftValue}
             readOnly
             className="w-20 h-12 text-center text-xl font-semibold focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 px-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
@@ -182,6 +186,7 @@ export function NumericInput({
 
           {/* Increment Button */}
           <Button
+            aria-label={`Increase ${label}`}
             variant="outline"
             size="icon"
             onClick={handleIncrement}


### PR DESCRIPTION
## Summary
- Adds survivor-management UI coverage for core, arc, and wanderer survivor creation.
- Adds survivor edit coverage for dead status, survival limits, head armor, and gear grid equip/unequip flows.
- Adds survivor UI test helpers and accessible labels for numeric inputs used by the tests.

## Dependency Changes
- None.

## Issues
Closes #278
Closes #287
Closes #267

## Verification
- npx prettier --check components/menu/numeric-input.tsx __tests__/ui/helpers/settlement.ts __tests__/ui/helpers/survivor.ts __tests__/ui/survivor-management.test.ts && git diff --check
- npm run ui-test -- __tests__/ui/survivor-management.test.ts --project=desktop-chromium
- npm run ui-test -- __tests__/ui/survivor-management.test.ts --project=mobile-chromium
- npm run ui-test -- --project=desktop-chromium
- npm run ui-test -- --project=mobile-chromium