### PR TITLE
Add UI custom content coverage

### DIFF
--- a/__tests__/ui/custom-content.test.ts
+++ b/__tests__/ui/custom-content.test.ts
@@ -1,0 +1,317 @@
+import {
+  assertLoginPage,
+  createAuthAccount,
+  createConfirmedAuthAccount
+} from '@/__tests__/ui/helpers/auth'
+import {
+  attachDisorderToSurvivorFixture,
+  countGearResourceCosts,
+  findCustomDisorderByName,
+  getCustomDisorderById,
+  getWeaponTypeId,
+  waitForCustomDisorderByName,
+  waitForCustomGearByName,
+  waitForMissingCustomGear
+} from '@/__tests__/ui/helpers/custom-content'
+import { createSettlementFixture } from '@/__tests__/ui/helpers/settlement'
+import { deleteUsersByEmail } from '@/__tests__/ui/helpers/supabase'
+import { createSurvivorFixture } from '@/__tests__/ui/helpers/survivor'
+import { LOCAL_STORAGE_KEY } from '@/lib/common'
+import { TabType } from '@/lib/enums'
+import { CATALOG_PERMANENT_DELETE_BLOCKED_MESSAGE } from '@/lib/messages'
+import { expect, type Page, test } from '@playwright/test'
+
+test.describe('custom content flow', () => {
+  const emailsToDelete = new Set<string>()
+
+  test.afterEach(async () => {
+    await deleteUsersByEmail(emailsToDelete)
+    emailsToDelete.clear()
+  })
+
+  test('creates, edits, attaches, archives, and guards custom disorder content', async ({
+    page
+  }) => {
+    test.slow()
+
+    const { account, settlementId, survivorId, userId } =
+      await createCustomScenario('disorder')
+    emailsToDelete.add(account.email)
+    const baseName = `E2E Flickering Dread ${crypto.randomUUID().slice(0, 8)}`
+    const editedName = `${baseName} Revised`
+
+    await openUserContent(page, account, settlementId)
+    await selectCustomContentCategory(page, 'Survivors')
+
+    await page.getByRole('button', { name: 'Add disorder' }).click()
+    let dialog = page.getByRole('dialog')
+    await expect(
+      dialog.getByRole('heading', { name: 'Create Custom Disorder' })
+    ).toBeVisible()
+    await dialog.getByLabel('Disorder Name').fill(baseName)
+    await dialog
+      .locator('textarea')
+      .fill(
+        '<script>alert("lantern")</script>\n\n**When departing**, gain +1 courage.'
+      )
+    await dialog.getByRole('button', { name: 'Create' }).click()
+
+    const created = await waitForCustomDisorderByName(userId, baseName)
+    expect(created.rules).toContain('When departing')
+
+    await page.getByRole('button', { name: `Edit ${baseName}` }).click()
+    dialog = page.getByRole('dialog')
+    await expect(
+      dialog.getByRole('heading', { name: 'Edit Disorder' })
+    ).toBeVisible()
+    await dialog.getByLabel('Disorder Name').fill(editedName)
+    await dialog
+      .locator('textarea')
+      .fill('**When departing**, gain +2 courage. Keep the lantern close.')
+    await dialog.getByRole('button', { name: 'Save' }).click()
+
+    await expect
+      .poll(() => findCustomDisorderByName(userId, editedName))
+      .not.toBeNull()
+
+    const edited = await waitForCustomDisorderByName(userId, editedName)
+    const blockerAccount = createAuthAccount('custom_blocker')
+    emailsToDelete.add(blockerAccount.email)
+    const blockerUser = await createConfirmedAuthAccount(blockerAccount)
+    const blockerSettlementId = await createSettlementFixture({
+      name: `E2E Custom blocker ${crypto.randomUUID().slice(0, 8)}`,
+      userId: blockerUser.id
+    })
+    const blockerSurvivorId = await createSurvivorFixture({
+      settlementId: blockerSettlementId,
+      name: 'E2E Blocker Survivor'
+    })
+    await attachDisorderToSurvivorFixture({
+      disorderId: edited.id,
+      settlementId: blockerSettlementId,
+      survivorId: blockerSurvivorId
+    })
+
+    await attachDisorderToSurvivorFixture({
+      disorderId: edited.id,
+      settlementId,
+      survivorId
+    })
+
+    await selectAppTab(page, settlementId, TabType.SURVIVORS, survivorId)
+    await expect(page.getByRole('button', { name: editedName })).toBeVisible()
+    await page.getByRole('button', { name: editedName }).click()
+    dialog = page.getByRole('dialog')
+    await expect(
+      dialog.getByRole('heading', { name: editedName })
+    ).toBeVisible()
+    await expect(dialog.getByText('gain +2 courage')).toBeVisible()
+    await expect(dialog).not.toContainText('alert("lantern")')
+    await page.keyboard.press('Escape')
+
+    await selectAppTab(page, settlementId, TabType.USER)
+    await selectCustomContentCategory(page, 'Survivors')
+    await page.getByRole('button', { name: `Delete ${editedName}` }).click()
+    await expect
+      .poll(async () =>
+        Boolean((await getCustomDisorderById(edited.id))?.archived_at)
+      )
+      .toBe(true)
+
+    await selectAppTab(page, settlementId, TabType.USER)
+    await selectCustomContentCategory(page, 'Archived')
+    await expect(page.getByText(editedName)).toBeVisible()
+    await page
+      .getByRole('button', { name: `Permanently delete ${editedName}` })
+      .click()
+    await page
+      .getByRole('alertdialog')
+      .getByRole('button', { name: 'Delete forever' })
+      .click()
+    await expect(
+      page.getByText(CATALOG_PERMANENT_DELETE_BLOCKED_MESSAGE())
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: `Permanently delete ${editedName}` })
+    ).toBeVisible()
+  })
+
+  test('creates, edits, and deletes custom gear with nested cost fields', async ({
+    page
+  }) => {
+    test.slow()
+
+    const { account, settlementId, userId } = await createCustomScenario('gear')
+    emailsToDelete.add(account.email)
+    const gearName = `E2E Lantern Cutter ${crypto.randomUUID().slice(0, 8)}`
+    const editedGearName = `${gearName} Tempered`
+    const swordWeaponTypeId = await getWeaponTypeId('Sword')
+
+    await openUserContent(page, account, settlementId)
+    await selectCustomContentCategory(page, 'Crafting')
+
+    await page.getByRole('button', { name: 'Add custom gear' }).click()
+    let dialog = page.getByRole('dialog')
+    await expect(
+      dialog.getByRole('heading', { name: 'Create Custom Gear' })
+    ).toBeVisible()
+    await selectOption(page, 'Gear type selector', 'Weapon')
+    await dialog.getByPlaceholder('Gear Name').fill(gearName)
+    await setNumericValue(page, 'Speed', 2)
+    await setNumericValue(page, 'Accuracy', 7)
+    await setNumericValue(page, 'Strength', 3)
+    await selectCommandItem(page, 'Weapon type selector', 'Sword')
+    await dialog
+      .getByPlaceholder('Special rules text.')
+      .fill('After attack, **archive one wound** in the dark.')
+    await dialog.getByRole('button', { name: 'Add resource cost' }).click()
+    await selectCommandItem(page, 'Cost resource 1 selector', 'Monster Bone')
+    await dialog.getByRole('button', { name: 'Create' }).click()
+
+    const createdGear = await waitForCustomGearByName(userId, gearName)
+    expect(createdGear.speed).toBe(2)
+    expect(createdGear.accuracy).toBe(7)
+    expect(createdGear.strength).toBe(3)
+    expect(createdGear.weapon_type_id).toBe(swordWeaponTypeId)
+    await expect.poll(() => countGearResourceCosts(createdGear.id)).toBe(1)
+
+    await page.getByRole('button', { name: `Edit ${gearName}` }).click()
+    dialog = page.getByRole('dialog')
+    await expect(
+      dialog.getByRole('heading', { name: 'Edit Gear' })
+    ).toBeVisible()
+    await dialog.getByPlaceholder('Gear Name').fill(editedGearName)
+    await setNumericValue(page, 'Strength', 4)
+    await dialog.getByRole('button', { name: 'Save' }).click()
+
+    const editedGear = await waitForCustomGearByName(userId, editedGearName)
+    expect(editedGear.strength).toBe(4)
+    await expect.poll(() => countGearResourceCosts(editedGear.id)).toBe(1)
+
+    await page.getByRole('button', { name: `Delete ${editedGearName}` }).click()
+    await waitForMissingCustomGear(userId, editedGearName)
+  })
+})
+
+async function createCustomScenario(prefix: string) {
+  const account = createAuthAccount(`custom_${prefix}`.slice(0, 20))
+  const user = await createConfirmedAuthAccount(account)
+  const settlementId = await createSettlementFixture({
+    name: `E2E Custom ${prefix}`,
+    userId: user.id
+  })
+  const survivorId = await createSurvivorFixture({
+    settlementId,
+    name: `E2E Custom ${prefix} Survivor`
+  })
+
+  return { account, settlementId, survivorId, userId: user.id }
+}
+
+async function openUserContent(
+  page: Page,
+  account: { email: string; password: string; username: string },
+  settlementId: string
+): Promise<void> {
+  await page.goto('/auth/login')
+  await page.evaluate(
+    (storageKey) => localStorage.removeItem(storageKey),
+    LOCAL_STORAGE_KEY
+  )
+  await assertLoginPage(page)
+  await page.getByLabel('Email').fill(account.email)
+  await page.getByLabel('Password').fill(account.password)
+  await page.getByRole('button', { name: /^Login$/ }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await selectAppTab(page, settlementId, TabType.USER)
+  await expect(page.getByText('Custom Content')).toBeVisible()
+}
+
+async function selectAppTab(
+  page: Page,
+  settlementId: string,
+  selectedTab: TabType,
+  selectedSurvivorId: string | null = null
+): Promise<void> {
+  await page.evaluate(
+    ({ selectedSettlementId, selectedSurvivorId, selectedTab, storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          selectedHuntId: null,
+          selectedHuntMonsterIndex: 0,
+          selectedSettlementId,
+          selectedSettlementPhaseId: null,
+          selectedShowdownId: null,
+          selectedShowdownMonsterIndex: 0,
+          selectedSurvivorId,
+          selectedTab
+        })
+      )
+    },
+    {
+      selectedSettlementId: settlementId,
+      selectedSurvivorId,
+      selectedTab,
+      storageKey: LOCAL_STORAGE_KEY
+    }
+  )
+  await page.reload()
+}
+
+async function selectCustomContentCategory(
+  page: Page,
+  category: string
+): Promise<void> {
+  await expect(page.getByText('Custom Content')).toBeVisible()
+
+  const tab = page.getByRole('tab', { exact: true, name: category })
+  if (await tab.isVisible({ timeout: 1_000 })) {
+    await tab.click()
+    return
+  }
+
+  await page.getByRole('combobox', { name: 'Custom content category' }).click()
+  await page.getByRole('option', { exact: true, name: category }).click()
+}
+
+async function selectOption(
+  page: Page,
+  comboboxName: string,
+  optionName: string
+): Promise<void> {
+  await page.getByRole('combobox', { name: comboboxName }).click()
+  await page.getByRole('option', { exact: true, name: optionName }).click()
+}
+
+async function selectCommandItem(
+  page: Page,
+  triggerName: string,
+  itemName: string
+): Promise<void> {
+  await page.getByRole('combobox', { name: triggerName }).click()
+  await page.getByPlaceholder(/^Search/).fill(itemName)
+  await page
+    .locator('[data-slot="command-item"]')
+    .filter({ hasText: itemName })
+    .first()
+    .click()
+}
+
+async function setNumericValue(
+  page: Page,
+  label: string,
+  desiredValue: number
+): Promise<void> {
+  await page.getByRole('spinbutton', { exact: true, name: label }).click()
+  const dialog = page.getByRole('dialog').last()
+  await expect(dialog.getByRole('heading', { name: label })).toBeVisible()
+
+  const value = dialog.getByRole('spinbutton', { name: `${label} value` })
+  while (Number(await value.inputValue()) < desiredValue)
+    await dialog.getByRole('button', { name: `Increase ${label}` }).click()
+  while (Number(await value.inputValue()) > desiredValue)
+    await dialog.getByRole('button', { name: `Decrease ${label}` }).click()
+
+  await dialog.getByRole('button', { name: 'Save' }).click()
+}

--- a/__tests__/ui/helpers/custom-content.ts
+++ b/__tests__/ui/helpers/custom-content.ts
@@ -1,0 +1,210 @@
+import { admin } from '@/__tests__/ui/helpers/supabase'
+
+/** Custom Disorder Row */
+export interface CustomDisorderRow {
+  /** Archive Timestamp */
+  archived_at: string | null
+  /** Custom Flag */
+  custom: boolean
+  /** Disorder ID */
+  id: string
+  /** Disorder Name */
+  disorder_name: string
+  /** Rules */
+  rules: string | null
+  /** User ID */
+  user_id: string | null
+}
+
+/** Custom Gear Row */
+export interface CustomGearRow {
+  /** Accuracy */
+  accuracy: number | null
+  /** Archive Timestamp */
+  archived_at: string | null
+  /** Custom Flag */
+  custom: boolean
+  /** Gear ID */
+  id: string
+  /** Gear Name */
+  gear_name: string
+  /** Rules */
+  rules: string | null
+  /** Speed */
+  speed: number | null
+  /** Strength */
+  strength: number | null
+  /** User ID */
+  user_id: string | null
+  /** Weapon Type ID */
+  weapon_type_id: string | null
+}
+
+/** Find Custom Disorder By Name */
+export async function findCustomDisorderByName(
+  userId: string,
+  disorderName: string
+): Promise<CustomDisorderRow | null> {
+  const { data, error } = await admin
+    .from('disorder')
+    .select('id, custom, disorder_name, rules, archived_at, user_id')
+    .eq('user_id', userId)
+    .eq('custom', true)
+    .eq('disorder_name', disorderName)
+    .maybeSingle()
+
+  if (error) throw new Error(`custom disorder lookup failed: ${error.message}`)
+
+  return data
+}
+
+/** Wait For Custom Disorder By Name */
+export async function waitForCustomDisorderByName(
+  userId: string,
+  disorderName: string
+): Promise<CustomDisorderRow> {
+  const timeoutAt = Date.now() + 10_000
+
+  while (Date.now() < timeoutAt) {
+    const disorder = await findCustomDisorderByName(userId, disorderName)
+    if (disorder) return disorder
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for custom disorder ${disorderName}`)
+}
+
+/** Find Custom Gear By Name */
+export async function findCustomGearByName(
+  userId: string,
+  gearName: string
+): Promise<CustomGearRow | null> {
+  const { data, error } = await admin
+    .from('gear')
+    .select(
+      'id, custom, gear_name, rules, archived_at, user_id, speed, accuracy, strength, weapon_type_id'
+    )
+    .eq('user_id', userId)
+    .eq('custom', true)
+    .eq('gear_name', gearName)
+    .maybeSingle()
+
+  if (error) throw new Error(`custom gear lookup failed: ${error.message}`)
+
+  return data
+}
+
+/** Wait For Custom Gear By Name */
+export async function waitForCustomGearByName(
+  userId: string,
+  gearName: string
+): Promise<CustomGearRow> {
+  const timeoutAt = Date.now() + 10_000
+
+  while (Date.now() < timeoutAt) {
+    const gear = await findCustomGearByName(userId, gearName)
+    if (gear) return gear
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for custom gear ${gearName}`)
+}
+
+/** Wait For Missing Custom Gear */
+export async function waitForMissingCustomGear(
+  userId: string,
+  gearName: string
+): Promise<void> {
+  const timeoutAt = Date.now() + 10_000
+
+  while (Date.now() < timeoutAt) {
+    const gear = await findCustomGearByName(userId, gearName)
+    if (!gear) return
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error(`Timed out waiting for custom gear ${gearName} to disappear`)
+}
+
+/** Attach Disorder To Survivor Fixture */
+export async function attachDisorderToSurvivorFixture({
+  disorderId,
+  settlementId,
+  survivorId
+}: {
+  disorderId: string
+  settlementId: string
+  survivorId: string
+}): Promise<void> {
+  const { error } = await admin.from('survivor_disorder').insert({
+    disorder_id: disorderId,
+    settlement_id: settlementId,
+    survivor_id: survivorId
+  })
+
+  if (error) throw new Error(`attach disorder failed: ${error.message}`)
+}
+
+/** Add Settlement Gear Fixture */
+export async function addCustomGearToSettlementFixture({
+  gearId,
+  settlementId,
+  quantity = 1
+}: {
+  gearId: string
+  quantity?: number
+  settlementId: string
+}): Promise<string> {
+  const { data, error } = await admin
+    .from('settlement_gear')
+    .insert({ gear_id: gearId, quantity, settlement_id: settlementId })
+    .select('id')
+    .single()
+
+  if (error) throw new Error(`settlement gear insert failed: ${error.message}`)
+
+  return data.id
+}
+
+/** Get Disorder By ID */
+export async function getCustomDisorderById(
+  disorderId: string
+): Promise<CustomDisorderRow | null> {
+  const { data, error } = await admin
+    .from('disorder')
+    .select('id, custom, disorder_name, rules, archived_at, user_id')
+    .eq('id', disorderId)
+    .maybeSingle()
+
+  if (error) throw new Error(`custom disorder by id failed: ${error.message}`)
+
+  return data
+}
+
+/** Count Gear Resource Costs */
+export async function countGearResourceCosts(gearId: string): Promise<number> {
+  const { count, error } = await admin
+    .from('gear_resource_cost')
+    .select('gear_id', { count: 'exact', head: true })
+    .eq('gear_id', gearId)
+
+  if (error)
+    throw new Error(`gear resource cost count failed: ${error.message}`)
+
+  return count ?? 0
+}
+
+/** Get Weapon Type ID */
+export async function getWeaponTypeId(
+  weaponTypeName = 'Sword'
+): Promise<string> {
+  const { data, error } = await admin
+    .from('weapon_type')
+    .select('id')
+    .eq('weapon_type_name', weaponTypeName)
+    .single()
+
+  if (error) throw new Error(`weapon type lookup failed: ${error.message}`)
+
+  return data.id
+}

--- a/components/custom/custom-disorders-card.tsx
+++ b/components/custom/custom-disorders-card.tsx
@@ -216,7 +216,11 @@ export function CustomDisordersCard(): ReactElement {
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Disorders</span>
-          <Button variant="outline" size="sm" onClick={openCreateDialog}>
+          <Button
+            aria-label="Add disorder"
+            variant="outline"
+            size="sm"
+            onClick={openCreateDialog}>
             <PlusIcon className="h-4 w-4 mr-2" />
             Add
           </Button>
@@ -259,6 +263,7 @@ export function CustomDisordersCard(): ReactElement {
                     <TableCell className="text-right">
                       <div className="flex items-center justify-end gap-1">
                         <Button
+                          aria-label={`Edit ${item.disorder_name}`}
                           variant="ghost"
                           size="icon"
                           onClick={() => openEditDialog(item)}
@@ -266,6 +271,7 @@ export function CustomDisordersCard(): ReactElement {
                           <PencilIcon className="h-4 w-4" />
                         </Button>
                         <Button
+                          aria-label={`Delete ${item.disorder_name}`}
                           variant="ghost"
                           size="icon"
                           onClick={() => handleDelete(item)}

--- a/components/custom/custom-gear-card.tsx
+++ b/components/custom/custom-gear-card.tsx
@@ -377,7 +377,11 @@ export function CustomGearCard(): ReactElement {
       <CardHeader className="px-4 pt-4 pb-2">
         <CardTitle className="text-md flex flex-row items-center justify-between">
           <span>Gear</span>
-          <Button variant="outline" size="sm" onClick={openCreateDialog}>
+          <Button
+            aria-label="Add custom gear"
+            variant="outline"
+            size="sm"
+            onClick={openCreateDialog}>
             <PlusIcon className="h-4 w-4 mr-2" />
             Add
           </Button>
@@ -443,6 +447,7 @@ export function CustomGearCard(): ReactElement {
                       <TableCell className="text-right">
                         <div className="flex items-center justify-end gap-1">
                           <Button
+                            aria-label={`Edit ${item.gear_name}`}
                             variant="ghost"
                             size="icon"
                             onClick={() => openEditDialog(item)}
@@ -450,6 +455,7 @@ export function CustomGearCard(): ReactElement {
                             <PencilIcon className="h-4 w-4" />
                           </Button>
                           <Button
+                            aria-label={`Delete ${item.gear_name}`}
                             variant="ghost"
                             size="icon"
                             onClick={() => handleDelete(item)}

--- a/components/custom/dialogs/gear-dialog.tsx
+++ b/components/custom/dialogs/gear-dialog.tsx
@@ -1225,6 +1225,7 @@ export function GearDialog({
             <div className="flex items-center justify-between">
               <Label>Gear Costs (optional)</Label>
               <Button
+                aria-label="Add gear cost"
                 type="button"
                 variant="outline"
                 size="sm"
@@ -1352,6 +1353,7 @@ export function GearDialog({
             <div className="flex items-center justify-between">
               <Label>Resource Costs (optional)</Label>
               <Button
+                aria-label="Add resource cost"
                 type="button"
                 variant="outline"
                 size="sm"
@@ -1481,6 +1483,7 @@ export function GearDialog({
             <div className="flex items-center justify-between">
               <Label>Resource Type Costs (optional)</Label>
               <Button
+                aria-label="Add resource type cost"
                 type="button"
                 variant="outline"
                 size="sm"

--- a/components/user/user-card.tsx
+++ b/components/user/user-card.tsx
@@ -265,7 +265,9 @@ export function UserCard({
         {/* Mobile: dropdown selector */}
         <div className="lg:hidden">
           <Select value={activeTab} onValueChange={setActiveTab}>
-            <SelectTrigger className="w-full">
+            <SelectTrigger
+              aria-label="Custom content category"
+              className="w-full">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
## Summary
- Adds custom-content UI coverage for a simple custom disorder flow and a complex custom gear flow.
- Covers disorder create/edit, survivor attachment rules sheet rendering, archive behavior, permanent-delete guard messaging, and gear create/edit/delete with resource-cost junctions.
- Adds accessible labels for User Content category selection and custom content icon controls.

## Dependency Changes
- None.

## Issues
Closes #289
Closes #270

## Verification
- npx prettier --check components/user/user-card.tsx components/custom/custom-disorders-card.tsx components/custom/custom-gear-card.tsx components/custom/dialogs/gear-dialog.tsx __tests__/ui/helpers/custom-content.ts __tests__/ui/custom-content.test.ts && git diff --check
- npm run ui-test -- __tests__/ui/custom-content.test.ts --project=desktop-chromium
- npm run ui-test -- __tests__/ui/custom-content.test.ts --project=mobile-chromium
- npm run ui-test -- --project=desktop-chromium
- npm run ui-test -- --project=mobile-chromium