### PR TITLE
Add UI settlement economy coverage

### DIFF
--- a/__tests__/ui/helpers/economy.ts
+++ b/__tests__/ui/helpers/economy.ts
@@ -1,0 +1,520 @@
+import { admin } from '@/__tests__/ui/helpers/supabase'
+import { type Database } from '@/lib/database.types'
+
+type SettlementPhaseStep = Database['public']['Enums']['settlement_phase_step']
+
+/** Economy Catalog Fixture */
+export interface EconomyCatalogFixture {
+  /** Butcher Settlement Nemesis ID */
+  butcherSettlementNemesisId: string
+  /** Death Settlement Principle ID */
+  deathSettlementPrincipleId: string
+  /** First Death Settlement Milestone ID */
+  firstDeathSettlementMilestoneId: string
+  /** Hovel Settlement Innovation ID */
+  hovelSettlementInnovationId: string
+  /** Lantern Hoard Settlement Location ID */
+  lanternHoardSettlementLocationId: string
+  /** White Lion Settlement Quarry ID */
+  whiteLionSettlementQuarryId: string
+}
+
+/** Crafting Fixture */
+export interface CraftingFixture {
+  /** Crafted Gear ID */
+  gearId: string
+  /** Crafted Gear Name */
+  gearName: string
+  /** Resource ID */
+  resourceId: string
+  /** Resource Name */
+  resourceName: string
+}
+
+/** Create Economy Survivor Fixture */
+export async function createEconomySurvivorFixture(
+  settlementId: string,
+  name: string
+): Promise<string> {
+  const { data, error } = await admin
+    .from('survivor')
+    .insert({
+      arm_armor: 2,
+      arm_light_damage: true,
+      body_armor: 2,
+      body_light_damage: true,
+      gender: 'FEMALE',
+      head_armor: 2,
+      head_heavy_damage: true,
+      settlement_id: settlementId,
+      survivor_name: name,
+      survival: 1
+    })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`create survivor failed: ${error.message}`)
+
+  return data.id
+}
+
+/** Create Settlement Phase Fixture */
+export async function createEconomySettlementPhaseFixture({
+  endeavors = 0,
+  returningSurvivorIds = [],
+  settlementId,
+  step
+}: {
+  endeavors?: number
+  returningSurvivorIds?: string[]
+  settlementId: string
+  step: SettlementPhaseStep
+}): Promise<string> {
+  const { data, error } = await admin
+    .from('settlement_phase')
+    .insert({ endeavors, settlement_id: settlementId, step })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`create settlement phase failed: ${error.message}`)
+
+  if (returningSurvivorIds.length > 0) {
+    const { error: returningError } = await admin
+      .from('settlement_phase_returning_survivor')
+      .insert(
+        returningSurvivorIds.map((survivorId) => ({
+          settlement_id: settlementId,
+          settlement_phase_id: data.id,
+          survivor_id: survivorId
+        }))
+      )
+
+    if (returningError)
+      throw new Error(
+        `create returning survivors failed: ${returningError.message}`
+      )
+  }
+
+  return data.id
+}
+
+/** Get Settlement Phase Step */
+export async function getSettlementPhaseStep(
+  settlementPhaseId: string
+): Promise<SettlementPhaseStep | null> {
+  const { data, error } = await admin
+    .from('settlement_phase')
+    .select('step')
+    .eq('id', settlementPhaseId)
+    .maybeSingle()
+
+  if (error) throw new Error(`settlement phase lookup failed: ${error.message}`)
+
+  return data?.step ?? null
+}
+
+/** Settlement Phase Exists */
+export async function economySettlementPhaseExists(
+  settlementPhaseId: string
+): Promise<boolean> {
+  return (await getSettlementPhaseStep(settlementPhaseId)) !== null
+}
+
+/** Get Survivor Heal Fields */
+export async function getSurvivorHealFields(survivorId: string) {
+  const { data, error } = await admin
+    .from('survivor')
+    .select(
+      'arm_armor, arm_light_damage, body_armor, body_light_damage, head_armor, head_heavy_damage'
+    )
+    .eq('id', survivorId)
+    .single()
+
+  if (error) throw new Error(`survivor lookup failed: ${error.message}`)
+
+  return data
+}
+
+/** Create Crafting Fixture */
+export async function createCraftingFixture({
+  gearName,
+  resourceName,
+  resourceQuantity,
+  userId,
+  settlementId
+}: {
+  gearName: string
+  resourceName: string
+  resourceQuantity: number
+  settlementId: string
+  userId: string
+}): Promise<CraftingFixture> {
+  const resourceId = await getResourceId(resourceName)
+
+  const { data: gear, error: gearError } = await admin
+    .from('gear')
+    .insert({ custom: true, gear_name: gearName, user_id: userId })
+    .select('id')
+    .single()
+
+  if (gearError)
+    throw new Error(`create custom gear failed: ${gearError.message}`)
+
+  const { error: costError } = await admin.from('gear_resource_cost').insert({
+    gear_id: gear.id,
+    quantity: 1,
+    resource_id: resourceId
+  })
+
+  if (costError)
+    throw new Error(`create gear cost failed: ${costError.message}`)
+
+  await addSettlementResourceFixture({
+    quantity: resourceQuantity,
+    resourceName,
+    settlementId
+  })
+
+  return { gearId: gear.id, gearName, resourceId, resourceName }
+}
+
+/** Create Expensive Gear Fixture */
+export async function createExpensiveGearFixture({
+  gearName,
+  quantity,
+  resourceName,
+  userId
+}: {
+  gearName: string
+  quantity: number
+  resourceName: string
+  userId: string
+}): Promise<string> {
+  const resourceId = await getResourceId(resourceName)
+  const { data: gear, error: gearError } = await admin
+    .from('gear')
+    .insert({ custom: true, gear_name: gearName, user_id: userId })
+    .select('id')
+    .single()
+
+  if (gearError)
+    throw new Error(`create expensive gear failed: ${gearError.message}`)
+
+  const { error: costError } = await admin.from('gear_resource_cost').insert({
+    gear_id: gear.id,
+    quantity,
+    resource_id: resourceId
+  })
+
+  if (costError)
+    throw new Error(`create expensive gear cost failed: ${costError.message}`)
+
+  return gear.id
+}
+
+/** Add Settlement Resource Fixture */
+export async function addSettlementResourceFixture({
+  quantity,
+  resourceName,
+  settlementId
+}: {
+  quantity: number
+  resourceName: string
+  settlementId: string
+}): Promise<string> {
+  const resourceId = await getResourceId(resourceName)
+  const { data, error } = await admin
+    .from('settlement_resource')
+    .insert({ quantity, resource_id: resourceId, settlement_id: settlementId })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`add settlement resource failed: ${error.message}`)
+
+  return data.id
+}
+
+/** Get Settlement Resource Quantity */
+export async function getSettlementResourceQuantity(
+  settlementId: string,
+  resourceName: string
+): Promise<number | null> {
+  const resourceId = await getResourceId(resourceName)
+  const { data, error } = await admin
+    .from('settlement_resource')
+    .select('quantity')
+    .eq('settlement_id', settlementId)
+    .eq('resource_id', resourceId)
+    .maybeSingle()
+
+  if (error)
+    throw new Error(`resource quantity lookup failed: ${error.message}`)
+
+  return data?.quantity ?? null
+}
+
+/** Get Settlement Gear Quantity */
+export async function getSettlementGearQuantity(
+  settlementId: string,
+  gearId: string
+): Promise<number | null> {
+  const { data, error } = await admin
+    .from('settlement_gear')
+    .select('quantity')
+    .eq('settlement_id', settlementId)
+    .eq('gear_id', gearId)
+    .maybeSingle()
+
+  if (error) throw new Error(`gear quantity lookup failed: ${error.message}`)
+
+  return data?.quantity ?? null
+}
+
+/** Create Timeline Year Fixture */
+export async function createTimelineYearFixture(
+  settlementId: string,
+  yearNumber = 0
+): Promise<string> {
+  const { data, error } = await admin
+    .from('settlement_timeline_year')
+    .insert({
+      entries: [],
+      settlement_id: settlementId,
+      year_number: yearNumber
+    })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`create timeline year failed: ${error.message}`)
+
+  return data.id
+}
+
+/** Get Timeline Entries */
+export async function getTimelineEntries(
+  settlementId: string,
+  yearNumber = 0
+): Promise<string[]> {
+  const { data, error } = await admin
+    .from('settlement_timeline_year')
+    .select('entries')
+    .eq('settlement_id', settlementId)
+    .eq('year_number', yearNumber)
+    .single()
+
+  if (error) throw new Error(`timeline lookup failed: ${error.message}`)
+
+  return data.entries ?? []
+}
+
+/** Create Catalog Junction Fixtures */
+export async function createEconomyCatalogFixture(
+  settlementId: string
+): Promise<EconomyCatalogFixture> {
+  const [
+    milestoneId,
+    principleId,
+    innovationId,
+    locationId,
+    quarryId,
+    nemesisId
+  ] = await Promise.all([
+    getCatalogId(
+      'milestone',
+      'milestone_name',
+      'First time death count is updated'
+    ),
+    getCatalogId('principle', 'principle_name', 'Death'),
+    getCatalogId('innovation', 'innovation_name', 'Hovel'),
+    getCatalogId('location', 'location_name', 'Lantern Hoard'),
+    getCatalogId('quarry', 'monster_name', 'White Lion'),
+    getCatalogId('nemesis', 'monster_name', 'Butcher')
+  ])
+
+  const [milestone, principle, innovation, location, quarry, nemesis] =
+    await Promise.all([
+      insertJunction('settlement_milestone', {
+        milestone_id: milestoneId,
+        settlement_id: settlementId
+      }),
+      insertJunction('settlement_principle', {
+        principle_id: principleId,
+        settlement_id: settlementId
+      }),
+      insertJunction('settlement_innovation', {
+        innovation_id: innovationId,
+        settlement_id: settlementId
+      }),
+      insertJunction('settlement_location', {
+        location_id: locationId,
+        settlement_id: settlementId,
+        unlocked: false
+      }),
+      insertJunction('settlement_quarry', {
+        quarry_id: quarryId,
+        settlement_id: settlementId,
+        unlocked: false
+      }),
+      insertJunction('settlement_nemesis', {
+        nemesis_id: nemesisId,
+        settlement_id: settlementId,
+        unlocked: false
+      })
+    ])
+
+  return {
+    butcherSettlementNemesisId: nemesis,
+    deathSettlementPrincipleId: principle,
+    firstDeathSettlementMilestoneId: milestone,
+    hovelSettlementInnovationId: innovation,
+    lanternHoardSettlementLocationId: location,
+    whiteLionSettlementQuarryId: quarry
+  }
+}
+
+/** Get Settlement Notes */
+export async function getEconomySettlementNotes(
+  settlementId: string
+): Promise<string> {
+  const { data, error } = await admin
+    .from('settlement')
+    .select('notes')
+    .eq('id', settlementId)
+    .single()
+
+  if (error) throw new Error(`notes lookup failed: ${error.message}`)
+
+  return data.notes
+}
+
+/** Get Milestone Complete */
+export async function getMilestoneComplete(id: string): Promise<boolean> {
+  const { data, error } = await admin
+    .from('settlement_milestone')
+    .select('complete')
+    .eq('id', id)
+    .single()
+
+  if (error) throw new Error(`milestone lookup failed: ${error.message}`)
+
+  return data.complete
+}
+
+/** Get Principle Options */
+export async function getPrincipleOptions(id: string) {
+  const { data, error } = await admin
+    .from('settlement_principle')
+    .select('option_1_selected, option_2_selected')
+    .eq('id', id)
+    .single()
+
+  if (error) throw new Error(`principle lookup failed: ${error.message}`)
+
+  return data
+}
+
+/** Get Location Unlocked */
+export async function getLocationUnlocked(id: string): Promise<boolean> {
+  const { data, error } = await admin
+    .from('settlement_location')
+    .select('unlocked')
+    .eq('id', id)
+    .single()
+
+  if (error) throw new Error(`location lookup failed: ${error.message}`)
+
+  return data.unlocked
+}
+
+/** Innovation Exists */
+export async function economyInnovationExists(id: string): Promise<boolean> {
+  const { data, error } = await admin
+    .from('settlement_innovation')
+    .select('id')
+    .eq('id', id)
+    .maybeSingle()
+
+  if (error) throw new Error(`innovation lookup failed: ${error.message}`)
+
+  return Boolean(data)
+}
+
+/** Get Quarry Unlocked */
+export async function getQuarryUnlocked(id: string): Promise<boolean> {
+  const { data, error } = await admin
+    .from('settlement_quarry')
+    .select('unlocked')
+    .eq('id', id)
+    .single()
+
+  if (error) throw new Error(`quarry lookup failed: ${error.message}`)
+
+  return data.unlocked
+}
+
+/** Get Nemesis State */
+export async function getNemesisState(id: string) {
+  const { data, error } = await admin
+    .from('settlement_nemesis')
+    .select('unlocked, level_1_defeated')
+    .eq('id', id)
+    .single()
+
+  if (error) throw new Error(`nemesis lookup failed: ${error.message}`)
+
+  return data
+}
+
+async function getResourceId(resourceName: string): Promise<string> {
+  return getCatalogId('resource', 'resource_name', resourceName)
+}
+
+async function getCatalogId(
+  table:
+    | 'innovation'
+    | 'location'
+    | 'milestone'
+    | 'nemesis'
+    | 'principle'
+    | 'quarry'
+    | 'resource',
+  column:
+    | 'innovation_name'
+    | 'location_name'
+    | 'milestone_name'
+    | 'monster_name'
+    | 'principle_name'
+    | 'resource_name',
+  value: string
+): Promise<string> {
+  const { data, error } = await admin
+    .from(table)
+    .select('id')
+    .eq(column, value)
+    .single()
+
+  if (error) throw new Error(`${table} lookup failed: ${error.message}`)
+
+  return data.id
+}
+
+async function insertJunction(
+  table:
+    | 'settlement_innovation'
+    | 'settlement_location'
+    | 'settlement_milestone'
+    | 'settlement_nemesis'
+    | 'settlement_principle'
+    | 'settlement_quarry',
+  values: Record<string, unknown>
+): Promise<string> {
+  const { data, error } = await admin
+    .from(table)
+    .insert(values)
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`${table} insert failed: ${error.message}`)
+
+  return data.id
+}

--- a/__tests__/ui/settlement-economy.test.ts
+++ b/__tests__/ui/settlement-economy.test.ts
@@ -1,0 +1,387 @@
+import {
+  assertLoginPage,
+  createAuthAccount,
+  createConfirmedAuthAccount
+} from '@/__tests__/ui/helpers/auth'
+import {
+  createCraftingFixture,
+  createEconomyCatalogFixture,
+  createEconomySettlementPhaseFixture,
+  createEconomySurvivorFixture,
+  createExpensiveGearFixture,
+  createTimelineYearFixture,
+  economyInnovationExists,
+  economySettlementPhaseExists,
+  getEconomySettlementNotes,
+  getLocationUnlocked,
+  getMilestoneComplete,
+  getNemesisState,
+  getPrincipleOptions,
+  getQuarryUnlocked,
+  getSettlementGearQuantity,
+  getSettlementPhaseStep,
+  getSettlementResourceQuantity,
+  getSurvivorHealFields,
+  getTimelineEntries,
+  type CraftingFixture,
+  type EconomyCatalogFixture
+} from '@/__tests__/ui/helpers/economy'
+import { createSettlementFixture } from '@/__tests__/ui/helpers/settlement'
+import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import { LOCAL_STORAGE_KEY } from '@/lib/common'
+import { TabType } from '@/lib/enums'
+import { ERROR_MESSAGE } from '@/lib/messages'
+import { expect, test, type Page } from '@playwright/test'
+
+test.describe('settlement economy flow', () => {
+  const emailsToDelete = new Set<string>()
+
+  test.afterEach(async () => {
+    await deleteUsersByEmail(emailsToDelete)
+    emailsToDelete.clear()
+  })
+
+  test('moves settlement phase steps, heals returners, and ends the phase', async ({
+    page
+  }) => {
+    const { account, settlementId } = await createEconomyScenario('phase')
+    emailsToDelete.add(account.email)
+    const survivorId = await createEconomySurvivorFixture(
+      settlementId,
+      'E2E Returning Survivor'
+    )
+    const settlementPhaseId = await createEconomySettlementPhaseFixture({
+      returningSurvivorIds: [survivorId],
+      settlementId,
+      step: 'SURVIVORS_RETURN'
+    })
+
+    await openEconomyTab(page, account, settlementId, TabType.SETTLEMENT_PHASE)
+    await page
+      .getByRole('button', {
+        name: 'Settlement phase space 4: Update Death Count'
+      })
+      .click()
+    await expect
+      .poll(() => getSettlementPhaseStep(settlementPhaseId))
+      .toBe('UPDATE_DEATH_COUNT')
+
+    await failNextRestPatch(page, '**/rest/v1/settlement_phase*')
+    await page
+      .getByRole('button', {
+        name: 'Settlement phase space 5: Check Milestones'
+      })
+      .click()
+    await expect(page.getByText(ERROR_MESSAGE())).toBeVisible()
+    await expect
+      .poll(() => getSettlementPhaseStep(settlementPhaseId))
+      .toBe('UPDATE_DEATH_COUNT')
+
+    await page.getByRole('button', { name: 'Heal Returning Survivors' }).click()
+    await expect
+      .poll(() => getSurvivorHealFields(survivorId))
+      .toEqual({
+        arm_armor: 0,
+        arm_light_damage: false,
+        body_armor: 0,
+        body_light_damage: false,
+        head_armor: 0,
+        head_heavy_damage: false
+      })
+
+    await page
+      .getByRole('button', {
+        name: 'Settlement phase space 8: Special Showdown'
+      })
+      .click()
+    await page
+      .getByRole('button', { name: 'Proceed to Special Showdown' })
+      .click()
+    await expect(
+      page.getByRole('button', { name: 'Begin Showdown' })
+    ).toBeVisible()
+
+    await selectEconomyTab(page, settlementId, TabType.SETTLEMENT_PHASE)
+    await page
+      .getByRole('button', {
+        name: 'Settlement phase space 10: End Settlement Phase'
+      })
+      .click()
+    await page
+      .getByRole('button', { exact: true, name: 'End Settlement Phase' })
+      .click()
+    await expect
+      .poll(() => economySettlementPhaseExists(settlementPhaseId))
+      .toBe(false)
+  })
+
+  test('crafts gear by spending resources and prevents negative resource counts', async ({
+    page
+  }) => {
+    const { account, settlementId, userId } =
+      await createEconomyScenario('craft')
+    emailsToDelete.add(account.email)
+    const crafting = await createCraftingFixture({
+      gearName: `E2E Bone Charm ${crypto.randomUUID().slice(0, 8)}`,
+      resourceName: 'Monster Bone',
+      resourceQuantity: 2,
+      settlementId,
+      userId
+    })
+    const expensiveGearName = `E2E Hungry Charm ${crypto.randomUUID().slice(0, 8)}`
+    await createExpensiveGearFixture({
+      gearName: expensiveGearName,
+      quantity: 5,
+      resourceName: crafting.resourceName,
+      userId
+    })
+
+    await openEconomyTab(page, account, settlementId, TabType.CRAFTING)
+    await craftGear(page, crafting)
+    await expect
+      .poll(() => getSettlementGearQuantity(settlementId, crafting.gearId))
+      .toBe(1)
+    await expect
+      .poll(() =>
+        getSettlementResourceQuantity(settlementId, crafting.resourceName)
+      )
+      .toBe(1)
+
+    await openCraftDialog(page, expensiveGearName)
+    await expect(
+      page.getByRole('button', { name: 'Craft & Deduct' })
+    ).toBeDisabled()
+    await page.getByRole('button', { name: 'Cancel' }).click()
+
+    await setNumericValue(page, `${crafting.resourceName} quantity`, 0)
+    await expect
+      .poll(() =>
+        getSettlementResourceQuantity(settlementId, crafting.resourceName)
+      )
+      .toBe(0)
+
+    await page
+      .getByRole('spinbutton', {
+        exact: true,
+        name: `${crafting.resourceName} quantity`
+      })
+      .click()
+    const quantityDialog = page.getByRole('dialog')
+    await expect(
+      quantityDialog.getByRole('button', {
+        name: `Decrease ${crafting.resourceName} quantity`
+      })
+    ).toBeDisabled()
+    await quantityDialog.getByRole('button', { name: 'Save' }).click()
+
+    await page.getByRole('button', { name: 'Remove resource' }).click()
+    await expect
+      .poll(() =>
+        getSettlementResourceQuantity(settlementId, crafting.resourceName)
+      )
+      .toBeNull()
+  })
+
+  test('edits timeline, society, monster, and notes surfaces', async ({
+    page
+  }) => {
+    const { account, settlementId } = await createEconomyScenario('surfaces')
+    emailsToDelete.add(account.email)
+    await createTimelineYearFixture(settlementId)
+    const catalog = await createEconomyCatalogFixture(settlementId)
+
+    await openEconomyTab(page, account, settlementId, TabType.NOTES)
+    await page
+      .getByPlaceholder('Add notes about your settlement...')
+      .fill('Lanterns trimmed. Stores counted. No one slept well.')
+    await page.getByRole('button', { name: 'Save Notes' }).click()
+    await expect
+      .poll(() => getEconomySettlementNotes(settlementId))
+      .toBe('Lanterns trimmed. Stores counted. No one slept well.')
+
+    await selectEconomyTab(page, settlementId, TabType.TIMELINE)
+    await page.getByRole('button', { name: 'Add event to Prologue' }).click()
+    await page
+      .getByPlaceholder('Prologue event...')
+      .fill('E2E lantern year begins')
+    await page.getByRole('button', { name: 'Save event' }).click()
+    await expect
+      .poll(() => getTimelineEntries(settlementId))
+      .toEqual(['E2E lantern year begins'])
+
+    await exerciseSocietySurface(page, settlementId, catalog)
+    await exerciseMonsterSurface(page, settlementId, catalog)
+  })
+})
+
+async function createEconomyScenario(prefix: string) {
+  const account = createAuthAccount(`economy_${prefix}`.slice(0, 20))
+  const user = await createConfirmedAuthAccount(account)
+  const settlementId = await createSettlementFixture({
+    name: `E2E Economy ${prefix}`,
+    userId: user.id
+  })
+
+  return { account, settlementId, userId: user.id }
+}
+
+async function openEconomyTab(
+  page: Page,
+  account: { email: string; password: string; username: string },
+  settlementId: string,
+  selectedTab: TabType
+): Promise<void> {
+  await page.goto('/auth/login')
+  await page.evaluate(
+    (storageKey) => localStorage.removeItem(storageKey),
+    LOCAL_STORAGE_KEY
+  )
+  await assertLoginPage(page)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password').fill(account.password)
+  await page.getByRole('button', { name: /^Login$/ }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await selectEconomyTab(page, settlementId, selectedTab)
+}
+
+async function selectEconomyTab(
+  page: Page,
+  settlementId: string,
+  selectedTab: TabType
+): Promise<void> {
+  await page.evaluate(
+    ({ selectedSettlementId, selectedTab, storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          selectedHuntId: null,
+          selectedHuntMonsterIndex: 0,
+          selectedSettlementId,
+          selectedSettlementPhaseId: null,
+          selectedShowdownId: null,
+          selectedShowdownMonsterIndex: 0,
+          selectedSurvivorId: null,
+          selectedTab
+        })
+      )
+    },
+    {
+      selectedSettlementId: settlementId,
+      selectedTab,
+      storageKey: LOCAL_STORAGE_KEY
+    }
+  )
+  await page.reload()
+}
+
+async function craftGear(page: Page, crafting: CraftingFixture): Promise<void> {
+  await openCraftDialog(page, crafting.gearName)
+  const dialog = page.getByRole('dialog')
+  await expect(
+    dialog.getByRole('heading', { name: `Craft ${crafting.gearName}` })
+  ).toBeVisible()
+  await expect(
+    dialog.getByRole('listitem').filter({ hasText: crafting.resourceName })
+  ).toContainText('2 / 1')
+  await dialog.getByRole('button', { name: 'Craft & Deduct' }).click()
+}
+
+async function openCraftDialog(page: Page, gearName: string): Promise<void> {
+  await page.getByRole('button', { name: 'Add gear' }).click()
+  await page.getByPlaceholder('Search gear...').fill(gearName)
+  await page
+    .locator('[data-slot="command-item"]')
+    .filter({ hasText: gearName })
+    .click()
+}
+
+async function setNumericValue(
+  page: Page,
+  label: string,
+  desiredValue: number
+): Promise<void> {
+  await page.getByRole('spinbutton', { exact: true, name: label }).click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog.getByRole('heading', { name: label })).toBeVisible()
+
+  const value = dialog.getByRole('spinbutton', { name: `${label} value` })
+  while (Number(await value.inputValue()) < desiredValue)
+    await dialog.getByRole('button', { name: `Increase ${label}` }).click()
+  while (Number(await value.inputValue()) > desiredValue)
+    await dialog.getByRole('button', { name: `Decrease ${label}` }).click()
+
+  await dialog.getByRole('button', { name: 'Save' }).click()
+}
+
+async function exerciseSocietySurface(
+  page: Page,
+  settlementId: string,
+  catalog: EconomyCatalogFixture
+): Promise<void> {
+  await selectEconomyTab(page, settlementId, TabType.SOCIETY)
+
+  await page
+    .getByRole('checkbox', {
+      name: 'Complete First time death count is updated'
+    })
+    .click()
+  await expect
+    .poll(() => getMilestoneComplete(catalog.firstDeathSettlementMilestoneId))
+    .toBe(true)
+
+  await page.getByRole('checkbox', { name: 'Graves' }).click()
+  await expect
+    .poll(() => getPrincipleOptions(catalog.deathSettlementPrincipleId))
+    .toEqual({ option_1_selected: true, option_2_selected: false })
+
+  await page.getByRole('checkbox', { name: 'Unlock Lantern Hoard' }).click()
+  await expect
+    .poll(() => getLocationUnlocked(catalog.lanternHoardSettlementLocationId))
+    .toBe(true)
+
+  await page.getByRole('button', { name: 'Remove innovation' }).click()
+  await expect
+    .poll(() => economyInnovationExists(catalog.hovelSettlementInnovationId))
+    .toBe(false)
+}
+
+async function exerciseMonsterSurface(
+  page: Page,
+  settlementId: string,
+  catalog: EconomyCatalogFixture
+): Promise<void> {
+  await selectEconomyTab(page, settlementId, TabType.MONSTERS)
+
+  await page.getByRole('checkbox', { name: 'White Lion' }).click()
+  await expect
+    .poll(() => getQuarryUnlocked(catalog.whiteLionSettlementQuarryId))
+    .toBe(true)
+
+  await page.getByRole('checkbox', { name: 'Butcher' }).click()
+  await expect
+    .poll(() => getNemesisState(catalog.butcherSettlementNemesisId))
+    .toEqual({ level_1_defeated: false, unlocked: true })
+
+  await page.getByRole('checkbox', { name: 'L1' }).click()
+  await expect
+    .poll(() => getNemesisState(catalog.butcherSettlementNemesisId))
+    .toEqual({ level_1_defeated: true, unlocked: true })
+}
+
+async function failNextRestPatch(page: Page, url: string): Promise<void> {
+  let failed = false
+
+  await page.route(url, async (route) => {
+    if (!failed && route.request().method() === 'PATCH') {
+      failed = true
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'E2E economy mutation failure' })
+      })
+      return
+    }
+
+    await route.continue()
+  })
+}

--- a/components/settlement-phase/settlement-phase-board/settlement-phase-board-space.tsx
+++ b/components/settlement-phase/settlement-phase-board/settlement-phase-board-space.tsx
@@ -2,14 +2,16 @@
 
 import { cn } from '@/lib/utils'
 import { useDroppable } from '@dnd-kit/core'
-import { ReactElement } from 'react'
+import { ReactElement, ReactNode } from 'react'
 
 /**
  * Settlement Phase Board Space Component Properties
  */
 interface SettlementPhaseBoardSpaceProps {
+  /** Accessible Label */
+  ariaLabel: string
   /** Children */
-  children?: React.ReactNode
+  children?: ReactNode
   /** Additional CSS classes */
   className?: string
   /** Space Index (0-12) */
@@ -17,7 +19,7 @@ interface SettlementPhaseBoardSpaceProps {
   /** Space Label */
   label: string | ReactElement | null | undefined
   /** Click handler */
-  onClick?: (e: React.MouseEvent) => void
+  onClick?: () => void
 }
 
 /**
@@ -30,6 +32,7 @@ interface SettlementPhaseBoardSpaceProps {
  * @returns Settlement Phase Board Space Component
  */
 export function SettlementPhaseBoardSpace({
+  ariaLabel,
   children,
   className,
   index,
@@ -42,8 +45,16 @@ export function SettlementPhaseBoardSpace({
 
   return (
     <div
+      aria-label={ariaLabel}
+      role="button"
+      tabIndex={0}
       ref={setNodeRef}
       onClick={onClick}
+      onKeyDown={(event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return
+        event.preventDefault()
+        onClick?.()
+      }}
       className={cn(
         'py-3 relative flex flex-col items-center justify-center w-full h-full border-2 rounded-lg transition-colors border-border bg-card hover:bg-accent/50',
         isOver && 'border-primary bg-primary/10',

--- a/components/settlement-phase/settlement-phase-board/settlement-phase-board.tsx
+++ b/components/settlement-phase/settlement-phase-board/settlement-phase-board.tsx
@@ -69,6 +69,7 @@ export function SettlementPhaseBoard({
                 key={space.index}
                 className="relative w-18.75 sm:w-21.25 md:w-22.5 h-18.75 sm:h-21.25 md:h-22.5 shrink-0 flex items-center justify-center">
                 <SettlementPhaseBoardSpace
+                  ariaLabel={`Settlement phase space ${space.index}: ${space.step}`}
                   index={space.index}
                   label={space.step}
                   onClick={() => handleClick(space.index)}>

--- a/components/settlement/gear/gear-card.tsx
+++ b/components/settlement/gear/gear-card.tsx
@@ -283,6 +283,7 @@ export function GearCard({
           <Popover open={addOpen} onOpenChange={setAddOpen}>
             <PopoverTrigger asChild>
               <Button
+                aria-label="Add gear"
                 type="button"
                 size="sm"
                 variant="outline"

--- a/components/settlement/innovations/innovations-card.tsx
+++ b/components/settlement/innovations/innovations-card.tsx
@@ -462,6 +462,7 @@ export function InnovationsCard({
                     authorUsername={item.author_username}
                   />
                   <Button
+                    aria-label="Remove innovation"
                     variant="ghost"
                     size="icon"
                     type="button"

--- a/components/settlement/locations/location-item.tsx
+++ b/components/settlement/locations/location-item.tsx
@@ -46,6 +46,7 @@ export const LocationItem = memo(function LocationItem({
     <div className="flex items-center gap-2 pl-2">
       {/* Unlocked Checkbox */}
       <Checkbox
+        aria-label={`Unlock ${location.location_name}`}
         id={`location-unlocked-${index}`}
         name={`location-unlocked-${index}`}
         checked={location.unlocked}

--- a/components/settlement/milestones/milestone-item.tsx
+++ b/components/settlement/milestones/milestone-item.tsx
@@ -47,6 +47,7 @@ export const MilestoneItem = memo(function MilestoneItem({
     <div className="flex items-center gap-2 pl-2">
       {/* Completion Checkbox */}
       <Checkbox
+        aria-label={`Complete ${milestone.milestone_name}`}
         id={`milestone-complete-${index}`}
         name={`milestone-complete-${index}`}
         checked={milestone.complete}

--- a/components/settlement/resources/resources-card.tsx
+++ b/components/settlement/resources/resources-card.tsx
@@ -371,6 +371,7 @@ export function ResourcesCard({
           <Popover open={addOpen} onOpenChange={setAddOpen}>
             <PopoverTrigger asChild>
               <Button
+                aria-label="Add resource"
                 type="button"
                 size="sm"
                 variant="outline"

--- a/components/settlement/timeline/timeline-year-row.tsx
+++ b/components/settlement/timeline/timeline-year-row.tsx
@@ -149,6 +149,13 @@ export const TimelineYearRow = ({
             )}
             {!completed && (
               <Button
+                aria-label={`Add event to ${
+                  index === 0 && !usesNormalNumbering
+                    ? 'Prologue'
+                    : usesNormalNumbering
+                      ? `Year ${index + 1}`
+                      : `Year ${index}`
+                }`}
                 type="button"
                 variant="outline"
                 size="sm"
@@ -170,6 +177,13 @@ export const TimelineYearRow = ({
 
             {!completed && (
               <Button
+                aria-label={`Add event to ${
+                  index === 0 && !usesNormalNumbering
+                    ? 'Prologue'
+                    : usesNormalNumbering
+                      ? `Year ${index + 1}`
+                      : `Year ${index}`
+                }`}
                 type="button"
                 variant="outline"
                 size="sm"
@@ -230,6 +244,13 @@ export const TimelineYearRow = ({
       {!completed && (
         <div className="justify-end pr-2 hidden sm:flex">
           <Button
+            aria-label={`Add event to ${
+              index === 0 && !usesNormalNumbering
+                ? 'Prologue'
+                : usesNormalNumbering
+                  ? `Year ${index + 1}`
+                  : `Year ${index}`
+            }`}
             type="button"
             variant="outline"
             size="sm"


### PR DESCRIPTION
## Summary
- Adds settlement economy UI coverage for settlement phase board rollback/actions, crafting resource deductions, negative resource guards, notes, timeline, society, and monster surface edits.
- Adds economy-focused UI fixtures for settlement phase, custom craftable gear, resources, timeline years, and catalog junction rows.
- Adds accessible labels for settlement phase spaces and icon-only resource, gear, timeline, milestone, location, and innovation controls.

## Dependency Changes
- None.

## Issues
Closes #285
Closes #286
Closes #288
Closes #269

## Verification
- npx prettier --check components/settlement-phase/settlement-phase-board/settlement-phase-board.tsx components/settlement-phase/settlement-phase-board/settlement-phase-board-space.tsx components/settlement/resources/resources-card.tsx components/settlement/gear/gear-card.tsx components/settlement/timeline/timeline-year-row.tsx components/settlement/milestones/milestone-item.tsx components/settlement/locations/location-item.tsx components/settlement/innovations/innovations-card.tsx __tests__/ui/helpers/economy.ts __tests__/ui/settlement-economy.test.ts && git diff --check
- npm run ui-test -- __tests__/ui/settlement-economy.test.ts --project=desktop-chromium
- npm run ui-test -- __tests__/ui/settlement-economy.test.ts --project=mobile-chromium
- npm run ui-test -- --project=desktop-chromium
- npm run ui-test -- --project=mobile-chromium