### PR TITLE
[VIG-01.03] Create vignette sharing migration and entitlement SQL

### DIFF
--- a/__tests__/integration/rls/vignette-sharing.test.ts
+++ b/__tests__/integration/rls/vignette-sharing.test.ts
@@ -213,6 +213,34 @@ describe('RLS: vignette encounter sharing', () => {
     expect(remainingRows).toEqual([])
   })
 
+  it('prevents duplicate shares for the same vignette and collaborator', async () => {
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await clearShares()
+
+    const share = {
+      vignette_encounter_id: vignetteEncounterId,
+      shared_user_id: collaborator.id,
+      created_by: owner.id
+    }
+
+    const { error: firstInsertError } = await owner.client
+      .from('vignette_encounter_shared_user')
+      .insert(share)
+    expect(firstInsertError).toBeNull()
+
+    const { error: duplicateInsertError } = await owner.client
+      .from('vignette_encounter_shared_user')
+      .insert(share)
+    expect(duplicateInsertError).not.toBeNull()
+
+    const { data: shareRows, error: shareRowsError } = await admin
+      .from('vignette_encounter_shared_user')
+      .select('shared_user_id')
+      .eq('vignette_encounter_id', vignetteEncounterId)
+    expect(shareRowsError).toBeNull()
+    expect(shareRows).toEqual([{ shared_user_id: collaborator.id }])
+  })
+
   it('prevents owners from sharing a vignette with themselves', async () => {
     await setUserSubscription(owner.id, 'lantern_hoard', 'active')
     await clearShares()

--- a/__tests__/integration/rls/vignette-sharing.test.ts
+++ b/__tests__/integration/rls/vignette-sharing.test.ts
@@ -1,0 +1,230 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * RLS — Vignette Encounter Sharing
+ *
+ * Exercises the sharing table and Lantern Hoard entitlement helper introduced
+ * for VIG-01.03 / GitHub issue #335.
+ */
+describe('RLS: vignette encounter sharing', () => {
+  let owner: TestUser
+  let collaborator: TestUser
+  let stranger: TestUser
+  let vignetteEncounterDefinitionId: string
+  let vignetteEncounterId: string
+
+  beforeAll(async () => {
+    owner = await createTestUser()
+    collaborator = await createTestUser()
+    stranger = await createTestUser()
+    vignetteEncounterId = await seedVignetteEncounter(owner.id)
+  })
+
+  afterAll(async () => {
+    await deleteTestUser(owner.id)
+    await deleteTestUser(collaborator.id)
+    await deleteTestUser(stranger.id)
+
+    if (vignetteEncounterDefinitionId) {
+      await admin
+        .from('vignette_encounter_definition')
+        .delete()
+        .eq('id', vignetteEncounterDefinitionId)
+    }
+  })
+
+  async function seedVignetteEncounter(userId: string): Promise<string> {
+    const { data: quarry, error: quarryError } = await admin
+      .from('quarry')
+      .select('id')
+      .limit(1)
+      .single()
+    expect(quarryError).toBeNull()
+    expect(quarry).not.toBeNull()
+
+    const { data: definition, error: definitionError } = await admin
+      .from('vignette_encounter_definition')
+      .insert({
+        name: 'RLS Test Vignette',
+        slug: `rls-test-vignette-${Date.now()}`,
+        source_monster_type: 'QUARRY',
+        source_quarry_id: quarry!.id,
+        published: true
+      })
+      .select('id')
+      .single()
+    expect(definitionError).toBeNull()
+    expect(definition).not.toBeNull()
+
+    vignetteEncounterDefinitionId = definition!.id
+
+    const { data: level, error: levelError } = await admin
+      .from('vignette_encounter_level')
+      .insert({
+        vignette_encounter_definition_id: vignetteEncounterDefinitionId,
+        level_number: 1
+      })
+      .select('id')
+      .single()
+    expect(levelError).toBeNull()
+    expect(level).not.toBeNull()
+
+    const { data: encounter, error: encounterError } = await admin
+      .from('vignette_encounter')
+      .insert({
+        user_id: userId,
+        vignette_encounter_definition_id: vignetteEncounterDefinitionId,
+        vignette_encounter_level_id: level!.id
+      })
+      .select('id')
+      .single()
+    expect(encounterError).toBeNull()
+    expect(encounter).not.toBeNull()
+
+    return encounter!.id
+  }
+
+  async function setUserSubscription(
+    userId: string,
+    planId: 'free' | 'lantern' | 'lantern_hoard',
+    status: 'active' | 'past_due' | 'canceled' | 'trialing' | 'incomplete'
+  ): Promise<void> {
+    const { error } = await admin
+      .from('user_subscription')
+      .update({ plan_id: planId, status })
+      .eq('user_id', userId)
+    expect(error).toBeNull()
+  }
+
+  async function clearShares(): Promise<void> {
+    const { error } = await admin
+      .from('vignette_encounter_shared_user')
+      .delete()
+      .eq('vignette_encounter_id', vignetteEncounterId)
+    expect(error).toBeNull()
+  }
+
+  it('denies share creation for a free owner', async () => {
+    await setUserSubscription(owner.id, 'free', 'active')
+    await clearShares()
+
+    const { error } = await owner.client
+      .from('vignette_encounter_shared_user')
+      .insert({
+        vignette_encounter_id: vignetteEncounterId,
+        shared_user_id: collaborator.id,
+        created_by: owner.id
+      })
+
+    expect(error).not.toBeNull()
+  })
+
+  it('allows an active Lantern Hoard owner to share with a free collaborator', async () => {
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await clearShares()
+
+    const { error: insertError } = await owner.client
+      .from('vignette_encounter_shared_user')
+      .insert({
+        vignette_encounter_id: vignetteEncounterId,
+        shared_user_id: collaborator.id,
+        created_by: owner.id
+      })
+    expect(insertError).toBeNull()
+
+    const { data: collaboratorRows, error: collaboratorSelectError } =
+      await collaborator.client
+        .from('vignette_encounter_shared_user')
+        .select('vignette_encounter_id, shared_user_id, created_by')
+        .eq('vignette_encounter_id', vignetteEncounterId)
+    expect(collaboratorSelectError).toBeNull()
+    expect(collaboratorRows).toEqual([
+      {
+        vignette_encounter_id: vignetteEncounterId,
+        shared_user_id: collaborator.id,
+        created_by: owner.id
+      }
+    ])
+
+    const { data: strangerRows, error: strangerSelectError } =
+      await stranger.client
+        .from('vignette_encounter_shared_user')
+        .select('vignette_encounter_id')
+        .eq('vignette_encounter_id', vignetteEncounterId)
+    expect(strangerSelectError).toBeNull()
+    expect(strangerRows).toEqual([])
+  })
+
+  it('prevents non-owners and collaborators from managing shares', async () => {
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await setUserSubscription(collaborator.id, 'lantern_hoard', 'active')
+    await clearShares()
+
+    const { error: ownerInsertError } = await owner.client
+      .from('vignette_encounter_shared_user')
+      .insert({
+        vignette_encounter_id: vignetteEncounterId,
+        shared_user_id: collaborator.id,
+        created_by: owner.id
+      })
+    expect(ownerInsertError).toBeNull()
+
+    const { error: collaboratorInsertError } = await collaborator.client
+      .from('vignette_encounter_shared_user')
+      .insert({
+        vignette_encounter_id: vignetteEncounterId,
+        shared_user_id: stranger.id,
+        created_by: collaborator.id
+      })
+    expect(collaboratorInsertError).not.toBeNull()
+
+    const { error: collaboratorDeleteError } = await collaborator.client
+      .from('vignette_encounter_shared_user')
+      .delete()
+      .eq('vignette_encounter_id', vignetteEncounterId)
+      .eq('shared_user_id', collaborator.id)
+    expect(collaboratorDeleteError).toBeNull()
+
+    const { data: stillSharedRows, error: stillSharedError } = await admin
+      .from('vignette_encounter_shared_user')
+      .select('shared_user_id')
+      .eq('vignette_encounter_id', vignetteEncounterId)
+    expect(stillSharedError).toBeNull()
+    expect(stillSharedRows).toEqual([{ shared_user_id: collaborator.id }])
+
+    const { error: ownerDeleteError } = await owner.client
+      .from('vignette_encounter_shared_user')
+      .delete()
+      .eq('vignette_encounter_id', vignetteEncounterId)
+      .eq('shared_user_id', collaborator.id)
+    expect(ownerDeleteError).toBeNull()
+
+    const { data: remainingRows, error: remainingError } = await admin
+      .from('vignette_encounter_shared_user')
+      .select('shared_user_id')
+      .eq('vignette_encounter_id', vignetteEncounterId)
+    expect(remainingError).toBeNull()
+    expect(remainingRows).toEqual([])
+  })
+
+  it('prevents owners from sharing a vignette with themselves', async () => {
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await clearShares()
+
+    const { error } = await owner.client
+      .from('vignette_encounter_shared_user')
+      .insert({
+        vignette_encounter_id: vignetteEncounterId,
+        shared_user_id: owner.id,
+        created_by: owner.id
+      })
+
+    expect(error).not.toBeNull()
+  })
+})

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5976,6 +5976,35 @@ export type Database = {
           },
         ]
       }
+      vignette_encounter_shared_user: {
+        Row: {
+          created_at: string
+          created_by: string
+          shared_user_id: string
+          vignette_encounter_id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          shared_user_id: string
+          vignette_encounter_id: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          shared_user_id?: string
+          vignette_encounter_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_shared_user_vignette_encounter_id_fkey"
+            columns: ["vignette_encounter_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       vignette_encounter_survivor: {
         Row: {
           accuracy: number
@@ -6945,6 +6974,10 @@ export type Database = {
         Args: { p_armor_set_id: string; p_equipped_gear_ids: string[] }
         Returns: boolean
       }
+      can_share_vignette_encounters: {
+        Args: { target_user_id: string }
+        Returns: boolean
+      }
       check_username_available: {
         Args: { desired_username: string }
         Returns: boolean
@@ -7021,6 +7054,10 @@ export type Database = {
         Returns: boolean
       }
       is_settlement_owner: { Args: { record_id: string }; Returns: boolean }
+      is_vignette_encounter_owner: {
+        Args: { target_vignette_encounter: string }
+        Returns: boolean
+      }
       lookup_user_by_username: { Args: { p_username: string }; Returns: string }
       provision_user_settings_for_oauth: {
         Args: { p_user_id: string }

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5997,6 +5997,13 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "fk_vignette_encounter_shared_user_settings"
+            columns: ["shared_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_settings"
+            referencedColumns: ["user_id"]
+          },
+          {
             foreignKeyName: "vignette_encounter_shared_user_vignette_encounter_id_fkey"
             columns: ["vignette_encounter_id"]
             isOneToOne: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.90.0",
+      "version": "0.91.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260613000003_vignette_sharing_entitlement.sql
+++ b/supabase/migrations/20260613000003_vignette_sharing_entitlement.sql
@@ -13,7 +13,8 @@ create table vignette_encounter_shared_user (
 	created_by uuid not null references auth.users(id) on delete cascade,
 	-- Constraints
 	primary key (vignette_encounter_id, shared_user_id),
-	constraint vignette_encounter_shared_user_no_self_share check (shared_user_id <> created_by)
+	constraint vignette_encounter_shared_user_no_self_share check (shared_user_id <> created_by),
+	constraint fk_vignette_encounter_shared_user_settings foreign key (shared_user_id) references user_settings(user_id) on delete cascade
 );
 --------------------------------------------------------------------------------
 -- Helper: is_vignette_encounter_owner(uuid)

--- a/supabase/migrations/20260613000003_vignette_sharing_entitlement.sql
+++ b/supabase/migrations/20260613000003_vignette_sharing_entitlement.sql
@@ -1,0 +1,113 @@
+--------------------------------------------------------------------------------
+-- Vignette Encounter Sharing And Entitlement
+-- Active instance collaboration for Lantern Hoard owners. This intentionally
+-- mirrors settlement sharing while keeping vignette membership independent
+-- from settlement membership.
+--------------------------------------------------------------------------------
+create table vignette_encounter_shared_user (
+	-- Metadata
+	created_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_id uuid not null references vignette_encounter(id) on delete cascade,
+	shared_user_id uuid not null references auth.users(id) on delete cascade,
+	created_by uuid not null references auth.users(id) on delete cascade,
+	-- Constraints
+	primary key (vignette_encounter_id, shared_user_id),
+	constraint vignette_encounter_shared_user_no_self_share check (shared_user_id <> created_by)
+);
+--------------------------------------------------------------------------------
+-- Helper: is_vignette_encounter_owner(uuid)
+--
+-- SECURITY DEFINER predicate for sharing-table RLS. The parent
+-- `vignette_encounter` table has its detailed owner/collaborator policies added
+-- in VIG-01.04, so this helper avoids re-entering parent-table RLS while still
+-- tying share management to the owning user.
+--------------------------------------------------------------------------------
+create or replace function is_vignette_encounter_owner(target_vignette_encounter uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select exists (
+    select 1
+    from public.vignette_encounter ve
+    where ve.id = target_vignette_encounter
+      and ve.user_id = (
+        select auth.uid()
+      )
+  );
+$$;
+--------------------------------------------------------------------------------
+-- Helper: can_share_vignette_encounters(uuid)
+--
+-- Returns true only when the provided user is the caller and has an active or
+-- trialing Lantern Hoard subscription. This is stricter than `user_can_share()`
+-- so future settlement-sharing tiers can evolve without widening vignette
+-- sharing access by accident.
+--------------------------------------------------------------------------------
+create or replace function can_share_vignette_encounters(target_user_id uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select coalesce(
+    (
+      select us.plan_id = 'lantern_hoard'
+      from public.user_subscription us
+      where us.user_id = target_user_id
+        and target_user_id = (
+          select auth.uid()
+        )
+        and us.status in ('active', 'trialing')
+    ),
+    false
+  );
+$$;
+--------------------------------------------------------------------------------
+-- Privilege Lockdown
+--------------------------------------------------------------------------------
+revoke all on function public.is_vignette_encounter_owner(uuid)
+from public;
+revoke execute on function public.is_vignette_encounter_owner(uuid)
+from anon;
+grant execute on function public.is_vignette_encounter_owner(uuid) to authenticated;
+
+revoke all on function public.can_share_vignette_encounters(uuid)
+from public;
+revoke execute on function public.can_share_vignette_encounters(uuid)
+from anon;
+grant execute on function public.can_share_vignette_encounters(uuid) to authenticated;
+--------------------------------------------------------------------------------
+-- Row Level Security Policies
+--------------------------------------------------------------------------------
+alter table vignette_encounter_shared_user enable row level security;
+
+create policy "Allow insert for entitled owner" on vignette_encounter_shared_user for
+insert to authenticated with check (
+		is_vignette_encounter_owner(vignette_encounter_id)
+		and created_by = (
+			select auth.uid()
+		)
+		and can_share_vignette_encounters(
+			(
+				select auth.uid()
+			)
+		)
+	);
+
+create policy "Allow select for owner" on vignette_encounter_shared_user for
+select to authenticated using (is_vignette_encounter_owner(vignette_encounter_id));
+
+create policy "Allow select for shared" on vignette_encounter_shared_user for
+select to authenticated using (
+		shared_user_id = (
+			select auth.uid()
+		)
+	);
+
+create policy "Allow delete for owner" on vignette_encounter_shared_user for delete to authenticated using (is_vignette_encounter_owner(vignette_encounter_id));
+--------------------------------------------------------------------------------
+-- Data API Privileges
+--------------------------------------------------------------------------------
+grant select, insert, delete on table vignette_encounter_shared_user to authenticated;
+revoke update on table vignette_encounter_shared_user from authenticated;
+--------------------------------------------------------------------------------
+-- Indexes
+--------------------------------------------------------------------------------
+create index idx_vignette_encounter_shared_user_vignette_encounter on vignette_encounter_shared_user(vignette_encounter_id);
+create index idx_vignette_encounter_shared_user_shared_user on vignette_encounter_shared_user(shared_user_id);
+create index idx_vignette_encounter_shared_user_created_by on vignette_encounter_shared_user(created_by);


### PR DESCRIPTION
## Summary
- Add the vignette encounter sharing table, owner helper, and Lantern Hoard-only SQL entitlement helper.
- Add RLS policies so entitled owners can create shares, owners can view/delete shares, and invited users can view their own membership rows.
- Regenerate Supabase database types and add focused integration coverage for share entitlement and management behavior.
- Bump package version to 0.91.0.

## Dependencies
- No dependency changes.

## Verification
- npx prettier --check package.json package-lock.json __tests__/integration/rls/vignette-sharing.test.ts supabase/migrations/20260613000003_vignette_sharing_entitlement.sql lib/database.types.ts
- git diff --check
- npx supabase db reset --local --yes
- npx supabase db lint --local
- ./scripts/integration.sh __tests__/integration/rls/vignette-sharing.test.ts

Closes #335