### PR TITLE
Add UI gameplay loop coverage

### DIFF
--- a/__tests__/ui/gameplay-loop.test.ts
+++ b/__tests__/ui/gameplay-loop.test.ts
@@ -1,0 +1,464 @@
+import {
+  assertLoginPage,
+  createAuthAccount,
+  createConfirmedAuthAccount
+} from '@/__tests__/ui/helpers/auth'
+import {
+  addSurvivorGearGridFixture,
+  countHuntsForSettlement,
+  countReturningSurvivors,
+  createActiveHuntFixture,
+  createGameplaySurvivorsFixture,
+  createSettlementPhaseAtStepFixture,
+  getHuntBoardSpace,
+  getHuntSummary,
+  getSettlementPhaseStep,
+  getShowdownSummary,
+  getShowdownTurn,
+  unlockNemesisFixture,
+  unlockQuarryFixture,
+  waitForActiveHunt,
+  waitForActiveSettlementPhase,
+  waitForActiveShowdown,
+  waitForNoActiveHunt,
+  waitForNoActiveShowdown,
+  type GameplaySurvivorFixture
+} from '@/__tests__/ui/helpers/gameplay'
+import {
+  createSettlementFixture,
+  createShowdownFixture,
+  showdownExists
+} from '@/__tests__/ui/helpers/settlement'
+import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import { LOCAL_STORAGE_KEY } from '@/lib/common'
+import { TabType } from '@/lib/enums'
+import {
+  EMBARK_GEAR_SHORTAGE_ERROR_MESSAGE,
+  ERROR_MESSAGE,
+  SHOWDOWN_ALREADY_ACTIVE_ERROR_MESSAGE
+} from '@/lib/messages'
+import { expect, test, type Page } from '@playwright/test'
+
+test.describe('gameplay loop flow', () => {
+  const emailsToDelete = new Set<string>()
+
+  test.afterEach(async () => {
+    await deleteUsersByEmail(emailsToDelete)
+    emailsToDelete.clear()
+  })
+
+  test('carries a hunt through showdown and settlement phase', async ({
+    page
+  }) => {
+    test.slow()
+
+    const { account, settlementId, survivors } = await createGameplayScenario(
+      'happy',
+      { survivorCount: 4 }
+    )
+    emailsToDelete.add(account.email)
+
+    await openGameplayTab(page, account, settlementId, TabType.HUNT)
+    await configureHunt(page, survivors.slice(0, 4))
+    await page.getByRole('button', { name: 'Begin Hunt' }).click()
+
+    const hunt = await waitForActiveHunt(settlementId)
+    await expect
+      .poll(() => getHuntSummary(hunt.id as string))
+      .toEqual({
+        aiDeckCount: 1,
+        boardCount: 1,
+        monsterCount: 1,
+        survivorCount: 4
+      })
+    await expect(
+      page.getByRole('button', { name: 'Begin Showdown' })
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: 'Begin Showdown' }).click()
+    await page
+      .getByRole('alertdialog')
+      .getByRole('button', { name: 'Proceed' })
+      .click()
+
+    await waitForNoActiveHunt(settlementId)
+    const showdown = await waitForActiveShowdown(settlementId)
+    const showdownSummary = await getShowdownSummary(showdown.id as string)
+    expect(showdownSummary).toEqual({
+      aiDeckCount: 1,
+      monsterCount: 1,
+      survivorCount: 4
+    })
+
+    await expect(
+      page.getByRole('button', { name: 'Begin Settlement Phase' })
+    ).toBeVisible()
+    await page.getByRole('button', { name: 'Begin Settlement Phase' }).click()
+    await page
+      .getByRole('alertdialog')
+      .getByRole('button', { name: 'Proceed' })
+      .click()
+
+    await waitForNoActiveShowdown(settlementId)
+    const settlementPhase = await waitForActiveSettlementPhase(settlementId)
+    expect(settlementPhase.step).toBe('SET_UP_SETTLEMENT')
+    await expect
+      .poll(() => countReturningSurvivors(settlementPhase.id as string))
+      .toBe(4)
+    await expect(page.getByText('Set Up Settlement')).toBeVisible()
+  })
+
+  test('validates hunt party constraints and gear shortages', async ({
+    page
+  }) => {
+    const { account, settlementId, survivors } = await createGameplayScenario(
+      'validation',
+      { survivorCount: 5, usesScouts: true }
+    )
+    emailsToDelete.add(account.email)
+    await addSurvivorGearGridFixture({
+      gearName: 'Founding Stone',
+      settlementId,
+      survivorId: survivors[0].id
+    })
+
+    await openGameplayTab(page, account, settlementId, TabType.HUNT)
+    await selectOption(page, 'Quarry', 'White Lion')
+
+    const beginHuntButton = page.getByRole('button', { name: 'Begin Hunt' })
+    await expect(beginHuntButton).toBeDisabled()
+
+    await selectSurvivorParty(page, survivors.slice(0, 4))
+    await expect(beginHuntButton).toBeDisabled()
+
+    await page.getByRole('button', { name: 'Select scout...' }).click()
+    const scoutDrawer = page.getByRole('dialog')
+    await expect(
+      scoutDrawer.getByRole('button', { name: new RegExp(survivors[0].name) })
+    ).toBeDisabled()
+    await scoutDrawer
+      .getByRole('button', { name: new RegExp(survivors[4].name) })
+      .click()
+    await scoutDrawer.getByRole('button', { name: 'Confirm Selection' }).click()
+
+    await expect(page.getByRole('button', { name: '1 scout' })).toBeVisible()
+    await expect(beginHuntButton).toBeEnabled()
+
+    await beginHuntButton.click()
+    await expect(
+      page.getByText(
+        EMBARK_GEAR_SHORTAGE_ERROR_MESSAGE([
+          { available: 0, gear_name: 'Founding Stone', needed: 1 }
+        ])
+      )
+    ).toBeVisible()
+    await expect.poll(() => countHuntsForSettlement(settlementId)).toBe(0)
+  })
+
+  test('blocks hunts while a showdown is already active', async ({ page }) => {
+    const { account, settlementId, survivors } = await createGameplayScenario(
+      'conflict',
+      { survivorCount: 4 }
+    )
+    emailsToDelete.add(account.email)
+    const showdownId = await createShowdownFixture(settlementId)
+
+    await openGameplayTab(page, account, settlementId, TabType.HUNT)
+    await configureHunt(page, survivors.slice(0, 4))
+    await page.getByRole('button', { name: 'Begin Hunt' }).click()
+
+    await expect(
+      page.getByText(SHOWDOWN_ALREADY_ACTIVE_ERROR_MESSAGE())
+    ).toBeVisible()
+    await expect.poll(() => countHuntsForSettlement(settlementId)).toBe(0)
+    await expect.poll(() => showdownExists(showdownId)).toBe(true)
+  })
+
+  test('persists and rolls back active hunt board edits', async ({ page }) => {
+    const { account, settlementId, survivors } = await createGameplayScenario(
+      'board',
+      { survivorCount: 4 }
+    )
+    emailsToDelete.add(account.email)
+    const { huntId } = await createActiveHuntFixture({
+      settlementId,
+      survivorIds: survivors.slice(0, 4).map((survivor) => survivor.id)
+    })
+
+    await openGameplayTab(page, account, settlementId, TabType.HUNT)
+    await page
+      .getByRole('button', { name: 'Hunt board space 1: BASIC' })
+      .click()
+    await expect.poll(() => getHuntBoardSpace(huntId, 1)).toBe('MONSTER')
+    await expect(
+      page.getByRole('button', { name: 'Hunt board space 1: MONSTER' })
+    ).toBeVisible()
+
+    await failNextRestPatch(page, '**/rest/v1/hunt_hunt_board*')
+    await page
+      .getByRole('button', { name: 'Hunt board space 1: MONSTER' })
+      .click()
+
+    await expect(page.getByText(ERROR_MESSAGE())).toBeVisible()
+    await expect.poll(() => getHuntBoardSpace(huntId, 1)).toBe('MONSTER')
+    await expect(
+      page.getByRole('button', { name: 'Hunt board space 1: MONSTER' })
+    ).toBeVisible()
+  })
+
+  test('creates a regular showdown and rolls back failed turn updates', async ({
+    page
+  }) => {
+    test.slow()
+
+    const { account, settlementId, survivors } = await createGameplayScenario(
+      'showdown',
+      { survivorCount: 4 }
+    )
+    emailsToDelete.add(account.email)
+
+    await openGameplayTab(page, account, settlementId, TabType.SHOWDOWN)
+    await configureShowdown(page, {
+      monsterName: 'White Lion',
+      survivors: survivors.slice(0, 4),
+      firstTurn: 'Survivors'
+    })
+    await page.getByRole('button', { name: 'Begin Showdown' }).click()
+
+    const showdown = await waitForActiveShowdown(settlementId)
+    const showdownId = showdown.id as string
+    expect(showdown.showdown_type).toBe('REGULAR')
+    expect(showdown.turn).toBe('SURVIVOR')
+    await expect
+      .poll(() => getShowdownSummary(showdownId))
+      .toEqual({
+        aiDeckCount: 1,
+        monsterCount: 1,
+        survivorCount: 4
+      })
+
+    await expect(page.getByText("Survivors' Turn")).toBeVisible()
+    await expect(page.getByText('White Lion')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Move' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Activate' })).toBeVisible()
+
+    await page.getByRole('button', { name: 'End Survivor Turn' }).click()
+    await expect.poll(() => getShowdownTurn(showdownId)).toBe('MONSTER')
+    await expect(
+      page.getByRole('button', { name: 'End Monster Turn' })
+    ).toBeVisible()
+
+    await failNextRestPatch(page, '**/rest/v1/showdown*')
+    await page.getByRole('button', { name: 'End Monster Turn' }).click()
+    await expect(page.getByText(ERROR_MESSAGE())).toBeVisible()
+    await expect.poll(() => getShowdownTurn(showdownId)).toBe('MONSTER')
+    await expect(
+      page.getByRole('button', { name: 'End Monster Turn' })
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: 'End Showdown' }).click()
+    const dialog = page.getByRole('alertdialog')
+    await expect(
+      dialog.getByRole('heading', { name: 'End Showdown' })
+    ).toBeVisible()
+    await dialog.getByRole('button', { name: 'Go Back' }).click()
+    await expect.poll(() => getShowdownTurn(showdownId)).toBe('MONSTER')
+  })
+
+  test('creates a special nemesis showdown from settlement phase and returns', async ({
+    page
+  }) => {
+    test.slow()
+
+    const { account, settlementId, survivors } = await createGameplayScenario(
+      'special',
+      { survivorCount: 4 }
+    )
+    emailsToDelete.add(account.email)
+    const settlementPhaseId = await createSettlementPhaseAtStepFixture({
+      returningSurvivorIds: survivors
+        .slice(0, 4)
+        .map((survivor) => survivor.id),
+      settlementId,
+      step: 'SPECIAL_SHOWDOWN'
+    })
+
+    await openGameplayTab(page, account, settlementId, TabType.SETTLEMENT_PHASE)
+    await page
+      .getByRole('button', { name: 'Proceed to Special Showdown' })
+      .click()
+    await expect(page.getByRole('combobox', { name: 'Monster' })).toBeVisible()
+    await expect(
+      page.getByRole('checkbox', { name: 'Special Showdown' })
+    ).toBeChecked()
+
+    await configureShowdown(page, {
+      ambush: 'Monster',
+      monsterName: 'Butcher',
+      survivors: survivors.slice(0, 4)
+    })
+    await page.getByRole('button', { name: 'Begin Showdown' }).click()
+
+    const showdown = await waitForActiveShowdown(settlementId)
+    expect(showdown.showdown_type).toBe('SPECIAL')
+    expect(showdown.ambush).toBe('MONSTER')
+    expect(showdown.turn).toBe('MONSTER')
+
+    await page
+      .getByRole('button', { name: 'Return to Settlement Phase' })
+      .click()
+    await page
+      .getByRole('alertdialog')
+      .getByRole('button', { name: 'Proceed' })
+      .click()
+
+    await waitForNoActiveShowdown(settlementId)
+    await expect
+      .poll(() => getSettlementPhaseStep(settlementPhaseId))
+      .toBe('UPDATE_DEATH_COUNT')
+    await expect(page.getByText('Update Death Count')).toBeVisible()
+  })
+})
+
+async function createGameplayScenario(
+  prefix: string,
+  options: { survivorCount: number; usesScouts?: boolean }
+) {
+  const account = createAuthAccount(`gameplay_${prefix}`.slice(0, 20))
+  const user = await createConfirmedAuthAccount(account)
+  const settlementId = await createSettlementFixture({
+    name: `E2E Gameplay ${prefix}`,
+    usesScouts: options.usesScouts ?? false,
+    userId: user.id
+  })
+  await Promise.all([
+    unlockQuarryFixture(settlementId, 'White Lion'),
+    unlockNemesisFixture(settlementId, 'Butcher')
+  ])
+  const survivors = await createGameplaySurvivorsFixture({
+    count: options.survivorCount,
+    prefix: `E2E ${prefix}`,
+    settlementId
+  })
+
+  return { account, settlementId, survivors }
+}
+
+async function openGameplayTab(
+  page: Page,
+  account: { email: string; password: string; username: string },
+  settlementId: string,
+  selectedTab: TabType
+): Promise<void> {
+  await page.goto('/auth/login')
+  await page.evaluate(
+    (storageKey) => localStorage.removeItem(storageKey),
+    LOCAL_STORAGE_KEY
+  )
+  await assertLoginPage(page)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password').fill(account.password)
+  await page.getByRole('button', { name: /^Login$/ }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await page.evaluate(
+    ({ selectedSettlementId, selectedTab, storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          selectedHuntId: null,
+          selectedHuntMonsterIndex: 0,
+          selectedSettlementId,
+          selectedSettlementPhaseId: null,
+          selectedShowdownId: null,
+          selectedShowdownMonsterIndex: 0,
+          selectedSurvivorId: null,
+          selectedTab
+        })
+      )
+    },
+    {
+      selectedSettlementId: settlementId,
+      selectedTab,
+      storageKey: LOCAL_STORAGE_KEY
+    }
+  )
+  await page.goto('/')
+}
+
+async function configureHunt(
+  page: Page,
+  survivors: GameplaySurvivorFixture[]
+): Promise<void> {
+  await selectOption(page, 'Quarry', 'White Lion')
+  await selectSurvivorParty(page, survivors)
+}
+
+async function configureShowdown(
+  page: Page,
+  options: {
+    ambush?: 'Monster' | 'None' | 'Survivors'
+    firstTurn?: 'Monster' | 'Survivors'
+    monsterName: string
+    survivors: GameplaySurvivorFixture[]
+  }
+): Promise<void> {
+  await selectOption(page, 'Monster', options.monsterName)
+  if (options.ambush) await selectOption(page, 'Ambush', options.ambush)
+  if (options.firstTurn)
+    await selectOption(page, 'First Turn', options.firstTurn)
+  await selectSurvivorParty(page, options.survivors)
+}
+
+async function selectSurvivorParty(
+  page: Page,
+  survivors: GameplaySurvivorFixture[]
+): Promise<void> {
+  await page.getByRole('button', { name: 'Select survivors...' }).click()
+  const drawer = page.getByRole('dialog')
+
+  for (const survivor of survivors)
+    await drawer
+      .getByRole('button', { name: new RegExp(escapeRegExp(survivor.name)) })
+      .click()
+
+  await drawer
+    .getByRole('button', {
+      name: new RegExp(`Confirm Selection \\(${survivors.length}/4\\)`)
+    })
+    .click()
+
+  await expect(
+    page.getByRole('button', { name: `${survivors.length} survivor(s)` })
+  ).toBeVisible()
+}
+
+async function selectOption(
+  page: Page,
+  comboboxName: string,
+  optionName: string
+): Promise<void> {
+  await page.getByRole('combobox', { name: comboboxName }).click()
+  await page.getByRole('option', { exact: true, name: optionName }).click()
+}
+
+async function failNextRestPatch(page: Page, url: string): Promise<void> {
+  let failed = false
+
+  await page.route(url, async (route) => {
+    if (!failed && route.request().method() === 'PATCH') {
+      failed = true
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'E2E gameplay mutation failure' })
+      })
+      return
+    }
+
+    await route.continue()
+  })
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/__tests__/ui/helpers/gameplay.ts
+++ b/__tests__/ui/helpers/gameplay.ts
@@ -1,0 +1,461 @@
+import { admin } from '@/__tests__/ui/helpers/supabase'
+import { type Database } from '@/lib/database.types'
+
+type HuntEventType = Database['public']['Enums']['hunt_event_type']
+type SettlementPhaseStep = Database['public']['Enums']['settlement_phase_step']
+type ShowdownTurn = Database['public']['Enums']['showdown_turn']
+
+/** Survivor Fixture */
+export interface GameplaySurvivorFixture {
+  /** Survivor ID */
+  id: string
+  /** Survivor Name */
+  name: string
+}
+
+/** Active Hunt Fixture Result */
+export interface ActiveHuntFixtureResult {
+  /** Hunt Board ID */
+  boardId: string
+  /** Hunt ID */
+  huntId: string
+}
+
+/** Active Hunt Summary */
+export interface ActiveHuntSummary {
+  /** Hunt AI Deck Count */
+  aiDeckCount: number
+  /** Hunt Board Count */
+  boardCount: number
+  /** Hunt Monster Count */
+  monsterCount: number
+  /** Hunt Survivor Count */
+  survivorCount: number
+}
+
+/** Active Showdown Summary */
+export interface ActiveShowdownSummary {
+  /** Showdown AI Deck Count */
+  aiDeckCount: number
+  /** Showdown Monster Count */
+  monsterCount: number
+  /** Showdown Survivor Count */
+  survivorCount: number
+}
+
+/** Create Gameplay Survivor Fixtures */
+export async function createGameplaySurvivorsFixture({
+  count,
+  prefix,
+  settlementId
+}: {
+  count: number
+  prefix: string
+  settlementId: string
+}): Promise<GameplaySurvivorFixture[]> {
+  const survivors: GameplaySurvivorFixture[] = []
+
+  for (let index = 1; index <= count; index += 1) {
+    const name = `${prefix} ${index}`
+    const { data, error } = await admin
+      .from('survivor')
+      .insert({
+        gender: index % 2 === 0 ? 'MALE' : 'FEMALE',
+        settlement_id: settlementId,
+        survivor_name: name,
+        survival: 1
+      })
+      .select('id')
+      .single()
+
+    if (error) throw new Error(`create survivor failed: ${error.message}`)
+
+    survivors.push({ id: data.id, name })
+  }
+
+  return survivors
+}
+
+/** Unlock Quarry Fixture */
+export async function unlockQuarryFixture(
+  settlementId: string,
+  monsterName = 'White Lion'
+): Promise<string> {
+  const quarryId = await findCatalogId('quarry', monsterName)
+  const { error } = await admin.from('settlement_quarry').insert({
+    quarry_id: quarryId,
+    settlement_id: settlementId,
+    unlocked: true
+  })
+
+  if (error) throw new Error(`unlock quarry failed: ${error.message}`)
+
+  return quarryId
+}
+
+/** Unlock Nemesis Fixture */
+export async function unlockNemesisFixture(
+  settlementId: string,
+  monsterName = 'Butcher'
+): Promise<string> {
+  const nemesisId = await findCatalogId('nemesis', monsterName)
+  const { error } = await admin.from('settlement_nemesis').insert({
+    nemesis_id: nemesisId,
+    settlement_id: settlementId,
+    unlocked: true
+  })
+
+  if (error) throw new Error(`unlock nemesis failed: ${error.message}`)
+
+  return nemesisId
+}
+
+/** Add Survivor Gear Grid Fixture */
+export async function addSurvivorGearGridFixture({
+  gearName,
+  settlementId,
+  survivorId
+}: {
+  gearName: string
+  settlementId: string
+  survivorId: string
+}): Promise<string> {
+  const gearId = await findGearId(gearName)
+  const { error: storageError } = await admin.from('settlement_gear').insert({
+    gear_id: gearId,
+    quantity: 1,
+    settlement_id: settlementId
+  })
+
+  if (storageError)
+    throw new Error(`settlement gear insert failed: ${storageError.message}`)
+
+  const { error } = await admin.from('gear_grid').insert({
+    pos_top_left: gearId,
+    settlement_id: settlementId,
+    survivor_id: survivorId
+  })
+
+  if (error) throw new Error(`gear grid insert failed: ${error.message}`)
+
+  const { error: reduceError } = await admin
+    .from('settlement_gear')
+    .update({ quantity: 0 })
+    .eq('gear_id', gearId)
+    .eq('settlement_id', settlementId)
+
+  if (reduceError)
+    throw new Error(`settlement gear reduction failed: ${reduceError.message}`)
+
+  return gearId
+}
+
+/** Create Active Hunt Fixture */
+export async function createActiveHuntFixture({
+  settlementId,
+  survivorIds
+}: {
+  settlementId: string
+  survivorIds: string[]
+}): Promise<ActiveHuntFixtureResult> {
+  const { data: hunt, error: huntError } = await admin
+    .from('hunt')
+    .insert({
+      monster_level: 1,
+      monster_position: 6,
+      settlement_id: settlementId,
+      survivor_position: 0
+    })
+    .select('id')
+    .single()
+
+  if (huntError)
+    throw new Error(`create active hunt failed: ${huntError.message}`)
+
+  const { data: board, error: boardError } = await admin
+    .from('hunt_hunt_board')
+    .insert({
+      hunt_id: hunt.id,
+      settlement_id: settlementId
+    })
+    .select('id')
+    .single()
+
+  if (boardError)
+    throw new Error(`create active hunt board failed: ${boardError.message}`)
+
+  const { data: aiDeck, error: aiDeckError } = await admin
+    .from('hunt_ai_deck')
+    .insert({ hunt_id: hunt.id, settlement_id: settlementId })
+    .select('id')
+    .single()
+
+  if (aiDeckError)
+    throw new Error(`create hunt ai deck failed: ${aiDeckError.message}`)
+
+  const { error: monsterError } = await admin.from('hunt_monster').insert({
+    ai_deck_id: aiDeck.id,
+    hunt_id: hunt.id,
+    monster_name: 'White Lion',
+    settlement_id: settlementId
+  })
+
+  if (monsterError)
+    throw new Error(`create hunt monster failed: ${monsterError.message}`)
+
+  const { error: survivorError } = await admin.from('hunt_survivor').insert(
+    survivorIds.map((survivorId) => ({
+      hunt_id: hunt.id,
+      settlement_id: settlementId,
+      survivor_id: survivorId
+    }))
+  )
+
+  if (survivorError)
+    throw new Error(`create hunt survivors failed: ${survivorError.message}`)
+
+  return { boardId: board.id, huntId: hunt.id }
+}
+
+/** Create Settlement Phase At Step Fixture */
+export async function createSettlementPhaseAtStepFixture({
+  returningSurvivorIds = [],
+  settlementId,
+  step
+}: {
+  returningSurvivorIds?: string[]
+  settlementId: string
+  step: SettlementPhaseStep
+}): Promise<string> {
+  const { data, error } = await admin
+    .from('settlement_phase')
+    .insert({ settlement_id: settlementId, step })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`create settlement phase failed: ${error.message}`)
+
+  if (returningSurvivorIds.length > 0) {
+    const { error: returningError } = await admin
+      .from('settlement_phase_returning_survivor')
+      .insert(
+        returningSurvivorIds.map((survivorId) => ({
+          settlement_id: settlementId,
+          settlement_phase_id: data.id,
+          survivor_id: survivorId
+        }))
+      )
+
+    if (returningError)
+      throw new Error(
+        `create returning survivors failed: ${returningError.message}`
+      )
+  }
+
+  return data.id
+}
+
+/** Wait For Active Hunt */
+export async function waitForActiveHunt(settlementId: string) {
+  return waitForRow('hunt', 'settlement_id', settlementId, true)
+}
+
+/** Wait For No Active Hunt */
+export async function waitForNoActiveHunt(settlementId: string): Promise<void> {
+  await waitForRow('hunt', 'settlement_id', settlementId, false)
+}
+
+/** Wait For Active Showdown */
+export async function waitForActiveShowdown(settlementId: string) {
+  return waitForRow('showdown', 'settlement_id', settlementId, true)
+}
+
+/** Wait For No Active Showdown */
+export async function waitForNoActiveShowdown(
+  settlementId: string
+): Promise<void> {
+  await waitForRow('showdown', 'settlement_id', settlementId, false)
+}
+
+/** Wait For Active Settlement Phase */
+export async function waitForActiveSettlementPhase(settlementId: string) {
+  return waitForRow('settlement_phase', 'settlement_id', settlementId, true)
+}
+
+/** Count Hunts For Settlement */
+export async function countHuntsForSettlement(
+  settlementId: string
+): Promise<number> {
+  return countRows('hunt', 'settlement_id', settlementId)
+}
+
+/** Get Hunt Summary */
+export async function getHuntSummary(
+  huntId: string
+): Promise<ActiveHuntSummary> {
+  const [boardCount, aiDeckCount, monsterCount, survivorCount] =
+    await Promise.all([
+      countRows('hunt_hunt_board', 'hunt_id', huntId),
+      countRows('hunt_ai_deck', 'hunt_id', huntId),
+      countRows('hunt_monster', 'hunt_id', huntId),
+      countRows('hunt_survivor', 'hunt_id', huntId)
+    ])
+
+  return { aiDeckCount, boardCount, monsterCount, survivorCount }
+}
+
+/** Get Hunt Board Space */
+export async function getHuntBoardSpace(
+  huntId: string,
+  position: number
+): Promise<HuntEventType> {
+  const column = `pos_${position}`
+  const { data, error } = await admin
+    .from('hunt_hunt_board')
+    .select(column)
+    .eq('hunt_id', huntId)
+    .single()
+
+  if (error) throw new Error(`hunt board lookup failed: ${error.message}`)
+
+  return (data as unknown as Record<string, HuntEventType>)[column]
+}
+
+/** Get Showdown Summary */
+export async function getShowdownSummary(
+  showdownId: string
+): Promise<ActiveShowdownSummary> {
+  const [aiDeckCount, monsterCount, survivorCount] = await Promise.all([
+    countRows('showdown_ai_deck', 'showdown_id', showdownId),
+    countRows('showdown_monster', 'showdown_id', showdownId),
+    countRows('showdown_survivor', 'showdown_id', showdownId)
+  ])
+
+  return { aiDeckCount, monsterCount, survivorCount }
+}
+
+/** Get Showdown Turn */
+export async function getShowdownTurn(
+  showdownId: string
+): Promise<ShowdownTurn> {
+  const { data, error } = await admin
+    .from('showdown')
+    .select('turn')
+    .eq('id', showdownId)
+    .single()
+
+  if (error) throw new Error(`showdown turn lookup failed: ${error.message}`)
+
+  return data.turn as ShowdownTurn
+}
+
+/** Get Settlement Phase Step */
+export async function getSettlementPhaseStep(
+  settlementPhaseId: string
+): Promise<SettlementPhaseStep> {
+  const { data, error } = await admin
+    .from('settlement_phase')
+    .select('step')
+    .eq('id', settlementPhaseId)
+    .single()
+
+  if (error)
+    throw new Error(`settlement phase step lookup failed: ${error.message}`)
+
+  return data.step as SettlementPhaseStep
+}
+
+/** Count Returning Survivors */
+export async function countReturningSurvivors(
+  settlementPhaseId: string
+): Promise<number> {
+  return countRows(
+    'settlement_phase_returning_survivor',
+    'settlement_phase_id',
+    settlementPhaseId
+  )
+}
+
+async function findCatalogId(
+  table: 'nemesis' | 'quarry',
+  monsterName: string
+): Promise<string> {
+  const { data, error } = await admin
+    .from(table)
+    .select('id')
+    .eq('monster_name', monsterName)
+    .single()
+
+  if (error) throw new Error(`${table} lookup failed: ${error.message}`)
+
+  return data.id
+}
+
+async function findGearId(gearName: string): Promise<string> {
+  const { data, error } = await admin
+    .from('gear')
+    .select('id')
+    .eq('gear_name', gearName)
+    .eq('custom', false)
+    .single()
+
+  if (error) throw new Error(`gear lookup failed: ${error.message}`)
+
+  return data.id
+}
+
+async function waitForRow(
+  table: 'hunt' | 'settlement_phase' | 'showdown',
+  column: string,
+  value: string,
+  shouldExist: true
+): Promise<Record<string, unknown>>
+async function waitForRow(
+  table: 'hunt' | 'settlement_phase' | 'showdown',
+  column: string,
+  value: string,
+  shouldExist: false
+): Promise<void>
+async function waitForRow(
+  table: 'hunt' | 'settlement_phase' | 'showdown',
+  column: string,
+  value: string,
+  shouldExist: boolean
+): Promise<Record<string, unknown> | void> {
+  const timeoutAt = Date.now() + 10_000
+
+  while (Date.now() < timeoutAt) {
+    const { data, error } = await admin
+      .from(table)
+      .select('*')
+      .eq(column, value)
+      .maybeSingle()
+
+    if (error) throw new Error(`${table} lookup failed: ${error.message}`)
+    if (shouldExist && data) return data as Record<string, unknown>
+    if (!shouldExist && !data) return
+
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(
+    `Timed out waiting for ${table}.${column}=${value} ${
+      shouldExist ? 'to exist' : 'to clear'
+    }`
+  )
+}
+
+async function countRows(
+  table: string,
+  column: string,
+  value: string
+): Promise<number> {
+  const { count, error } = await admin
+    .from(table)
+    .select('*', { count: 'exact', head: true })
+    .eq(column, value)
+
+  if (error) throw new Error(`${table} count failed: ${error.message}`)
+
+  return count ?? 0
+}

--- a/components/hunt/create-hunt/create-hunt-card.tsx
+++ b/components/hunt/create-hunt/create-hunt-card.tsx
@@ -682,7 +682,7 @@ export function CreateHuntCard({
             <Select
               value={selectedQuarryId ?? ''}
               onValueChange={handleQuarrySelection}>
-              <SelectTrigger className="w-full">
+              <SelectTrigger aria-label="Quarry" className="w-full">
                 <SelectValue placeholder="Choose a quarry..." />
               </SelectTrigger>
 
@@ -711,7 +711,7 @@ export function CreateHuntCard({
             value={String(selectedLevelNumber)}
             onValueChange={(value) => handleLevelSelection(Number(value))}
             disabled={activeLevels.length === 0}>
-            <SelectTrigger className="w-full">
+            <SelectTrigger aria-label="Hunt Level" className="w-full">
               <SelectValue placeholder="Choose level..." />
             </SelectTrigger>
 
@@ -737,7 +737,7 @@ export function CreateHuntCard({
               onValueChange={(value) =>
                 handleVersionSelection(value as MonsterVersion)
               }>
-              <SelectTrigger className="w-full">
+              <SelectTrigger aria-label="Hunt Version" className="w-full">
                 <SelectValue placeholder="Choose version..." />
               </SelectTrigger>
 

--- a/components/hunt/hunt-board/hunt-board-space.tsx
+++ b/components/hunt/hunt-board/hunt-board-space.tsx
@@ -8,6 +8,8 @@ import { ReactElement } from 'react'
  * Hunt Board Space Component Properties
  */
 interface HuntBoardSpaceProps {
+  /** Accessible Label */
+  ariaLabel: string
   /** Additional CSS classes */
   className?: string
   /** Space Index (0-12) */
@@ -19,7 +21,7 @@ interface HuntBoardSpaceProps {
   /** Is Starvation Space */
   isStarvation?: boolean
   /** Click handler */
-  onClick?: (e: React.MouseEvent) => void
+  onClick?: () => void
 }
 
 /**
@@ -31,6 +33,7 @@ interface HuntBoardSpaceProps {
  * @returns Hunt Board Space Component
  */
 export function HuntBoardSpace({
+  ariaLabel,
   className,
   index,
   label,
@@ -44,8 +47,17 @@ export function HuntBoardSpace({
 
   return (
     <div
+      aria-label={ariaLabel}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
       ref={setNodeRef}
       onClick={onClick}
+      onKeyDown={(event) => {
+        if (!onClick) return
+        if (event.key !== 'Enter' && event.key !== ' ') return
+        event.preventDefault()
+        onClick()
+      }}
       className={cn(
         'relative flex flex-col items-center justify-center w-full h-full border-2 rounded-lg transition-colors',
         'border-border bg-card hover:bg-accent/50',

--- a/components/hunt/hunt-board/hunt-board.tsx
+++ b/components/hunt/hunt-board/hunt-board.tsx
@@ -138,49 +138,70 @@ export function HuntBoard({
     }
   }
 
+  /**
+   * Get Accessible Space Label
+   *
+   * @param index Hunt Board Space Index
+   * @param label Hunt Board Space Label
+   * @returns Accessible Label
+   */
+  const getAccessibleSpaceLabel = (
+    index: number,
+    label: string | null | undefined
+  ) => `Hunt board space ${index}: ${label ?? index}`
+
   return (
     <Card className="p-0 w-full">
       <CardContent className="p-0 w-full overflow-x-auto">
         <DndContext onDragEnd={handleDragEnd}>
           <div className="w-full overflow-x-auto gap-1 p-2 bg-muted/30 rounded-lg relative flex flex-row flex-wrap items-center justify-center">
-            {spaces.map((space) => (
-              <div
-                key={space.index}
-                className="relative w-18.75 sm:w-21.25 md:w-22.5 h-18.75 sm:h-21.25 md:h-22.5 shrink-0 flex items-center justify-center">
-                <HuntBoardSpace
-                  onClick={() => handleSpaceClick(space.index)}
-                  className={
-                    space.isStart || space.isStarvation || space.index === 6
-                      ? ''
-                      : 'cursor-pointer'
-                  }
-                  index={space.index}
-                  label={getLabelOrIcon(space.label)}
-                  isStart={space.isStart}
-                  isStarvation={space.isStarvation}
-                />
+            {spaces.map((space) => {
+              const isEditableSpace =
+                !space.isStart && !space.isStarvation && space.index !== 6
 
-                {selectedHunt?.survivor_position === space.index && (
-                  <HuntBoardToken
-                    overlap={
-                      selectedHunt?.survivor_position ===
-                      selectedHunt?.monster_position
+              return (
+                <div
+                  key={space.index}
+                  className="relative w-18.75 sm:w-21.25 md:w-22.5 h-18.75 sm:h-21.25 md:h-22.5 shrink-0 flex items-center justify-center">
+                  <HuntBoardSpace
+                    ariaLabel={getAccessibleSpaceLabel(
+                      space.index,
+                      space.label
+                    )}
+                    onClick={
+                      isEditableSpace
+                        ? () => handleSpaceClick(space.index)
+                        : undefined
                     }
-                    tokenType="survivors"
+                    className={isEditableSpace ? 'cursor-pointer' : ''}
+                    index={space.index}
+                    label={getLabelOrIcon(space.label)}
+                    isStart={space.isStart}
+                    isStarvation={space.isStarvation}
                   />
-                )}
 
-                {selectedHunt?.monster_position === space.index && (
-                  <HuntBoardToken
-                    overlap={
-                      selectedHunt?.survivor_position ===
-                      selectedHunt?.monster_position
-                    }
-                    tokenType="quarry"
-                  />
-                )}
-              </div>
-            ))}
+                  {selectedHunt?.survivor_position === space.index && (
+                    <HuntBoardToken
+                      overlap={
+                        selectedHunt?.survivor_position ===
+                        selectedHunt?.monster_position
+                      }
+                      tokenType="survivors"
+                    />
+                  )}
+
+                  {selectedHunt?.monster_position === space.index && (
+                    <HuntBoardToken
+                      overlap={
+                        selectedHunt?.survivor_position ===
+                        selectedHunt?.monster_position
+                      }
+                      tokenType="quarry"
+                    />
+                  )}
+                </div>
+              )
+            })}
           </div>
         </DndContext>
       </CardContent>

--- a/components/showdown/create-showdown/create-showdown-card.tsx
+++ b/components/showdown/create-showdown/create-showdown-card.tsx
@@ -158,21 +158,7 @@ export function CreateShowdownCard({
   const [selectedSurvivors, setSelectedSurvivors] = useState<string[]>([])
   const [selectedScout, setSelectedScout] = useState<string | null>(null)
 
-  // Consume the pending special showdown flag from the parent. The handoff
-  // is performed at render time (via a render-time prev check) so the
-  // setState cascade isn't synchronous inside a `useEffect`.
-  const [prevPendingSpecial, setPrevPendingSpecial] = useState(
-    pendingSpecialShowdown
-  )
-
-  if (prevPendingSpecial !== pendingSpecialShowdown) {
-    setPrevPendingSpecial(pendingSpecialShowdown)
-
-    if (pendingSpecialShowdown) {
-      setIsSpecialShowdown(true)
-      setPendingSpecialShowdown(false)
-    }
-  }
+  const specialShowdownSelected = isSpecialShowdown || pendingSpecialShowdown
 
   /** Available survivors (excluding dead/retired/skip next hunt) */
   const availableSurvivors = useMemo(
@@ -459,14 +445,14 @@ export function CreateShowdownCard({
     try {
       // Determine the turn based on ambush type
       const turn: 'MONSTER' | 'SURVIVOR' =
-        ambushType === AmbushType.SURVIVORS ? 'SURVIVOR' : 'MONSTER'
+        startingTurn === TurnType.SURVIVORS ? 'SURVIVOR' : 'MONSTER'
 
       // 1. Create showdown record
       const showdownId = await addShowdown({
         ambush: ambushType.toUpperCase() as 'NONE' | 'SURVIVORS' | 'MONSTER',
         monster_level: selectedLevelNumber,
         settlement_id: selectedSettlement.id,
-        showdown_type: isSpecialShowdown ? 'SPECIAL' : 'REGULAR',
+        showdown_type: specialShowdownSelected ? 'SPECIAL' : 'REGULAR',
         turn
       })
 
@@ -674,7 +660,7 @@ export function CreateShowdownCard({
         ambush: ambushType.toUpperCase() as 'NONE' | 'SURVIVORS' | 'MONSTER',
         monster_level: selectedLevelNumber,
         settlement_id: selectedSettlement.id,
-        showdown_type: isSpecialShowdown ? 'SPECIAL' : 'REGULAR',
+        showdown_type: specialShowdownSelected ? 'SPECIAL' : 'REGULAR',
         turn,
         showdown_monsters: showdownMonsters,
         showdown_survivors: showdownSurvivorMap
@@ -694,6 +680,7 @@ export function CreateShowdownCard({
       setVignetteLevels([])
       setSelectedMonsterIndex(0)
       setIsSpecialShowdown(false)
+      setPendingSpecialShowdown(false)
       setAmbushType(AmbushType.NONE)
       setStartingTurn(TurnType.MONSTER)
       setSelectedSurvivors([])
@@ -710,7 +697,6 @@ export function CreateShowdownCard({
     availableNemeses,
     availableQuarries,
     displayedLevel,
-    isSpecialShowdown,
     selectedHunt,
     selectedLevelNumber,
     selectedLevels,
@@ -718,6 +704,9 @@ export function CreateShowdownCard({
     selectedScout,
     selectedSettlement,
     selectedSurvivors,
+    startingTurn,
+    specialShowdownSelected,
+    setPendingSpecialShowdown,
     setSelectedShowdown,
     survivors
   ])
@@ -744,7 +733,7 @@ export function CreateShowdownCard({
                 const monster = availableMonsters.find((m) => m.id === id)
                 if (monster) handleMonsterSelection(id, monster.source)
               }}>
-              <SelectTrigger className="w-full">
+              <SelectTrigger aria-label="Monster" className="w-full">
                 <SelectValue placeholder="Choose a monster..." />
               </SelectTrigger>
               <SelectContent>
@@ -771,7 +760,7 @@ export function CreateShowdownCard({
             value={String(selectedLevelNumber)}
             onValueChange={(value) => handleLevelSelection(Number(value))}
             disabled={activeLevels.length === 0}>
-            <SelectTrigger className="w-full">
+            <SelectTrigger aria-label="Showdown Level" className="w-full">
               <SelectValue placeholder="Choose level..." />
             </SelectTrigger>
             <SelectContent>
@@ -795,7 +784,7 @@ export function CreateShowdownCard({
               onValueChange={(value) =>
                 handleVersionSelection(value as MonsterVersion)
               }>
-              <SelectTrigger className="w-full">
+              <SelectTrigger aria-label="Showdown Version" className="w-full">
                 <SelectValue placeholder="Choose version..." />
               </SelectTrigger>
               <SelectContent>
@@ -824,9 +813,31 @@ export function CreateShowdownCard({
           </Label>
           <Checkbox
             id="special-showdown-checkbox"
-            checked={isSpecialShowdown}
-            onCheckedChange={(checked) => setIsSpecialShowdown(!!checked)}
+            checked={specialShowdownSelected}
+            onCheckedChange={(checked) => {
+              setIsSpecialShowdown(!!checked)
+              setPendingSpecialShowdown(false)
+            }}
           />
+        </div>
+
+        {/* Ambush */}
+        <div className="flex items-center justify-between">
+          <Label className="text-left whitespace-nowrap min-w-22.5">
+            Ambush
+          </Label>
+          <Select
+            value={ambushType}
+            onValueChange={(value) => setAmbushType(value as AmbushType)}>
+            <SelectTrigger aria-label="Ambush" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={AmbushType.NONE}>None</SelectItem>
+              <SelectItem value={AmbushType.MONSTER}>Monster</SelectItem>
+              <SelectItem value={AmbushType.SURVIVORS}>Survivors</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
 
         {/* Starting Turn */}
@@ -837,7 +848,7 @@ export function CreateShowdownCard({
           <Select
             value={startingTurn}
             onValueChange={(value) => setStartingTurn(value as TurnType)}>
-            <SelectTrigger className="w-full">
+            <SelectTrigger aria-label="First Turn" className="w-full">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -1041,7 +1052,7 @@ export function CreateShowdownCard({
             availableSurvivors.length === 0 ||
             selectedSurvivors.length === 0 ||
             (selectedSettlement?.uses_scouts === true && !selectedScout) ||
-            (!!selectedSettlementPhase && !isSpecialShowdown) ||
+            (!!selectedSettlementPhase && !specialShowdownSelected) ||
             isCreating
           }
           className="w-full mt-2">


### PR DESCRIPTION
## Summary
- Adds gameplay-loop UI coverage for hunt creation, hunt-to-showdown-to-settlement phase handoff, hunt validation, board rollback, regular showdown controls, and special showdown return flow.
- Adds gameplay UI fixtures for unlocked monsters, survivors, gear grids, active hunt setup, and persisted row polling.
- Adds accessible labels for hunt/showdown selectors and hunt board spaces, plus an Ambush control and persisted First Turn behavior for showdown creation.

## Dependency Changes
- None.

## Issues
Closes #279
Closes #283
Closes #284
Closes #268

## Verification
- npx prettier --check components/hunt/create-hunt/create-hunt-card.tsx components/hunt/hunt-board/hunt-board.tsx components/hunt/hunt-board/hunt-board-space.tsx components/showdown/create-showdown/create-showdown-card.tsx __tests__/ui/helpers/gameplay.ts __tests__/ui/gameplay-loop.test.ts && git diff --check
- npm run ui-test -- __tests__/ui/gameplay-loop.test.ts --project=desktop-chromium
- npm run ui-test -- __tests__/ui/gameplay-loop.test.ts --project=mobile-chromium
- npm run ui-test -- --project=desktop-chromium
- npm run ui-test -- --project=mobile-chromium