### PR TITLE
Add vignette encounter RLS policies

### DIFF
--- a/__tests__/integration/rls/vignette-sharing.test.ts
+++ b/__tests__/integration/rls/vignette-sharing.test.ts
@@ -16,7 +16,7 @@ describe('RLS: vignette encounter sharing', () => {
   let owner: TestUser
   let collaborator: TestUser
   let stranger: TestUser
-  let vignetteEncounterDefinitionId: string
+  const vignetteEncounterDefinitionIds: string[] = []
   let vignetteEncounterId: string
   let vignetteEncounterMonsterId: string
   let vignetteEncounterSurvivorId: string
@@ -39,11 +39,11 @@ describe('RLS: vignette encounter sharing', () => {
     await deleteTestUser(collaborator.id)
     await deleteTestUser(stranger.id)
 
-    if (vignetteEncounterDefinitionId) {
+    if (vignetteEncounterDefinitionIds.length > 0) {
       await admin
         .from('vignette_encounter_definition')
         .delete()
-        .eq('id', vignetteEncounterDefinitionId)
+        .in('id', vignetteEncounterDefinitionIds)
     }
   })
 
@@ -70,7 +70,8 @@ describe('RLS: vignette encounter sharing', () => {
     expect(definitionError).toBeNull()
     expect(definition).not.toBeNull()
 
-    vignetteEncounterDefinitionId = definition!.id
+    const vignetteEncounterDefinitionId = definition!.id
+    vignetteEncounterDefinitionIds.push(vignetteEncounterDefinitionId)
 
     const { data: level, error: levelError } = await admin
       .from('vignette_encounter_level')

--- a/__tests__/integration/rls/vignette-sharing.test.ts
+++ b/__tests__/integration/rls/vignette-sharing.test.ts
@@ -9,8 +9,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 /**
  * RLS — Vignette Encounter Sharing
  *
- * Exercises the sharing table and Lantern Hoard entitlement helper introduced
- * for VIG-01.03 / GitHub issue #335.
+ * Exercises vignette instance ownership, collaboration, and sharing policies
+ * introduced for VIG-01.04 / GitHub issue #332.
  */
 describe('RLS: vignette encounter sharing', () => {
   let owner: TestUser
@@ -18,12 +18,20 @@ describe('RLS: vignette encounter sharing', () => {
   let stranger: TestUser
   let vignetteEncounterDefinitionId: string
   let vignetteEncounterId: string
+  let vignetteEncounterMonsterId: string
+  let vignetteEncounterSurvivorId: string
+  let vignetteEncounterGearGridId: string
 
   beforeAll(async () => {
     owner = await createTestUser()
     collaborator = await createTestUser()
     stranger = await createTestUser()
     vignetteEncounterId = await seedVignetteEncounter(owner.id)
+    const stateIds =
+      await seedVignetteEncounterGameplayState(vignetteEncounterId)
+    vignetteEncounterMonsterId = stateIds.monsterId
+    vignetteEncounterSurvivorId = stateIds.survivorId
+    vignetteEncounterGearGridId = stateIds.gearGridId
   })
 
   afterAll(async () => {
@@ -90,6 +98,56 @@ describe('RLS: vignette encounter sharing', () => {
     return encounter!.id
   }
 
+  async function seedVignetteEncounterGameplayState(
+    encounterId: string
+  ): Promise<{ monsterId: string; survivorId: string; gearGridId: string }> {
+    const { data: gear, error: gearError } = await admin
+      .from('gear')
+      .select('id')
+      .limit(1)
+      .single()
+    expect(gearError).toBeNull()
+    expect(gear).not.toBeNull()
+
+    const { data: monster, error: monsterError } = await admin
+      .from('vignette_encounter_monster')
+      .insert({ vignette_encounter_id: encounterId })
+      .select('id')
+      .single()
+    expect(monsterError).toBeNull()
+    expect(monster).not.toBeNull()
+
+    const { data: survivor, error: survivorError } = await admin
+      .from('vignette_encounter_survivor')
+      .insert({
+        vignette_encounter_id: encounterId,
+        survivor_name: 'RLS Vignette Survivor'
+      })
+      .select('id')
+      .single()
+    expect(survivorError).toBeNull()
+    expect(survivor).not.toBeNull()
+
+    const { data: gearGrid, error: gearGridError } = await admin
+      .from('vignette_encounter_gear_grid')
+      .insert({
+        vignette_encounter_survivor_id: survivor!.id,
+        gear_id: gear!.id,
+        row_number: 0,
+        column_number: 0
+      })
+      .select('id')
+      .single()
+    expect(gearGridError).toBeNull()
+    expect(gearGrid).not.toBeNull()
+
+    return {
+      monsterId: monster!.id,
+      survivorId: survivor!.id,
+      gearGridId: gearGrid!.id
+    }
+  }
+
   async function setUserSubscription(
     userId: string,
     planId: 'free' | 'lantern' | 'lantern_hoard',
@@ -109,6 +167,222 @@ describe('RLS: vignette encounter sharing', () => {
       .eq('vignette_encounter_id', vignetteEncounterId)
     expect(error).toBeNull()
   }
+
+  it('allows the owner to create and update their own active vignette instance', async () => {
+    const tempOwner = await createTestUser()
+    const tempEncounterId = await seedVignetteEncounter(tempOwner.id)
+
+    const { data: selected, error: selectError } = await tempOwner.client
+      .from('vignette_encounter')
+      .select('id, round')
+      .eq('id', tempEncounterId)
+    expect(selectError).toBeNull()
+    expect(selected).toEqual([{ id: tempEncounterId, round: 1 }])
+
+    const { data: updated, error: updateError } = await tempOwner.client
+      .from('vignette_encounter')
+      .update({ round: 2, notes: 'Owner keeps the lantern high' })
+      .eq('id', tempEncounterId)
+      .select('id, round, notes')
+    expect(updateError).toBeNull()
+    expect(updated).toEqual([
+      {
+        id: tempEncounterId,
+        round: 2,
+        notes: 'Owner keeps the lantern high'
+      }
+    ])
+
+    await deleteTestUser(tempOwner.id)
+  })
+
+  it('allows the owner to end their own active vignette instance', async () => {
+    const tempOwner = await createTestUser()
+    const tempEncounterId = await seedVignetteEncounter(tempOwner.id)
+    const endedAt = new Date().toISOString()
+
+    const { data, error } = await tempOwner.client
+      .from('vignette_encounter')
+      .update({ status: 'ENDED', ended_at: endedAt })
+      .eq('id', tempEncounterId)
+      .select('id, status, ended_at')
+    expect(error).toBeNull()
+    expect(data).toEqual([
+      {
+        id: tempEncounterId,
+        status: 'ENDED',
+        ended_at: expect.any(String)
+      }
+    ])
+    expect(new Date(data![0].ended_at!).toISOString()).toBe(endedAt)
+
+    await deleteTestUser(tempOwner.id)
+  })
+
+  it('allows the owner to delete their own active vignette instance', async () => {
+    const tempOwner = await createTestUser()
+    const tempEncounterId = await seedVignetteEncounter(tempOwner.id)
+
+    const { error } = await tempOwner.client
+      .from('vignette_encounter')
+      .delete()
+      .eq('id', tempEncounterId)
+    expect(error).toBeNull()
+
+    const { data: remaining, error: remainingError } = await admin
+      .from('vignette_encounter')
+      .select('id')
+      .eq('id', tempEncounterId)
+    expect(remainingError).toBeNull()
+    expect(remaining).toEqual([])
+
+    await deleteTestUser(tempOwner.id)
+  })
+
+  it('allows a collaborator to read and update active gameplay state', async () => {
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await clearShares()
+
+    const { error: shareError } = await owner.client
+      .from('vignette_encounter_shared_user')
+      .insert({
+        vignette_encounter_id: vignetteEncounterId,
+        shared_user_id: collaborator.id,
+        created_by: owner.id
+      })
+    expect(shareError).toBeNull()
+
+    const { data: encounterRows, error: encounterSelectError } =
+      await collaborator.client
+        .from('vignette_encounter')
+        .select('id, round')
+        .eq('id', vignetteEncounterId)
+    expect(encounterSelectError).toBeNull()
+    expect(encounterRows).toEqual([{ id: vignetteEncounterId, round: 1 }])
+
+    const { data: encounterUpdate, error: encounterUpdateError } =
+      await collaborator.client
+        .from('vignette_encounter')
+        .update({ round: 2, notes: 'Collaborator trims the wick' })
+        .eq('id', vignetteEncounterId)
+        .select('id, round, notes')
+    expect(encounterUpdateError).toBeNull()
+    expect(encounterUpdate).toEqual([
+      {
+        id: vignetteEncounterId,
+        round: 2,
+        notes: 'Collaborator trims the wick'
+      }
+    ])
+
+    const { data: monsterUpdate, error: monsterUpdateError } =
+      await collaborator.client
+        .from('vignette_encounter_monster')
+        .update({ current_wounds: 3, knocked_down: true })
+        .eq('id', vignetteEncounterMonsterId)
+        .select('id, current_wounds, knocked_down')
+    expect(monsterUpdateError).toBeNull()
+    expect(monsterUpdate).toEqual([
+      {
+        id: vignetteEncounterMonsterId,
+        current_wounds: 3,
+        knocked_down: true
+      }
+    ])
+
+    const { data: survivorUpdate, error: survivorUpdateError } =
+      await collaborator.client
+        .from('vignette_encounter_survivor')
+        .update({ survival: 2, notes: 'The survivor refuses the dark' })
+        .eq('id', vignetteEncounterSurvivorId)
+        .select('id, survival, notes')
+    expect(survivorUpdateError).toBeNull()
+    expect(survivorUpdate).toEqual([
+      {
+        id: vignetteEncounterSurvivorId,
+        survival: 2,
+        notes: 'The survivor refuses the dark'
+      }
+    ])
+
+    const { data: gearGridUpdate, error: gearGridUpdateError } =
+      await collaborator.client
+        .from('vignette_encounter_gear_grid')
+        .update({ row_number: 1, column_number: 1 })
+        .eq('id', vignetteEncounterGearGridId)
+        .select('id, row_number, column_number')
+    expect(gearGridUpdateError).toBeNull()
+    expect(gearGridUpdate).toEqual([
+      {
+        id: vignetteEncounterGearGridId,
+        row_number: 1,
+        column_number: 1
+      }
+    ])
+  })
+
+  it('prevents a collaborator from ending or deleting a vignette instance', async () => {
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await clearShares()
+
+    const { error: shareError } = await owner.client
+      .from('vignette_encounter_shared_user')
+      .insert({
+        vignette_encounter_id: vignetteEncounterId,
+        shared_user_id: collaborator.id,
+        created_by: owner.id
+      })
+    expect(shareError).toBeNull()
+
+    const { error: endError } = await collaborator.client
+      .from('vignette_encounter')
+      .update({ status: 'ENDED', ended_at: new Date().toISOString() })
+      .eq('id', vignetteEncounterId)
+    expect(endError).not.toBeNull()
+
+    const { error: deleteError } = await collaborator.client
+      .from('vignette_encounter')
+      .delete()
+      .eq('id', vignetteEncounterId)
+    expect(deleteError).toBeNull()
+
+    const { data: remaining, error: remainingError } = await admin
+      .from('vignette_encounter')
+      .select('id, status')
+      .eq('id', vignetteEncounterId)
+    expect(remainingError).toBeNull()
+    expect(remaining).toEqual([{ id: vignetteEncounterId, status: 'ACTIVE' }])
+  })
+
+  it('prevents strangers from reading or mutating vignette instance rows', async () => {
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await clearShares()
+
+    const { data: encounterRows, error: encounterSelectError } =
+      await stranger.client
+        .from('vignette_encounter')
+        .select('id')
+        .eq('id', vignetteEncounterId)
+    expect(encounterSelectError).toBeNull()
+    expect(encounterRows).toEqual([])
+
+    const { data: updateRows, error: updateError } = await stranger.client
+      .from('vignette_encounter_monster')
+      .update({ current_wounds: 9 })
+      .eq('id', vignetteEncounterMonsterId)
+      .select('id')
+    expect(updateError).toBeNull()
+    expect(updateRows).toEqual([])
+
+    const { data: monsterRows, error: monsterRowsError } = await admin
+      .from('vignette_encounter_monster')
+      .select('id, current_wounds')
+      .eq('id', vignetteEncounterMonsterId)
+    expect(monsterRowsError).toBeNull()
+    expect(monsterRows).toEqual([
+      { id: vignetteEncounterMonsterId, current_wounds: 3 }
+    ])
+  })
 
   it('denies share creation for a free owner', async () => {
     await setUserSubscription(owner.id, 'free', 'active')

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -6981,8 +6981,23 @@ export type Database = {
         Args: { p_armor_set_id: string; p_equipped_gear_ids: string[] }
         Returns: boolean
       }
+      can_access_active_vignette_encounter: {
+        Args: { target_vignette_encounter: string }
+        Returns: boolean
+      }
       can_share_vignette_encounters: {
         Args: { target_user_id: string }
+        Returns: boolean
+      }
+      can_update_vignette_encounter_as_collaborator: {
+        Args: {
+          proposed_definition_id: string
+          proposed_ended_at: string
+          proposed_level_id: string
+          proposed_status: string
+          proposed_user_id: string
+          target_vignette_encounter: string
+        }
         Returns: boolean
       }
       check_username_available: {
@@ -7030,6 +7045,10 @@ export type Database = {
         Args: { target_user_id: string }
         Returns: number
       }
+      is_active_vignette_encounter_owner: {
+        Args: { target_vignette_encounter: string }
+        Returns: boolean
+      }
       is_admin: { Args: never; Returns: boolean }
       is_armor_set_owner: { Args: { record_id: string }; Returns: boolean }
       is_collective_cognition_reward_visible_via_quarry_reference: {
@@ -7061,6 +7080,10 @@ export type Database = {
         Returns: boolean
       }
       is_settlement_owner: { Args: { record_id: string }; Returns: boolean }
+      is_vignette_encounter_collaborator: {
+        Args: { target_vignette_encounter: string }
+        Returns: boolean
+      }
       is_vignette_encounter_owner: {
         Args: { target_vignette_encounter: string }
         Returns: boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.91.0",
+  "version": "0.91.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.91.0",
+      "version": "0.91.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.91.0",
+  "version": "0.91.1",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260424000029_seed_pattern_extension.sql
+++ b/supabase/migrations/20260424000029_seed_pattern_extension.sql
@@ -2,14 +2,14 @@
 -- Seed Pattern Table
 --------------------------------------------------------------------------------
 ALTER TABLE seed_pattern
-ADD COLUMN crafting_limit INT CHECK (crafting_limit >= 0),
-  ADD COLUMN crafting_steps TEXT,
-  ADD COLUMN endeavor_cost INT CHECK (endeavor_cost >= 0),
-  ADD COLUMN era INT CHECK (
+ADD COLUMN IF NOT EXISTS crafting_limit INT CHECK (crafting_limit >= 0),
+  ADD COLUMN IF NOT EXISTS crafting_steps TEXT,
+  ADD COLUMN IF NOT EXISTS endeavor_cost INT CHECK (endeavor_cost >= 0),
+  ADD COLUMN IF NOT EXISTS era INT CHECK (
     era >= 1
     AND era <= 4
   ),
-  ADD COLUMN keywords VARCHAR [] DEFAULT '{}',
-  ADD COLUMN requirements TEXT,
-  ADD COLUMN crafted_gear_id UUID REFERENCES gear(id),
-  ADD COLUMN number INT;
+  ADD COLUMN IF NOT EXISTS keywords VARCHAR [] DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS requirements TEXT,
+  ADD COLUMN IF NOT EXISTS crafted_gear_id UUID REFERENCES gear(id),
+  ADD COLUMN IF NOT EXISTS number INT;

--- a/supabase/migrations/20260613000004_vignette_rls_policies.sql
+++ b/supabase/migrations/20260613000004_vignette_rls_policies.sql
@@ -1,0 +1,240 @@
+--------------------------------------------------------------------------------
+-- Vignette Encounter RLS Policies
+-- Owner/collaborator access for active one-shot showdown instances.
+--------------------------------------------------------------------------------
+create or replace function public.is_vignette_encounter_collaborator(target_vignette_encounter uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select exists (
+		select 1
+		from public.vignette_encounter_shared_user vesu
+		where vesu.vignette_encounter_id = target_vignette_encounter
+			and vesu.shared_user_id = (
+				select auth.uid()
+			)
+	);
+$$;
+
+create or replace function public.is_active_vignette_encounter_owner(target_vignette_encounter uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select exists (
+		select 1
+		from public.vignette_encounter ve
+		where ve.id = target_vignette_encounter
+			and ve.status = 'ACTIVE'
+			and ve.user_id = (
+				select auth.uid()
+			)
+	);
+$$;
+
+create or replace function public.can_access_active_vignette_encounter(target_vignette_encounter uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select exists (
+		select 1
+		from public.vignette_encounter ve
+		where ve.id = target_vignette_encounter
+			and ve.status = 'ACTIVE'
+			and (
+				ve.user_id = (
+					select auth.uid()
+				)
+				or exists (
+					select 1
+					from public.vignette_encounter_shared_user vesu
+					where vesu.vignette_encounter_id = ve.id
+						and vesu.shared_user_id = (
+							select auth.uid()
+						)
+				)
+			)
+	);
+$$;
+
+create or replace function public.can_update_vignette_encounter_as_collaborator(
+	target_vignette_encounter uuid,
+	proposed_user_id uuid,
+	proposed_definition_id uuid,
+	proposed_level_id uuid,
+	proposed_status text,
+	proposed_ended_at timestamptz
+) returns boolean language sql stable security definer
+set search_path = '' as $$
+select exists (
+		select 1
+		from public.vignette_encounter ve
+		where ve.id = target_vignette_encounter
+			and ve.status = 'ACTIVE'
+			and ve.user_id = proposed_user_id
+			and ve.vignette_encounter_definition_id = proposed_definition_id
+			and ve.vignette_encounter_level_id = proposed_level_id
+			and proposed_status = 'ACTIVE'
+			and proposed_ended_at is null
+			and exists (
+				select 1
+				from public.vignette_encounter_shared_user vesu
+				where vesu.vignette_encounter_id = ve.id
+					and vesu.shared_user_id = (
+						select auth.uid()
+					)
+			)
+	);
+$$;
+
+revoke all on function public.is_vignette_encounter_collaborator(uuid)
+from public;
+revoke execute on function public.is_vignette_encounter_collaborator(uuid)
+from anon;
+grant execute on function public.is_vignette_encounter_collaborator(uuid) to authenticated;
+
+revoke all on function public.is_active_vignette_encounter_owner(uuid)
+from public;
+revoke execute on function public.is_active_vignette_encounter_owner(uuid)
+from anon;
+grant execute on function public.is_active_vignette_encounter_owner(uuid) to authenticated;
+
+revoke all on function public.can_access_active_vignette_encounter(uuid)
+from public;
+revoke execute on function public.can_access_active_vignette_encounter(uuid)
+from anon;
+grant execute on function public.can_access_active_vignette_encounter(uuid) to authenticated;
+
+revoke all on function public.can_update_vignette_encounter_as_collaborator(uuid, uuid, uuid, uuid, text, timestamptz)
+from public;
+revoke execute on function public.can_update_vignette_encounter_as_collaborator(uuid, uuid, uuid, uuid, text, timestamptz)
+from anon;
+grant execute on function public.can_update_vignette_encounter_as_collaborator(uuid, uuid, uuid, uuid, text, timestamptz) to authenticated;
+
+create policy "Allow select for active member" on public.vignette_encounter for
+select to authenticated using (public.can_access_active_vignette_encounter(id));
+
+create policy "Allow insert for owner" on public.vignette_encounter for
+insert to authenticated with check (
+		user_id = (
+			select auth.uid()
+		)
+		and status = 'ACTIVE'
+		and ended_at is null
+		and exists (
+			select 1
+			from public.vignette_encounter_level vel
+				join public.vignette_encounter_definition ved on ved.id = vel.vignette_encounter_definition_id
+			where vel.id = vignette_encounter_level_id
+				and ved.id = vignette_encounter_definition_id
+				and ved.published
+		)
+	);
+
+create policy "Allow update for active member" on public.vignette_encounter for
+update to authenticated using (public.can_access_active_vignette_encounter(id)) with check (
+		(
+			user_id = (
+				select auth.uid()
+			)
+			and exists (
+				select 1
+				from public.vignette_encounter_level vel
+					join public.vignette_encounter_definition ved on ved.id = vel.vignette_encounter_definition_id
+				where vel.id = vignette_encounter_level_id
+					and ved.id = vignette_encounter_definition_id
+					and ved.published
+			)
+		)
+		or public.can_update_vignette_encounter_as_collaborator(
+			id,
+			user_id,
+			vignette_encounter_definition_id,
+			vignette_encounter_level_id,
+			status,
+			ended_at
+		)
+	);
+
+create policy "Allow delete for active owner" on public.vignette_encounter for delete to authenticated using (public.is_active_vignette_encounter_owner(id));
+
+create policy "Allow select for active member" on public.vignette_encounter_monster for
+select to authenticated using (public.can_access_active_vignette_encounter(vignette_encounter_id));
+create policy "Allow insert for active owner" on public.vignette_encounter_monster for
+insert to authenticated with check (public.is_active_vignette_encounter_owner(vignette_encounter_id));
+create policy "Allow update for active member" on public.vignette_encounter_monster for
+update to authenticated using (public.can_access_active_vignette_encounter(vignette_encounter_id)) with check (public.can_access_active_vignette_encounter(vignette_encounter_id));
+create policy "Allow delete for active owner" on public.vignette_encounter_monster for delete to authenticated using (public.is_active_vignette_encounter_owner(vignette_encounter_id));
+
+create policy "Allow select for active member" on public.vignette_encounter_survivor for
+select to authenticated using (public.can_access_active_vignette_encounter(vignette_encounter_id));
+create policy "Allow insert for active owner" on public.vignette_encounter_survivor for
+insert to authenticated with check (public.is_active_vignette_encounter_owner(vignette_encounter_id));
+create policy "Allow update for active member" on public.vignette_encounter_survivor for
+update to authenticated using (public.can_access_active_vignette_encounter(vignette_encounter_id)) with check (public.can_access_active_vignette_encounter(vignette_encounter_id));
+create policy "Allow delete for active owner" on public.vignette_encounter_survivor for delete to authenticated using (public.is_active_vignette_encounter_owner(vignette_encounter_id));
+
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_encounter_survivor_fighting_art',
+		'vignette_encounter_survivor_secret_fighting_art',
+		'vignette_encounter_survivor_disorder',
+		'vignette_encounter_survivor_ability_impairment',
+		'vignette_encounter_survivor_status',
+		'vignette_encounter_gear_grid'
+	] loop
+		execute format(
+			$sql$create policy "Allow select for active member" on public.%1$I for
+select to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.can_access_active_vignette_encounter(ves.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow insert for active owner" on public.%1$I for
+insert to authenticated with check (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.is_active_vignette_encounter_owner(ves.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow update for active member" on public.%1$I for
+update to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.can_access_active_vignette_encounter(ves.vignette_encounter_id)
+	)
+) with check (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.can_access_active_vignette_encounter(ves.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow delete for active owner" on public.%1$I for delete to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.is_active_vignette_encounter_owner(ves.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+	end loop;
+end $$;


### PR DESCRIPTION
## Summary

- Add RLS helper functions and policies for active vignette encounter instances, monsters, survivors, survivor junctions, and gear grids.
- Enforce owner-only create/end/delete semantics while allowing collaborators to read and update active gameplay state.
- Expand vignette RLS integration coverage for owner, collaborator, stranger, and sharing behavior.
- Bump package version to `0.91.1`.

## Dependencies

No dependency changes.

## Related Issues

Closes #332.

## Verification

- `npx supabase db reset --local --yes`
- `npm run db:generate`
- `npm run integration-test -- __tests__/integration/rls/vignette-sharing.test.ts`
- `npx prettier --check package.json package-lock.json supabase/migrations/20260613000004_vignette_rls_policies.sql __tests__/integration/rls/vignette-sharing.test.ts lib/database.types.ts`