### PR TITLE
Add vignette instance migrations

### DIFF
--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5579,6 +5579,63 @@ export type Database = {
           },
         ]
       }
+      vignette_encounter: {
+        Row: {
+          created_at: string
+          ended_at: string | null
+          id: string
+          notes: string
+          round: number
+          status: string
+          turn: Database["public"]["Enums"]["showdown_turn"]
+          updated_at: string
+          user_id: string
+          vignette_encounter_definition_id: string
+          vignette_encounter_level_id: string
+        }
+        Insert: {
+          created_at?: string
+          ended_at?: string | null
+          id?: string
+          notes?: string
+          round?: number
+          status?: string
+          turn?: Database["public"]["Enums"]["showdown_turn"]
+          updated_at?: string
+          user_id: string
+          vignette_encounter_definition_id: string
+          vignette_encounter_level_id: string
+        }
+        Update: {
+          created_at?: string
+          ended_at?: string | null
+          id?: string
+          notes?: string
+          round?: number
+          status?: string
+          turn?: Database["public"]["Enums"]["showdown_turn"]
+          updated_at?: string
+          user_id?: string
+          vignette_encounter_definition_id?: string
+          vignette_encounter_level_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_vignette_encounter_definition_id_fkey"
+            columns: ["vignette_encounter_definition_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_definition"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_vignette_encounter_level_id_fkey"
+            columns: ["vignette_encounter_level_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_level"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       vignette_encounter_definition: {
         Row: {
           created_at: string
@@ -5632,6 +5689,51 @@ export type Database = {
             columns: ["source_quarry_id"]
             isOneToOne: false
             referencedRelation: "quarry"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_encounter_gear_grid: {
+        Row: {
+          column_number: number
+          created_at: string
+          gear_id: string
+          id: string
+          row_number: number
+          updated_at: string
+          vignette_encounter_survivor_id: string
+        }
+        Insert: {
+          column_number: number
+          created_at?: string
+          gear_id: string
+          id?: string
+          row_number: number
+          updated_at?: string
+          vignette_encounter_survivor_id: string
+        }
+        Update: {
+          column_number?: number
+          created_at?: string
+          gear_id?: string
+          id?: string
+          row_number?: number
+          updated_at?: string
+          vignette_encounter_survivor_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_gear_grid_gear_id_fkey"
+            columns: ["gear_id"]
+            isOneToOne: false
+            referencedRelation: "gear"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_gear_grid_vignette_encounter_survivor_i_fkey"
+            columns: ["vignette_encounter_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_survivor"
             referencedColumns: ["id"]
           },
         ]
@@ -5826,6 +5928,450 @@ export type Database = {
             columns: ["vignette_encounter_level_id"]
             isOneToOne: false
             referencedRelation: "vignette_encounter_level"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_encounter_monster: {
+        Row: {
+          created_at: string
+          current_ai_cards: number | null
+          current_hit_location_cards: number | null
+          current_wounds: number | null
+          id: string
+          knocked_down: boolean
+          notes: string
+          updated_at: string
+          vignette_encounter_id: string
+        }
+        Insert: {
+          created_at?: string
+          current_ai_cards?: number | null
+          current_hit_location_cards?: number | null
+          current_wounds?: number | null
+          id?: string
+          knocked_down?: boolean
+          notes?: string
+          updated_at?: string
+          vignette_encounter_id: string
+        }
+        Update: {
+          created_at?: string
+          current_ai_cards?: number | null
+          current_hit_location_cards?: number | null
+          current_wounds?: number | null
+          id?: string
+          knocked_down?: boolean
+          notes?: string
+          updated_at?: string
+          vignette_encounter_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_monster_vignette_encounter_id_fkey"
+            columns: ["vignette_encounter_id"]
+            isOneToOne: true
+            referencedRelation: "vignette_encounter"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_encounter_survivor: {
+        Row: {
+          accuracy: number
+          accuracy_tokens: number
+          activation_used: boolean
+          arm_armor: number
+          arm_heavy_damage: boolean
+          arm_light_damage: boolean
+          bleeding_tokens: number
+          block_tokens: number
+          body_armor: number
+          body_heavy_damage: boolean
+          body_light_damage: boolean
+          brain_light_damage: boolean
+          courage: number
+          created_at: string
+          dead: boolean
+          deflect_tokens: number
+          evasion: number
+          evasion_tokens: number
+          gender: Database["public"]["Enums"]["gender"] | null
+          head_armor: number
+          head_heavy_damage: boolean
+          id: string
+          insanity: number
+          insanity_tokens: number
+          knocked_down: boolean
+          leg_armor: number
+          leg_heavy_damage: boolean
+          leg_light_damage: boolean
+          luck: number
+          luck_tokens: number
+          movement: number
+          movement_tokens: number
+          movement_used: boolean
+          notes: string
+          retired: boolean
+          sort_order: number
+          speed: number
+          speed_tokens: number
+          strength: number
+          strength_tokens: number
+          survival: number
+          survival_tokens: number
+          survivor_name: string
+          survivor_type: Database["public"]["Enums"]["survivor_type"]
+          understanding: number
+          updated_at: string
+          vignette_encounter_id: string
+          vignette_survivor_template_id: string | null
+          waist_armor: number
+          waist_heavy_damage: boolean
+          waist_light_damage: boolean
+          weapon_proficiency: number
+          weapon_type_id: string | null
+        }
+        Insert: {
+          accuracy?: number
+          accuracy_tokens?: number
+          activation_used?: boolean
+          arm_armor?: number
+          arm_heavy_damage?: boolean
+          arm_light_damage?: boolean
+          bleeding_tokens?: number
+          block_tokens?: number
+          body_armor?: number
+          body_heavy_damage?: boolean
+          body_light_damage?: boolean
+          brain_light_damage?: boolean
+          courage?: number
+          created_at?: string
+          dead?: boolean
+          deflect_tokens?: number
+          evasion?: number
+          evasion_tokens?: number
+          gender?: Database["public"]["Enums"]["gender"] | null
+          head_armor?: number
+          head_heavy_damage?: boolean
+          id?: string
+          insanity?: number
+          insanity_tokens?: number
+          knocked_down?: boolean
+          leg_armor?: number
+          leg_heavy_damage?: boolean
+          leg_light_damage?: boolean
+          luck?: number
+          luck_tokens?: number
+          movement?: number
+          movement_tokens?: number
+          movement_used?: boolean
+          notes?: string
+          retired?: boolean
+          sort_order?: number
+          speed?: number
+          speed_tokens?: number
+          strength?: number
+          strength_tokens?: number
+          survival?: number
+          survival_tokens?: number
+          survivor_name: string
+          survivor_type?: Database["public"]["Enums"]["survivor_type"]
+          understanding?: number
+          updated_at?: string
+          vignette_encounter_id: string
+          vignette_survivor_template_id?: string | null
+          waist_armor?: number
+          waist_heavy_damage?: boolean
+          waist_light_damage?: boolean
+          weapon_proficiency?: number
+          weapon_type_id?: string | null
+        }
+        Update: {
+          accuracy?: number
+          accuracy_tokens?: number
+          activation_used?: boolean
+          arm_armor?: number
+          arm_heavy_damage?: boolean
+          arm_light_damage?: boolean
+          bleeding_tokens?: number
+          block_tokens?: number
+          body_armor?: number
+          body_heavy_damage?: boolean
+          body_light_damage?: boolean
+          brain_light_damage?: boolean
+          courage?: number
+          created_at?: string
+          dead?: boolean
+          deflect_tokens?: number
+          evasion?: number
+          evasion_tokens?: number
+          gender?: Database["public"]["Enums"]["gender"] | null
+          head_armor?: number
+          head_heavy_damage?: boolean
+          id?: string
+          insanity?: number
+          insanity_tokens?: number
+          knocked_down?: boolean
+          leg_armor?: number
+          leg_heavy_damage?: boolean
+          leg_light_damage?: boolean
+          luck?: number
+          luck_tokens?: number
+          movement?: number
+          movement_tokens?: number
+          movement_used?: boolean
+          notes?: string
+          retired?: boolean
+          sort_order?: number
+          speed?: number
+          speed_tokens?: number
+          strength?: number
+          strength_tokens?: number
+          survival?: number
+          survival_tokens?: number
+          survivor_name?: string
+          survivor_type?: Database["public"]["Enums"]["survivor_type"]
+          understanding?: number
+          updated_at?: string
+          vignette_encounter_id?: string
+          vignette_survivor_template_id?: string | null
+          waist_armor?: number
+          waist_heavy_damage?: boolean
+          waist_light_damage?: boolean
+          weapon_proficiency?: number
+          weapon_type_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor_vignette_encounter_id_fkey"
+            columns: ["vignette_encounter_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_survivor_vignette_survivor_template_id_fkey"
+            columns: ["vignette_survivor_template_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor_template"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_survivor_weapon_type_id_fkey"
+            columns: ["weapon_type_id"]
+            isOneToOne: false
+            referencedRelation: "weapon_type"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_encounter_survivor_ability_impairment: {
+        Row: {
+          ability_impairment_id: string
+          created_at: string
+          id: string
+          sort_order: number
+          updated_at: string
+          vignette_encounter_survivor_id: string
+        }
+        Insert: {
+          ability_impairment_id: string
+          created_at?: string
+          id?: string
+          sort_order?: number
+          updated_at?: string
+          vignette_encounter_survivor_id: string
+        }
+        Update: {
+          ability_impairment_id?: string
+          created_at?: string
+          id?: string
+          sort_order?: number
+          updated_at?: string
+          vignette_encounter_survivor_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor_a_vignette_encounter_survivor__fkey"
+            columns: ["vignette_encounter_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_survivor"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_survivor_ability__ability_impairment_id_fkey"
+            columns: ["ability_impairment_id"]
+            isOneToOne: false
+            referencedRelation: "ability_impairment"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_encounter_survivor_disorder: {
+        Row: {
+          created_at: string
+          disorder_id: string
+          id: string
+          sort_order: number
+          updated_at: string
+          vignette_encounter_survivor_id: string
+        }
+        Insert: {
+          created_at?: string
+          disorder_id: string
+          id?: string
+          sort_order?: number
+          updated_at?: string
+          vignette_encounter_survivor_id: string
+        }
+        Update: {
+          created_at?: string
+          disorder_id?: string
+          id?: string
+          sort_order?: number
+          updated_at?: string
+          vignette_encounter_survivor_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor_d_vignette_encounter_survivor__fkey"
+            columns: ["vignette_encounter_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_survivor"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_survivor_disorder_disorder_id_fkey"
+            columns: ["disorder_id"]
+            isOneToOne: false
+            referencedRelation: "disorder"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_encounter_survivor_fighting_art: {
+        Row: {
+          created_at: string
+          fighting_art_id: string
+          id: string
+          sort_order: number
+          updated_at: string
+          vignette_encounter_survivor_id: string
+        }
+        Insert: {
+          created_at?: string
+          fighting_art_id: string
+          id?: string
+          sort_order?: number
+          updated_at?: string
+          vignette_encounter_survivor_id: string
+        }
+        Update: {
+          created_at?: string
+          fighting_art_id?: string
+          id?: string
+          sort_order?: number
+          updated_at?: string
+          vignette_encounter_survivor_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor_f_vignette_encounter_survivor__fkey"
+            columns: ["vignette_encounter_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_survivor"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_survivor_fighting_art_fighting_art_id_fkey"
+            columns: ["fighting_art_id"]
+            isOneToOne: false
+            referencedRelation: "fighting_art"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_encounter_survivor_secret_fighting_art: {
+        Row: {
+          created_at: string
+          id: string
+          secret_fighting_art_id: string
+          sort_order: number
+          updated_at: string
+          vignette_encounter_survivor_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          secret_fighting_art_id: string
+          sort_order?: number
+          updated_at?: string
+          vignette_encounter_survivor_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          secret_fighting_art_id?: string
+          sort_order?: number
+          updated_at?: string
+          vignette_encounter_survivor_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor_s_vignette_encounter_survivor__fkey"
+            columns: ["vignette_encounter_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_survivor"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_survivor_secret__secret_fighting_art_id_fkey"
+            columns: ["secret_fighting_art_id"]
+            isOneToOne: false
+            referencedRelation: "secret_fighting_art"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_encounter_survivor_status: {
+        Row: {
+          created_at: string
+          id: string
+          sort_order: number
+          survivor_status_id: string
+          updated_at: string
+          vignette_encounter_survivor_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          sort_order?: number
+          survivor_status_id: string
+          updated_at?: string
+          vignette_encounter_survivor_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          sort_order?: number
+          survivor_status_id?: string
+          updated_at?: string
+          vignette_encounter_survivor_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor__vignette_encounter_survivor__fkey1"
+            columns: ["vignette_encounter_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_survivor"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_survivor_status_survivor_status_id_fkey"
+            columns: ["survivor_status_id"]
+            isOneToOne: false
+            referencedRelation: "survivor_status"
             referencedColumns: ["id"]
           },
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.89.0",
+      "version": "0.90.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260613000002_vignette_instance_tables.sql
+++ b/supabase/migrations/20260613000002_vignette_instance_tables.sql
@@ -1,0 +1,279 @@
+--------------------------------------------------------------------------------
+-- Vignette Encounter Instance Tables
+-- User-owned mutable one-shot showdown state copied from published templates.
+-- These rows intentionally stay separate from settlement, hunt, and showdown
+-- campaign tables.
+--------------------------------------------------------------------------------
+create table vignette_encounter (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Owner Data
+	user_id uuid not null references auth.users(id) on delete cascade,
+	-- Data
+	vignette_encounter_definition_id uuid not null references vignette_encounter_definition(id) on delete restrict,
+	vignette_encounter_level_id uuid not null references vignette_encounter_level(id) on delete restrict,
+	status text not null default 'ACTIVE' check (status in ('ACTIVE', 'ENDED')),
+	round int not null default 1 check (round >= 1),
+	turn showdown_turn not null default 'MONSTER',
+	notes text not null default '',
+	ended_at timestamptz,
+	-- Constraints
+	constraint vignette_encounter_lifecycle check (
+		(
+			status = 'ACTIVE'
+			and ended_at is null
+		)
+		or (
+			status = 'ENDED'
+			and ended_at is not null
+		)
+	)
+);
+--------------------------------------------------------------------------------
+-- Vignette Encounter Monster
+--------------------------------------------------------------------------------
+create table vignette_encounter_monster (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_id uuid not null unique references vignette_encounter(id) on delete cascade,
+	current_wounds int check (
+		current_wounds is null
+		or current_wounds >= 0
+	),
+	current_ai_cards int check (
+		current_ai_cards is null
+		or current_ai_cards >= 0
+	),
+	current_hit_location_cards int check (
+		current_hit_location_cards is null
+		or current_hit_location_cards >= 0
+	),
+	knocked_down boolean not null default false,
+	notes text not null default ''
+);
+--------------------------------------------------------------------------------
+-- Vignette Encounter Survivors
+--------------------------------------------------------------------------------
+create table vignette_encounter_survivor (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_id uuid not null references vignette_encounter(id) on delete cascade,
+	vignette_survivor_template_id uuid references vignette_survivor_template(id) on delete set null,
+	survivor_name varchar not null check (char_length(survivor_name) <= 100),
+	survivor_type survivor_type not null default 'CORE',
+	gender gender,
+	movement int not null default 5,
+	accuracy int not null default 0,
+	strength int not null default 0,
+	evasion int not null default 0,
+	luck int not null default 0,
+	speed int not null default 0,
+	survival int not null default 0 check (survival >= 0),
+	insanity int not null default 0 check (insanity >= 0),
+	courage int not null default 0 check (courage >= 0),
+	understanding int not null default 0 check (understanding >= 0),
+	weapon_proficiency int not null default 0 check (
+		weapon_proficiency >= 0
+		and weapon_proficiency <= 8
+	),
+	weapon_type_id uuid references weapon_type(id) on delete set null,
+	arm_armor int not null default 0 check (arm_armor >= 0),
+	arm_light_damage boolean not null default false,
+	arm_heavy_damage boolean not null default false,
+	body_armor int not null default 0 check (body_armor >= 0),
+	body_light_damage boolean not null default false,
+	body_heavy_damage boolean not null default false,
+	brain_light_damage boolean not null default false,
+	head_armor int not null default 0 check (head_armor >= 0),
+	head_heavy_damage boolean not null default false,
+	leg_armor int not null default 0 check (leg_armor >= 0),
+	leg_light_damage boolean not null default false,
+	leg_heavy_damage boolean not null default false,
+	waist_armor int not null default 0 check (waist_armor >= 0),
+	waist_light_damage boolean not null default false,
+	waist_heavy_damage boolean not null default false,
+	accuracy_tokens int not null default 0,
+	activation_used boolean not null default false,
+	bleeding_tokens int not null default 0 check (bleeding_tokens >= 0),
+	block_tokens int not null default 0,
+	deflect_tokens int not null default 0,
+	evasion_tokens int not null default 0,
+	insanity_tokens int not null default 0,
+	knocked_down boolean not null default false,
+	luck_tokens int not null default 0,
+	movement_tokens int not null default 0,
+	movement_used boolean not null default false,
+	speed_tokens int not null default 0,
+	strength_tokens int not null default 0,
+	survival_tokens int not null default 0,
+	dead boolean not null default false,
+	retired boolean not null default false,
+	notes text not null default '',
+	sort_order int not null default 0,
+	-- Constraints
+	unique (vignette_encounter_id, vignette_survivor_template_id)
+);
+--------------------------------------------------------------------------------
+-- Vignette Encounter Survivor Junction Tables
+--------------------------------------------------------------------------------
+create table vignette_encounter_survivor_fighting_art (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references vignette_encounter_survivor(id) on delete cascade,
+	fighting_art_id uuid not null references fighting_art(id) on delete restrict,
+	sort_order int not null default 0,
+	-- Constraints
+	unique (vignette_encounter_survivor_id, fighting_art_id)
+);
+
+create table vignette_encounter_survivor_secret_fighting_art (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references vignette_encounter_survivor(id) on delete cascade,
+	secret_fighting_art_id uuid not null references secret_fighting_art(id) on delete restrict,
+	sort_order int not null default 0,
+	-- Constraints
+	unique (vignette_encounter_survivor_id, secret_fighting_art_id)
+);
+
+create table vignette_encounter_survivor_disorder (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references vignette_encounter_survivor(id) on delete cascade,
+	disorder_id uuid not null references disorder(id) on delete restrict,
+	sort_order int not null default 0,
+	-- Constraints
+	unique (vignette_encounter_survivor_id, disorder_id)
+);
+
+create table vignette_encounter_survivor_ability_impairment (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references vignette_encounter_survivor(id) on delete cascade,
+	ability_impairment_id uuid not null references ability_impairment(id) on delete restrict,
+	sort_order int not null default 0,
+	-- Constraints
+	unique (vignette_encounter_survivor_id, ability_impairment_id)
+);
+
+create table vignette_encounter_survivor_status (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references vignette_encounter_survivor(id) on delete cascade,
+	survivor_status_id uuid not null references survivor_status(id) on delete restrict,
+	sort_order int not null default 0,
+	-- Constraints
+	unique (vignette_encounter_survivor_id, survivor_status_id)
+);
+--------------------------------------------------------------------------------
+-- Vignette Encounter Gear Grid
+--------------------------------------------------------------------------------
+create table vignette_encounter_gear_grid (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references vignette_encounter_survivor(id) on delete cascade,
+	gear_id uuid not null references gear(id) on delete restrict,
+	row_number int not null check (row_number between 0 and 2),
+	column_number int not null check (column_number between 0 and 2),
+	-- Constraints
+	unique (vignette_encounter_survivor_id, row_number, column_number)
+);
+--------------------------------------------------------------------------------
+-- Row Level Security
+-- Detailed owner/collaborator policies are added in VIG-01.03. Until then,
+-- RLS remains enabled with no row access policies.
+--------------------------------------------------------------------------------
+alter table vignette_encounter enable row level security;
+alter table vignette_encounter_monster enable row level security;
+alter table vignette_encounter_survivor enable row level security;
+alter table vignette_encounter_survivor_fighting_art enable row level security;
+alter table vignette_encounter_survivor_secret_fighting_art enable row level security;
+alter table vignette_encounter_survivor_disorder enable row level security;
+alter table vignette_encounter_survivor_ability_impairment enable row level security;
+alter table vignette_encounter_survivor_status enable row level security;
+alter table vignette_encounter_gear_grid enable row level security;
+--------------------------------------------------------------------------------
+-- Data API Privileges
+-- Table privileges are in place for PostgREST exposure; RLS policies still
+-- control row access and are intentionally absent until VIG-01.03.
+--------------------------------------------------------------------------------
+grant select, insert, update, delete on table vignette_encounter to authenticated;
+grant select, insert, update, delete on table vignette_encounter_monster to authenticated;
+grant select, insert, update, delete on table vignette_encounter_survivor to authenticated;
+grant select, insert, update, delete on table vignette_encounter_survivor_fighting_art to authenticated;
+grant select, insert, update, delete on table vignette_encounter_survivor_secret_fighting_art to authenticated;
+grant select, insert, update, delete on table vignette_encounter_survivor_disorder to authenticated;
+grant select, insert, update, delete on table vignette_encounter_survivor_ability_impairment to authenticated;
+grant select, insert, update, delete on table vignette_encounter_survivor_status to authenticated;
+grant select, insert, update, delete on table vignette_encounter_gear_grid to authenticated;
+--------------------------------------------------------------------------------
+-- Indexes
+--------------------------------------------------------------------------------
+create unique index one_active_vignette_encounter_per_user on vignette_encounter(user_id)
+where status = 'ACTIVE';
+create index idx_vignette_encounter_user on vignette_encounter(user_id);
+create index idx_vignette_encounter_definition on vignette_encounter(vignette_encounter_definition_id);
+create index idx_vignette_encounter_level on vignette_encounter(vignette_encounter_level_id);
+create index idx_vignette_encounter_status on vignette_encounter(status);
+create index idx_vignette_encounter_survivor_encounter on vignette_encounter_survivor(vignette_encounter_id);
+create index idx_vignette_encounter_survivor_template on vignette_encounter_survivor(vignette_survivor_template_id);
+create index idx_vignette_encounter_survivor_weapon_type on vignette_encounter_survivor(weapon_type_id);
+create index idx_vignette_encounter_survivor_fighting_art_survivor on vignette_encounter_survivor_fighting_art(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_survivor_fighting_art_art on vignette_encounter_survivor_fighting_art(fighting_art_id);
+create index idx_vignette_encounter_survivor_secret_fighting_art_survivor on vignette_encounter_survivor_secret_fighting_art(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_survivor_secret_fighting_art_art on vignette_encounter_survivor_secret_fighting_art(secret_fighting_art_id);
+create index idx_vignette_encounter_survivor_disorder_survivor on vignette_encounter_survivor_disorder(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_survivor_disorder_disorder on vignette_encounter_survivor_disorder(disorder_id);
+create index idx_vignette_encounter_survivor_ability_impairment_survivor on vignette_encounter_survivor_ability_impairment(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_survivor_ability_impairment_ability on vignette_encounter_survivor_ability_impairment(ability_impairment_id);
+create index idx_vignette_encounter_survivor_status_survivor on vignette_encounter_survivor_status(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_survivor_status_status on vignette_encounter_survivor_status(survivor_status_id);
+create index idx_vignette_encounter_gear_grid_survivor on vignette_encounter_gear_grid(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_gear_grid_gear on vignette_encounter_gear_grid(gear_id);
+--------------------------------------------------------------------------------
+-- Triggers
+--------------------------------------------------------------------------------
+create trigger set_updated_at before
+update on vignette_encounter for each row execute function update_updated_at();
+create trigger set_updated_at before
+update on vignette_encounter_monster for each row execute function update_updated_at();
+create trigger set_updated_at before
+update on vignette_encounter_survivor for each row execute function update_updated_at();
+create trigger set_updated_at before
+update on vignette_encounter_survivor_fighting_art for each row execute function update_updated_at();
+create trigger set_updated_at before
+update on vignette_encounter_survivor_secret_fighting_art for each row execute function update_updated_at();
+create trigger set_updated_at before
+update on vignette_encounter_survivor_disorder for each row execute function update_updated_at();
+create trigger set_updated_at before
+update on vignette_encounter_survivor_ability_impairment for each row execute function update_updated_at();
+create trigger set_updated_at before
+update on vignette_encounter_survivor_status for each row execute function update_updated_at();
+create trigger set_updated_at before
+update on vignette_encounter_gear_grid for each row execute function update_updated_at();


### PR DESCRIPTION
## Summary
- Add mutable vignette encounter instance tables for issue #333
- Add monster, survivor, survivor junction, and gear-grid instance storage separate from settlement/showdown rows
- Add ACTIVE/ENDED lifecycle checks and the one-active-owned-vignette partial unique index
- Enable RLS on all new public tables and grant authenticated table privileges for future Data API access
- Regenerate Supabase database types and bump the package version to 0.90.0

## Dependencies
- No dependency changes

## Verification
- npx prettier --check supabase/migrations/20260613000002_vignette_instance_tables.sql
- git diff --check
- npx supabase db reset --local --yes
- npx supabase db lint --local
- targeted DB query confirmed RLS is enabled for the new tables
- targeted DB query confirmed the one-active-owned-vignette constraint rejects a second active owned row while allowing ended history

Closes #333