### PR TITLE
Add vignette tables to realtime publication

### DIFF
--- a/__tests__/integration/realtime-publication.test.ts
+++ b/__tests__/integration/realtime-publication.test.ts
@@ -4,11 +4,12 @@ import { describe, expect, it } from 'vitest'
 /**
  * Integration — Realtime Publication Membership
  *
- * Asserts that every settlement-scoped table AND every catalog table
- * covered by [E2.1.a/b/c] is included in the `supabase_realtime`
- * publication. Tables in the publication broadcast row-level changes to
- * subscribed clients, which is what powers multiplayer sync for shared
- * settlements and collaborator-visible custom rules text.
+ * Asserts that every settlement-scoped table, every catalog table covered
+ * by [E2.1.a/b/c], and every vignette encounter instance/share table is
+ * included in the `supabase_realtime` publication. Tables in the
+ * publication broadcast row-level changes to subscribed clients, which is
+ * what powers multiplayer sync for shared settlements, collaborator-visible
+ * custom rules text, and shared vignette encounter state.
  *
  * If a new settlement-scoped table or a custom catalog is added to the
  * schema without being added to the publication, this test fails with a
@@ -186,6 +187,25 @@ describe('Realtime publication membership', () => {
     'encounter_monster_level_mood'
   ] as const
 
+  /**
+   * Source of truth: every vignette encounter instance/share table whose
+   * rows must broadcast to owners and collaborators. Mirrors the
+   * `vignette_realtime_tables` array in
+   * `20260613000005_vignette_realtime_publication.sql`.
+   */
+  const EXPECTED_VIGNETTE_TABLES = [
+    'vignette_encounter',
+    'vignette_encounter_monster',
+    'vignette_encounter_survivor',
+    'vignette_encounter_survivor_fighting_art',
+    'vignette_encounter_survivor_secret_fighting_art',
+    'vignette_encounter_survivor_disorder',
+    'vignette_encounter_survivor_ability_impairment',
+    'vignette_encounter_survivor_status',
+    'vignette_encounter_gear_grid',
+    'vignette_encounter_shared_user'
+  ] as const
+
   it('includes every settlement-scoped table in `supabase_realtime`', async () => {
     const { data, error } = await admin.rpc('realtime_publication_tables')
 
@@ -264,6 +284,20 @@ describe('Realtime publication membership', () => {
     const missing = EXPECTED_CATALOG_SUB_ROW_TABLES.filter(
       (t) => !actual.has(t)
     )
+
+    expect(missing).toEqual([])
+  })
+
+  // [VIG-01.05] acceptance: vignette encounter gameplay and sharing tables
+  // are in the publication so later owner/collaborator subscriptions can
+  // receive encounter, monster, survivor, gear-grid, and share/revoke events.
+  it('includes every vignette encounter table in `supabase_realtime` ([VIG-01.05])', async () => {
+    const { data, error } = await admin.rpc('realtime_publication_tables')
+
+    expect(error).toBeNull()
+    const rows = (data ?? []) as { tablename: string }[]
+    const actual = new Set(rows.map((r) => r.tablename))
+    const missing = EXPECTED_VIGNETTE_TABLES.filter((t) => !actual.has(t))
 
     expect(missing).toEqual([])
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.91.1",
+  "version": "0.91.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.91.1",
+      "version": "0.91.2",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.91.1",
+  "version": "0.91.2",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260613000005_vignette_realtime_publication.sql
+++ b/supabase/migrations/20260613000005_vignette_realtime_publication.sql
@@ -1,0 +1,56 @@
+--------------------------------------------------------------------------------
+-- VIG-01.05: Add vignette encounter tables to `supabase_realtime`.
+--
+-- Vignette encounter instances are independent from settlement gameplay, so
+-- their mutable showdown state and sharing rows need their own publication
+-- membership before owner/collaborator clients can receive live changes.
+--
+-- The RLS policies from `20260613000004_vignette_rls_policies.sql` still gate
+-- delivery. Adding a table here only makes eligible INSERT / UPDATE / DELETE
+-- events available to Supabase Realtime; it does not widen row visibility.
+--
+-- `vignette_encounter_shared_user` is included so later user-level listeners can
+-- observe invite and revoke events for the Vignette Encounters surface.
+--
+-- One guarded loop mirrors the catalog realtime migrations and keeps replays or
+-- partial local applications from failing if a table was already added.
+--
+-- Citations:
+--   GitHub issue #334 ([VIG-01.05])
+--   docs/vignette-encounters-implementation-plan.md Realtime section
+--   supabase/migrations/20260519000000_catalog_realtime_publication.sql
+--   supabase/migrations/20260613000002_vignette_instance_tables.sql
+--   supabase/migrations/20260613000003_vignette_sharing_entitlement.sql
+--   supabase/migrations/20260613000004_vignette_rls_policies.sql
+--------------------------------------------------------------------------------
+do $$
+declare
+	vignette_table_name text;
+	vignette_realtime_tables text [] := array [
+		'vignette_encounter',
+		'vignette_encounter_monster',
+		'vignette_encounter_survivor',
+		'vignette_encounter_survivor_fighting_art',
+		'vignette_encounter_survivor_secret_fighting_art',
+		'vignette_encounter_survivor_disorder',
+		'vignette_encounter_survivor_ability_impairment',
+		'vignette_encounter_survivor_status',
+		'vignette_encounter_gear_grid',
+		'vignette_encounter_shared_user'
+	];
+begin
+	foreach vignette_table_name in array vignette_realtime_tables loop
+		if not exists (
+			select 1
+			from pg_publication_tables
+			where pubname = 'supabase_realtime'
+				and schemaname = 'public'
+				and tablename = vignette_table_name
+		) then
+			execute format(
+				'alter publication supabase_realtime add table public.%I',
+				vignette_table_name
+			);
+		end if;
+	end loop;
+end $$;


### PR DESCRIPTION
## Summary
- Add a VIG-01.05 Supabase migration that registers vignette encounter gameplay and sharing tables with `supabase_realtime`.
- Extend realtime publication integration coverage with the expected vignette table membership list.
- Bump the package version to `0.91.2`.

## Dependencies
- No dependency changes.

## Tests
- `npx prettier --check __tests__/integration/realtime-publication.test.ts supabase/migrations/20260613000005_vignette_realtime_publication.sql package.json package-lock.json`
- `npx supabase db reset --local --yes`
- `npm run integration-test -- __tests__/integration/realtime-publication.test.ts`

Closes #334
