### PR TITLE
[VIG-01.06] Seed initial vignette encounter fixture data

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,25 +67,6 @@ jobs:
           node-version-file: .node-version
           cache: npm
 
-      - name: Setup Supabase CLI
-        id: setup-supabase
-        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
-        with:
-          version: latest
-
-      - name: Start Supabase
-        id: supabase-start
-        run: supabase start
-
-      - name: Export Supabase Env
-        id: supabase-env
-        run: |
-          {
-            echo "SUPABASE_URL=$(supabase status -o env | awk -F'=' '/^API_URL=/ {print $2}' | tr -d '"')"
-            echo "SUPABASE_ANON_KEY=$(supabase status -o env | awk -F'=' '/^ANON_KEY=/ {print $2}' | tr -d '"')"
-            echo "SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o env | awk -F'=' '/^SERVICE_ROLE_KEY=/ {print $2}' | tr -d '"')"
-          } >> "$GITHUB_ENV"
-
       - name: Install Dependencies
         id: install
         run: npm install
@@ -97,7 +78,7 @@ jobs:
       - if: ${{ always() }}
         name: Stop Supabase
         id: supabase-stop
-        run: supabase stop || true
+        run: npx supabase stop || true
 
   ui-tests:
     name: UI Tests (Playwright - ${{ matrix.label }})

--- a/__tests__/integration/realtime-publication.test.ts
+++ b/__tests__/integration/realtime-publication.test.ts
@@ -191,18 +191,22 @@ describe('Realtime publication membership', () => {
    * Source of truth: every vignette encounter instance/share table whose
    * rows must broadcast to owners and collaborators. Mirrors the
    * `vignette_realtime_tables` array in
-   * `20260613000005_vignette_realtime_publication.sql`.
+   * `20260616010944_reshape_vignette_tables.sql` plus later active
+   * monster-state publication migrations.
    */
   const EXPECTED_VIGNETTE_TABLES = [
     'vignette_encounter',
+    'vignette_encounter_ai_deck',
     'vignette_encounter_monster',
+    'vignette_encounter_monster_mood',
+    'vignette_encounter_monster_trait',
+    'vignette_encounter_monster_survivor_status',
     'vignette_encounter_survivor',
+    'vignette_encounter_survivor_ability_impairment',
+    'vignette_encounter_survivor_disorder',
     'vignette_encounter_survivor_fighting_art',
     'vignette_encounter_survivor_secret_fighting_art',
-    'vignette_encounter_survivor_disorder',
-    'vignette_encounter_survivor_ability_impairment',
-    'vignette_encounter_survivor_status',
-    'vignette_encounter_gear_grid',
+    'vignette_encounter_survivor_gear_grid',
     'vignette_encounter_shared_user'
   ] as const
 

--- a/__tests__/integration/rls/vignette-sharing.test.ts
+++ b/__tests__/integration/rls/vignette-sharing.test.ts
@@ -7,29 +7,56 @@ import {
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 /**
- * RLS — Vignette Encounter Sharing
+ * RLS - Vignette Encounter Sharing
  *
  * Exercises vignette instance ownership, collaboration, and sharing policies
- * introduced for VIG-01.04 / GitHub issue #332.
+ * against the final VIG-01 active encounter schema.
  */
 describe('RLS: vignette encounter sharing', () => {
   let owner: TestUser
   let collaborator: TestUser
   let stranger: TestUser
-  const vignetteEncounterDefinitionIds: string[] = []
+  const vignetteMonsterIds: string[] = []
+  const moodIds: string[] = []
+  const traitIds: string[] = []
+  const survivorStatusIds: string[] = []
+  let vignetteMonsterId: string
   let vignetteEncounterId: string
+  let vignetteEncounterAiDeckId: string
   let vignetteEncounterMonsterId: string
+  let vignetteEncounterMonsterMoodId: string
+  let vignetteEncounterMonsterTraitId: string
+  let vignetteEncounterMonsterSurvivorStatusId: string
   let vignetteEncounterSurvivorId: string
   let vignetteEncounterGearGridId: string
+  let moodId: string
+  let alternateMoodId: string
+  let traitId: string
+  let alternateTraitId: string
+  let survivorStatusId: string
+  let alternateSurvivorStatusId: string
 
   beforeAll(async () => {
     owner = await createTestUser()
     collaborator = await createTestUser()
     stranger = await createTestUser()
+    const primaryCards = await seedMonsterStateCards('primary')
+    moodId = primaryCards.moodId
+    traitId = primaryCards.traitId
+    survivorStatusId = primaryCards.survivorStatusId
+    const alternateCards = await seedMonsterStateCards('alternate')
+    alternateMoodId = alternateCards.moodId
+    alternateTraitId = alternateCards.traitId
+    alternateSurvivorStatusId = alternateCards.survivorStatusId
+    vignetteMonsterId = await seedVignetteMonster()
     vignetteEncounterId = await seedVignetteEncounter(owner.id)
     const stateIds =
       await seedVignetteEncounterGameplayState(vignetteEncounterId)
+    vignetteEncounterAiDeckId = stateIds.aiDeckId
     vignetteEncounterMonsterId = stateIds.monsterId
+    vignetteEncounterMonsterMoodId = stateIds.monsterMoodId
+    vignetteEncounterMonsterTraitId = stateIds.monsterTraitId
+    vignetteEncounterMonsterSurvivorStatusId = stateIds.monsterSurvivorStatusId
     vignetteEncounterSurvivorId = stateIds.survivorId
     vignetteEncounterGearGridId = stateIds.gearGridId
   })
@@ -39,15 +66,62 @@ describe('RLS: vignette encounter sharing', () => {
     await deleteTestUser(collaborator.id)
     await deleteTestUser(stranger.id)
 
-    if (vignetteEncounterDefinitionIds.length > 0) {
-      await admin
-        .from('vignette_encounter_definition')
-        .delete()
-        .in('id', vignetteEncounterDefinitionIds)
+    if (vignetteMonsterIds.length > 0) {
+      await admin.from('vignette_monster').delete().in('id', vignetteMonsterIds)
+    }
+    if (moodIds.length > 0) await admin.from('mood').delete().in('id', moodIds)
+    if (traitIds.length > 0)
+      await admin.from('trait').delete().in('id', traitIds)
+    if (survivorStatusIds.length > 0) {
+      await admin.from('survivor_status').delete().in('id', survivorStatusIds)
     }
   })
 
-  async function seedVignetteEncounter(userId: string): Promise<string> {
+  async function seedMonsterStateCards(label: string): Promise<{
+    moodId: string
+    traitId: string
+    survivorStatusId: string
+  }> {
+    const suffix = `${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+    const { data: mood, error: moodError } = await admin
+      .from('mood')
+      .insert({ custom: false, mood_name: `RLS Vignette Mood ${suffix}` })
+      .select('id')
+      .single()
+    expect(moodError).toBeNull()
+    expect(mood).not.toBeNull()
+    moodIds.push(mood!.id)
+
+    const { data: trait, error: traitError } = await admin
+      .from('trait')
+      .insert({ custom: false, trait_name: `RLS Vignette Trait ${suffix}` })
+      .select('id')
+      .single()
+    expect(traitError).toBeNull()
+    expect(trait).not.toBeNull()
+    traitIds.push(trait!.id)
+
+    const { data: survivorStatus, error: survivorStatusError } = await admin
+      .from('survivor_status')
+      .insert({
+        custom: false,
+        survivor_status_name: `RLS Vignette Status ${suffix}`
+      })
+      .select('id')
+      .single()
+    expect(survivorStatusError).toBeNull()
+    expect(survivorStatus).not.toBeNull()
+    survivorStatusIds.push(survivorStatus!.id)
+
+    return {
+      moodId: mood!.id,
+      traitId: trait!.id,
+      survivorStatusId: survivorStatus!.id
+    }
+  }
+
+  async function seedVignetteMonster(): Promise<string> {
     const { data: quarry, error: quarryError } = await admin
       .from('quarry')
       .select('id')
@@ -56,40 +130,39 @@ describe('RLS: vignette encounter sharing', () => {
     expect(quarryError).toBeNull()
     expect(quarry).not.toBeNull()
 
-    const { data: definition, error: definitionError } = await admin
-      .from('vignette_encounter_definition')
+    const { data: monster, error: monsterError } = await admin
+      .from('vignette_monster')
       .insert({
-        name: 'RLS Test Vignette',
-        slug: `rls-test-vignette-${Date.now()}`,
+        monster_name: `RLS Test Vignette ${Date.now()}`,
         source_monster_type: 'QUARRY',
-        source_quarry_id: quarry!.id,
-        published: true
+        source_quarry_id: quarry!.id
       })
       .select('id')
       .single()
-    expect(definitionError).toBeNull()
-    expect(definition).not.toBeNull()
+    expect(monsterError).toBeNull()
+    expect(monster).not.toBeNull()
 
-    const vignetteEncounterDefinitionId = definition!.id
-    vignetteEncounterDefinitionIds.push(vignetteEncounterDefinitionId)
+    const monsterId = monster!.id
+    vignetteMonsterIds.push(monsterId)
 
-    const { data: level, error: levelError } = await admin
-      .from('vignette_encounter_level')
+    const { error: levelError } = await admin
+      .from('vignette_monster_level')
       .insert({
-        vignette_encounter_definition_id: vignetteEncounterDefinitionId,
+        vignette_monster_id: monsterId,
         level_number: 1
       })
-      .select('id')
-      .single()
     expect(levelError).toBeNull()
-    expect(level).not.toBeNull()
 
+    return monsterId
+  }
+
+  async function seedVignetteEncounter(userId: string): Promise<string> {
     const { data: encounter, error: encounterError } = await admin
       .from('vignette_encounter')
       .insert({
         user_id: userId,
-        vignette_encounter_definition_id: vignetteEncounterDefinitionId,
-        vignette_encounter_level_id: level!.id
+        vignette_monster_id: vignetteMonsterId,
+        level_number: 1
       })
       .select('id')
       .single()
@@ -101,7 +174,15 @@ describe('RLS: vignette encounter sharing', () => {
 
   async function seedVignetteEncounterGameplayState(
     encounterId: string
-  ): Promise<{ monsterId: string; survivorId: string; gearGridId: string }> {
+  ): Promise<{
+    aiDeckId: string
+    monsterId: string
+    monsterMoodId: string
+    monsterTraitId: string
+    monsterSurvivorStatusId: string
+    survivorId: string
+    gearGridId: string
+  }> {
     const { data: gear, error: gearError } = await admin
       .from('gear')
       .select('id')
@@ -110,17 +191,64 @@ describe('RLS: vignette encounter sharing', () => {
     expect(gearError).toBeNull()
     expect(gear).not.toBeNull()
 
+    const { data: aiDeck, error: aiDeckError } = await admin
+      .from('vignette_encounter_ai_deck')
+      .insert({ vignette_encounter_id: encounterId, basic_cards: 1 })
+      .select('id')
+      .single()
+    expect(aiDeckError).toBeNull()
+    expect(aiDeck).not.toBeNull()
+
     const { data: monster, error: monsterError } = await admin
       .from('vignette_encounter_monster')
-      .insert({ vignette_encounter_id: encounterId })
+      .insert({
+        ai_deck_id: aiDeck!.id,
+        vignette_encounter_id: encounterId,
+        monster_name: 'RLS Vignette Monster'
+      })
       .select('id')
       .single()
     expect(monsterError).toBeNull()
     expect(monster).not.toBeNull()
 
+    const { data: monsterMood, error: monsterMoodError } = await admin
+      .from('vignette_encounter_monster_mood')
+      .insert({
+        vignette_encounter_monster_id: monster!.id,
+        mood_id: moodId
+      })
+      .select('id')
+      .single()
+    expect(monsterMoodError).toBeNull()
+    expect(monsterMood).not.toBeNull()
+
+    const { data: monsterTrait, error: monsterTraitError } = await admin
+      .from('vignette_encounter_monster_trait')
+      .insert({
+        vignette_encounter_monster_id: monster!.id,
+        trait_id: traitId
+      })
+      .select('id')
+      .single()
+    expect(monsterTraitError).toBeNull()
+    expect(monsterTrait).not.toBeNull()
+
+    const { data: monsterSurvivorStatus, error: monsterSurvivorStatusError } =
+      await admin
+        .from('vignette_encounter_monster_survivor_status')
+        .insert({
+          vignette_encounter_monster_id: monster!.id,
+          survivor_status_id: survivorStatusId
+        })
+        .select('id')
+        .single()
+    expect(monsterSurvivorStatusError).toBeNull()
+    expect(monsterSurvivorStatus).not.toBeNull()
+
     const { data: survivor, error: survivorError } = await admin
       .from('vignette_encounter_survivor')
       .insert({
+        vignette_monster_id: vignetteMonsterId,
         vignette_encounter_id: encounterId,
         survivor_name: 'RLS Vignette Survivor'
       })
@@ -130,7 +258,7 @@ describe('RLS: vignette encounter sharing', () => {
     expect(survivor).not.toBeNull()
 
     const { data: gearGrid, error: gearGridError } = await admin
-      .from('vignette_encounter_gear_grid')
+      .from('vignette_encounter_survivor_gear_grid')
       .insert({
         vignette_encounter_survivor_id: survivor!.id,
         gear_id: gear!.id,
@@ -143,10 +271,76 @@ describe('RLS: vignette encounter sharing', () => {
     expect(gearGrid).not.toBeNull()
 
     return {
+      aiDeckId: aiDeck!.id,
       monsterId: monster!.id,
+      monsterMoodId: monsterMood!.id,
+      monsterTraitId: monsterTrait!.id,
+      monsterSurvivorStatusId: monsterSurvivorStatus!.id,
       survivorId: survivor!.id,
       gearGridId: gearGrid!.id
     }
+  }
+
+  function monsterStateCases(cardIds: {
+    moodId: string
+    traitId: string
+    survivorStatusId: string
+  }): Array<{
+    table:
+      | 'vignette_encounter_monster_mood'
+      | 'vignette_encounter_monster_trait'
+      | 'vignette_encounter_monster_survivor_status'
+    cardColumn: 'mood_id' | 'trait_id' | 'survivor_status_id'
+    cardId: string
+  }> {
+    return [
+      {
+        table: 'vignette_encounter_monster_mood',
+        cardColumn: 'mood_id',
+        cardId: cardIds.moodId
+      },
+      {
+        table: 'vignette_encounter_monster_trait',
+        cardColumn: 'trait_id',
+        cardId: cardIds.traitId
+      },
+      {
+        table: 'vignette_encounter_monster_survivor_status',
+        cardColumn: 'survivor_status_id',
+        cardId: cardIds.survivorStatusId
+      }
+    ]
+  }
+
+  function seededMonsterStateCases(): Array<{
+    table:
+      | 'vignette_encounter_monster_mood'
+      | 'vignette_encounter_monster_trait'
+      | 'vignette_encounter_monster_survivor_status'
+    cardColumn: 'mood_id' | 'trait_id' | 'survivor_status_id'
+    cardId: string
+    rowId: string
+  }> {
+    return [
+      {
+        table: 'vignette_encounter_monster_mood',
+        cardColumn: 'mood_id',
+        cardId: moodId,
+        rowId: vignetteEncounterMonsterMoodId
+      },
+      {
+        table: 'vignette_encounter_monster_trait',
+        cardColumn: 'trait_id',
+        cardId: traitId,
+        rowId: vignetteEncounterMonsterTraitId
+      },
+      {
+        table: 'vignette_encounter_monster_survivor_status',
+        cardColumn: 'survivor_status_id',
+        cardId: survivorStatusId,
+        rowId: vignetteEncounterMonsterSurvivorStatusId
+      }
+    ]
   }
 
   async function setUserSubscription(
@@ -169,27 +363,40 @@ describe('RLS: vignette encounter sharing', () => {
     expect(error).toBeNull()
   }
 
-  it('allows the owner to create and update their own active vignette instance', async () => {
+  async function shareWithCollaborator(): Promise<void> {
+    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await clearShares()
+
+    const { error } = await owner.client
+      .from('vignette_encounter_shared_user')
+      .insert({
+        vignette_encounter_id: vignetteEncounterId,
+        shared_user_id: collaborator.id
+      })
+    expect(error).toBeNull()
+  }
+
+  it('allows the owner to create and update their own vignette instance', async () => {
     const tempOwner = await createTestUser()
     const tempEncounterId = await seedVignetteEncounter(tempOwner.id)
 
     const { data: selected, error: selectError } = await tempOwner.client
       .from('vignette_encounter')
-      .select('id, round')
+      .select('id, turn')
       .eq('id', tempEncounterId)
     expect(selectError).toBeNull()
-    expect(selected).toEqual([{ id: tempEncounterId, round: 1 }])
+    expect(selected).toEqual([{ id: tempEncounterId, turn: 'MONSTER' }])
 
     const { data: updated, error: updateError } = await tempOwner.client
       .from('vignette_encounter')
-      .update({ round: 2, notes: 'Owner keeps the lantern high' })
+      .update({ turn: 'SURVIVOR', notes: 'Owner keeps the lantern high' })
       .eq('id', tempEncounterId)
-      .select('id, round, notes')
+      .select('id, turn, notes')
     expect(updateError).toBeNull()
     expect(updated).toEqual([
       {
         id: tempEncounterId,
-        round: 2,
+        turn: 'SURVIVOR',
         notes: 'Owner keeps the lantern high'
       }
     ])
@@ -197,30 +404,7 @@ describe('RLS: vignette encounter sharing', () => {
     await deleteTestUser(tempOwner.id)
   })
 
-  it('allows the owner to end their own active vignette instance', async () => {
-    const tempOwner = await createTestUser()
-    const tempEncounterId = await seedVignetteEncounter(tempOwner.id)
-    const endedAt = new Date().toISOString()
-
-    const { data, error } = await tempOwner.client
-      .from('vignette_encounter')
-      .update({ status: 'ENDED', ended_at: endedAt })
-      .eq('id', tempEncounterId)
-      .select('id, status, ended_at')
-    expect(error).toBeNull()
-    expect(data).toEqual([
-      {
-        id: tempEncounterId,
-        status: 'ENDED',
-        ended_at: expect.any(String)
-      }
-    ])
-    expect(new Date(data![0].ended_at!).toISOString()).toBe(endedAt)
-
-    await deleteTestUser(tempOwner.id)
-  })
-
-  it('allows the owner to delete their own active vignette instance', async () => {
+  it('allows the owner to delete their own vignette instance', async () => {
     const tempOwner = await createTestUser()
     const tempEncounterId = await seedVignetteEncounter(tempOwner.id)
 
@@ -241,52 +425,59 @@ describe('RLS: vignette encounter sharing', () => {
   })
 
   it('allows a collaborator to read and update active gameplay state', async () => {
-    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
-    await clearShares()
-
-    const { error: shareError } = await owner.client
-      .from('vignette_encounter_shared_user')
-      .insert({
-        vignette_encounter_id: vignetteEncounterId,
-        shared_user_id: collaborator.id,
-        created_by: owner.id
-      })
-    expect(shareError).toBeNull()
+    await shareWithCollaborator()
 
     const { data: encounterRows, error: encounterSelectError } =
       await collaborator.client
         .from('vignette_encounter')
-        .select('id, round')
+        .select('id, turn')
         .eq('id', vignetteEncounterId)
     expect(encounterSelectError).toBeNull()
-    expect(encounterRows).toEqual([{ id: vignetteEncounterId, round: 1 }])
+    expect(encounterRows).toEqual([
+      { id: vignetteEncounterId, turn: 'MONSTER' }
+    ])
 
     const { data: encounterUpdate, error: encounterUpdateError } =
       await collaborator.client
         .from('vignette_encounter')
-        .update({ round: 2, notes: 'Collaborator trims the wick' })
+        .update({ turn: 'SURVIVOR', notes: 'Collaborator trims the wick' })
         .eq('id', vignetteEncounterId)
-        .select('id, round, notes')
+        .select('id, turn, notes')
     expect(encounterUpdateError).toBeNull()
     expect(encounterUpdate).toEqual([
       {
         id: vignetteEncounterId,
-        round: 2,
+        turn: 'SURVIVOR',
         notes: 'Collaborator trims the wick'
+      }
+    ])
+
+    const { data: aiDeckUpdate, error: aiDeckUpdateError } =
+      await collaborator.client
+        .from('vignette_encounter_ai_deck')
+        .update({ basic_cards: 2, advanced_cards: 1 })
+        .eq('id', vignetteEncounterAiDeckId)
+        .select('id, basic_cards, advanced_cards')
+    expect(aiDeckUpdateError).toBeNull()
+    expect(aiDeckUpdate).toEqual([
+      {
+        id: vignetteEncounterAiDeckId,
+        basic_cards: 2,
+        advanced_cards: 1
       }
     ])
 
     const { data: monsterUpdate, error: monsterUpdateError } =
       await collaborator.client
         .from('vignette_encounter_monster')
-        .update({ current_wounds: 3, knocked_down: true })
+        .update({ wounds: 3, knocked_down: true })
         .eq('id', vignetteEncounterMonsterId)
-        .select('id, current_wounds, knocked_down')
+        .select('id, wounds, knocked_down')
     expect(monsterUpdateError).toBeNull()
     expect(monsterUpdate).toEqual([
       {
         id: vignetteEncounterMonsterId,
-        current_wounds: 3,
+        wounds: 3,
         knocked_down: true
       }
     ])
@@ -294,21 +485,36 @@ describe('RLS: vignette encounter sharing', () => {
     const { data: survivorUpdate, error: survivorUpdateError } =
       await collaborator.client
         .from('vignette_encounter_survivor')
-        .update({ survival: 2, notes: 'The survivor refuses the dark' })
+        .update({
+          activation_used: true,
+          bleeding_tokens: 1,
+          knocked_down: true,
+          movement_used: true,
+          notes: 'The survivor refuses the dark',
+          survival: 2,
+          survival_tokens: -1
+        })
         .eq('id', vignetteEncounterSurvivorId)
-        .select('id, survival, notes')
+        .select(
+          'id, activation_used, bleeding_tokens, knocked_down, movement_used, survival, survival_tokens, notes'
+        )
     expect(survivorUpdateError).toBeNull()
     expect(survivorUpdate).toEqual([
       {
         id: vignetteEncounterSurvivorId,
+        activation_used: true,
+        bleeding_tokens: 1,
+        knocked_down: true,
+        movement_used: true,
         survival: 2,
+        survival_tokens: -1,
         notes: 'The survivor refuses the dark'
       }
     ])
 
     const { data: gearGridUpdate, error: gearGridUpdateError } =
       await collaborator.client
-        .from('vignette_encounter_gear_grid')
+        .from('vignette_encounter_survivor_gear_grid')
         .update({ row_number: 1, column_number: 1 })
         .eq('id', vignetteEncounterGearGridId)
         .select('id, row_number, column_number')
@@ -322,24 +528,106 @@ describe('RLS: vignette encounter sharing', () => {
     ])
   })
 
-  it('prevents a collaborator from ending or deleting a vignette instance', async () => {
-    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
-    await clearShares()
+  it('allows the owner to read and manage active monster state cards', async () => {
+    for (const stateCase of seededMonsterStateCases()) {
+      const { data: selected, error: selectError } = await owner.client
+        .from(stateCase.table)
+        .select(`id, ${stateCase.cardColumn}`)
+        .eq('id', stateCase.rowId)
+      expect(selectError).toBeNull()
+      expect(selected).toEqual([
+        {
+          id: stateCase.rowId,
+          [stateCase.cardColumn]: stateCase.cardId
+        }
+      ])
+    }
 
-    const { error: shareError } = await owner.client
-      .from('vignette_encounter_shared_user')
-      .insert({
-        vignette_encounter_id: vignetteEncounterId,
-        shared_user_id: collaborator.id,
-        created_by: owner.id
+    for (const stateCase of monsterStateCases({
+      moodId: alternateMoodId,
+      traitId: alternateTraitId,
+      survivorStatusId: alternateSurvivorStatusId
+    })) {
+      const { data: inserted, error: insertError } = await owner.client
+        .from(stateCase.table)
+        .insert({
+          vignette_encounter_monster_id: vignetteEncounterMonsterId,
+          [stateCase.cardColumn]: stateCase.cardId
+        })
+        .select(`id, ${stateCase.cardColumn}`)
+        .single()
+      expect(insertError).toBeNull()
+      expect(inserted).toMatchObject({
+        [stateCase.cardColumn]: stateCase.cardId
       })
-    expect(shareError).toBeNull()
 
-    const { error: endError } = await collaborator.client
-      .from('vignette_encounter')
-      .update({ status: 'ENDED', ended_at: new Date().toISOString() })
-      .eq('id', vignetteEncounterId)
-    expect(endError).not.toBeNull()
+      const { error: deleteError } = await owner.client
+        .from(stateCase.table)
+        .delete()
+        .eq('id', inserted!.id)
+      expect(deleteError).toBeNull()
+
+      const { data: remaining, error: remainingError } = await admin
+        .from(stateCase.table)
+        .select('id')
+        .eq('id', inserted!.id)
+      expect(remainingError).toBeNull()
+      expect(remaining).toEqual([])
+    }
+  })
+
+  it('allows collaborators to read and manage active monster state cards', async () => {
+    await shareWithCollaborator()
+
+    for (const stateCase of seededMonsterStateCases()) {
+      const { data: selected, error: selectError } = await collaborator.client
+        .from(stateCase.table)
+        .select(`id, ${stateCase.cardColumn}`)
+        .eq('id', stateCase.rowId)
+      expect(selectError).toBeNull()
+      expect(selected).toEqual([
+        {
+          id: stateCase.rowId,
+          [stateCase.cardColumn]: stateCase.cardId
+        }
+      ])
+    }
+
+    for (const stateCase of monsterStateCases({
+      moodId: alternateMoodId,
+      traitId: alternateTraitId,
+      survivorStatusId: alternateSurvivorStatusId
+    })) {
+      const { data: inserted, error: insertError } = await collaborator.client
+        .from(stateCase.table)
+        .insert({
+          vignette_encounter_monster_id: vignetteEncounterMonsterId,
+          [stateCase.cardColumn]: stateCase.cardId
+        })
+        .select(`id, ${stateCase.cardColumn}`)
+        .single()
+      expect(insertError).toBeNull()
+      expect(inserted).toMatchObject({
+        [stateCase.cardColumn]: stateCase.cardId
+      })
+
+      const { error: deleteError } = await collaborator.client
+        .from(stateCase.table)
+        .delete()
+        .eq('id', inserted!.id)
+      expect(deleteError).toBeNull()
+
+      const { data: remaining, error: remainingError } = await admin
+        .from(stateCase.table)
+        .select('id')
+        .eq('id', inserted!.id)
+      expect(remainingError).toBeNull()
+      expect(remaining).toEqual([])
+    }
+  })
+
+  it('prevents a collaborator from deleting a vignette instance', async () => {
+    await shareWithCollaborator()
 
     const { error: deleteError } = await collaborator.client
       .from('vignette_encounter')
@@ -349,15 +637,14 @@ describe('RLS: vignette encounter sharing', () => {
 
     const { data: remaining, error: remainingError } = await admin
       .from('vignette_encounter')
-      .select('id, status')
+      .select('id')
       .eq('id', vignetteEncounterId)
     expect(remainingError).toBeNull()
-    expect(remaining).toEqual([{ id: vignetteEncounterId, status: 'ACTIVE' }])
+    expect(remaining).toEqual([{ id: vignetteEncounterId }])
   })
 
   it('prevents strangers from reading or mutating vignette instance rows', async () => {
-    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
-    await clearShares()
+    await shareWithCollaborator()
 
     const { data: encounterRows, error: encounterSelectError } =
       await stranger.client
@@ -369,7 +656,7 @@ describe('RLS: vignette encounter sharing', () => {
 
     const { data: updateRows, error: updateError } = await stranger.client
       .from('vignette_encounter_monster')
-      .update({ current_wounds: 9 })
+      .update({ wounds: 9 })
       .eq('id', vignetteEncounterMonsterId)
       .select('id')
     expect(updateError).toBeNull()
@@ -377,12 +664,46 @@ describe('RLS: vignette encounter sharing', () => {
 
     const { data: monsterRows, error: monsterRowsError } = await admin
       .from('vignette_encounter_monster')
-      .select('id, current_wounds')
+      .select('id, wounds')
       .eq('id', vignetteEncounterMonsterId)
     expect(monsterRowsError).toBeNull()
-    expect(monsterRows).toEqual([
-      { id: vignetteEncounterMonsterId, current_wounds: 3 }
-    ])
+    expect(monsterRows).toEqual([{ id: vignetteEncounterMonsterId, wounds: 3 }])
+  })
+
+  it('prevents strangers from reading or mutating active monster state cards', async () => {
+    await shareWithCollaborator()
+
+    for (const stateCase of seededMonsterStateCases()) {
+      const { data: selected, error: selectError } = await stranger.client
+        .from(stateCase.table)
+        .select(`id, ${stateCase.cardColumn}`)
+        .eq('id', stateCase.rowId)
+      expect(selectError).toBeNull()
+      expect(selected).toEqual([])
+
+      const { data: inserted, error: insertError } = await stranger.client
+        .from(stateCase.table)
+        .insert({
+          vignette_encounter_monster_id: vignetteEncounterMonsterId,
+          [stateCase.cardColumn]: stateCase.cardId
+        })
+        .select('id')
+      expect(insertError).not.toBeNull()
+      expect(inserted).toBeNull()
+
+      const { error: deleteError } = await stranger.client
+        .from(stateCase.table)
+        .delete()
+        .eq('id', stateCase.rowId)
+      expect(deleteError).toBeNull()
+
+      const { data: remaining, error: remainingError } = await admin
+        .from(stateCase.table)
+        .select('id')
+        .eq('id', stateCase.rowId)
+      expect(remainingError).toBeNull()
+      expect(remaining).toEqual([{ id: stateCase.rowId }])
+    }
   })
 
   it('denies share creation for a free owner', async () => {
@@ -393,37 +714,25 @@ describe('RLS: vignette encounter sharing', () => {
       .from('vignette_encounter_shared_user')
       .insert({
         vignette_encounter_id: vignetteEncounterId,
-        shared_user_id: collaborator.id,
-        created_by: owner.id
+        shared_user_id: collaborator.id
       })
 
     expect(error).not.toBeNull()
   })
 
   it('allows an active Lantern Hoard owner to share with a free collaborator', async () => {
-    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
-    await clearShares()
-
-    const { error: insertError } = await owner.client
-      .from('vignette_encounter_shared_user')
-      .insert({
-        vignette_encounter_id: vignetteEncounterId,
-        shared_user_id: collaborator.id,
-        created_by: owner.id
-      })
-    expect(insertError).toBeNull()
+    await shareWithCollaborator()
 
     const { data: collaboratorRows, error: collaboratorSelectError } =
       await collaborator.client
         .from('vignette_encounter_shared_user')
-        .select('vignette_encounter_id, shared_user_id, created_by')
+        .select('vignette_encounter_id, shared_user_id')
         .eq('vignette_encounter_id', vignetteEncounterId)
     expect(collaboratorSelectError).toBeNull()
     expect(collaboratorRows).toEqual([
       {
         vignette_encounter_id: vignetteEncounterId,
-        shared_user_id: collaborator.id,
-        created_by: owner.id
+        shared_user_id: collaborator.id
       }
     ])
 
@@ -437,25 +746,14 @@ describe('RLS: vignette encounter sharing', () => {
   })
 
   it('prevents non-owners and collaborators from managing shares', async () => {
-    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
+    await shareWithCollaborator()
     await setUserSubscription(collaborator.id, 'lantern_hoard', 'active')
-    await clearShares()
-
-    const { error: ownerInsertError } = await owner.client
-      .from('vignette_encounter_shared_user')
-      .insert({
-        vignette_encounter_id: vignetteEncounterId,
-        shared_user_id: collaborator.id,
-        created_by: owner.id
-      })
-    expect(ownerInsertError).toBeNull()
 
     const { error: collaboratorInsertError } = await collaborator.client
       .from('vignette_encounter_shared_user')
       .insert({
         vignette_encounter_id: vignetteEncounterId,
-        shared_user_id: stranger.id,
-        created_by: collaborator.id
+        shared_user_id: stranger.id
       })
     expect(collaboratorInsertError).not.toBeNull()
 
@@ -489,23 +787,14 @@ describe('RLS: vignette encounter sharing', () => {
   })
 
   it('prevents duplicate shares for the same vignette and collaborator', async () => {
-    await setUserSubscription(owner.id, 'lantern_hoard', 'active')
-    await clearShares()
-
-    const share = {
-      vignette_encounter_id: vignetteEncounterId,
-      shared_user_id: collaborator.id,
-      created_by: owner.id
-    }
-
-    const { error: firstInsertError } = await owner.client
-      .from('vignette_encounter_shared_user')
-      .insert(share)
-    expect(firstInsertError).toBeNull()
+    await shareWithCollaborator()
 
     const { error: duplicateInsertError } = await owner.client
       .from('vignette_encounter_shared_user')
-      .insert(share)
+      .insert({
+        vignette_encounter_id: vignetteEncounterId,
+        shared_user_id: collaborator.id
+      })
     expect(duplicateInsertError).not.toBeNull()
 
     const { data: shareRows, error: shareRowsError } = await admin
@@ -524,8 +813,7 @@ describe('RLS: vignette encounter sharing', () => {
       .from('vignette_encounter_shared_user')
       .insert({
         vignette_encounter_id: vignetteEncounterId,
-        shared_user_id: owner.id,
-        created_by: owner.id
+        shared_user_id: owner.id
       })
 
     expect(error).not.toBeNull()

--- a/__tests__/integration/vignette-seed-fixtures.test.ts
+++ b/__tests__/integration/vignette-seed-fixtures.test.ts
@@ -6,52 +6,48 @@ import {
 } from '@/__tests__/integration/helpers/supabase'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-const SINGLE_MONSTER_FIXTURE_SLUG = 'fixture-lantern-raked-lion'
-const MULTI_MONSTER_FIXTURE_SLUG = 'fixture-three-witches-at-the-door'
-const EXPECTED_FIXTURE_SLUGS = [
-  SINGLE_MONSTER_FIXTURE_SLUG,
-  MULTI_MONSTER_FIXTURE_SLUG
+const KILLENIUM_BUTCHER_FIXTURE_NAME = 'Killenium Butcher'
+const SCREAMING_NUKALOPE_FIXTURE_NAME = 'Screaming Nukalope'
+const WHITE_GIGALION_FIXTURE_NAME = 'White Gigalion'
+const EXPECTED_FIXTURE_NAMES = [
+  KILLENIUM_BUTCHER_FIXTURE_NAME,
+  SCREAMING_NUKALOPE_FIXTURE_NAME,
+  WHITE_GIGALION_FIXTURE_NAME
 ] as const
 
-interface FixtureDefinition {
+interface FixtureMonster {
   id: string
-  name: string
-  slug: string
-  description: string | null
+  monster_name: string
+  multi_monster: boolean
   source_monster_type: 'NEMESIS' | 'QUARRY'
   source_nemesis_id: string | null
   source_quarry_id: string | null
-  published: boolean
 }
 
-interface FixtureLevel {
-  id: string
-  vignette_encounter_definition_id: string
+interface FixtureMonsterLevel {
+  vignette_monster_id: string
   level_number: number
+  movement: number
+  speed: number
+  accuracy: number
+  evasion: number
+  damage: number
+  toughness: number
+  life: number | null
+  ai_deck_remaining: number
 }
 
-interface FixtureSurvivorTemplate {
-  id: string
-  vignette_encounter_definition_id: string
+interface FixtureSurvivor {
+  vignette_monster_id: string
   survivor_name: string
-  notes: string
-}
-
-interface LevelJunctionRow {
-  vignette_encounter_level_id: string
-}
-
-interface SurvivorTemplateJunctionRow {
-  vignette_survivor_template_id: string
 }
 
 /**
- * Integration — Vignette Seed Fixtures
+ * Integration - Vignette Seed Fixtures
  *
- * Locks down the fixture-only vignette encounter catalog rows seeded for
- * VIG-01.06. These rows intentionally exercise published quarry and nemesis
- * source relationships, single and multi-monster source data, level setup
- * junctions, survivor templates, and gear-grid templates.
+ * Locks down the VIG-01.06 fixture catalog rows against the final vignette
+ * monster and survivor schema. The current fixtures cover one nemesis source
+ * and two quarry sources, with four preset survivors for each encounter.
  */
 describe('Vignette seed fixtures', () => {
   let authenticatedUser: TestUser
@@ -64,235 +60,167 @@ describe('Vignette seed fixtures', () => {
     if (authenticatedUser) await deleteTestUser(authenticatedUser.id)
   })
 
-  it('seeds visible published fixture definitions for single and multi-monster sources', async () => {
+  it('seeds visible fixture monsters for nemesis and quarry sources', async () => {
     const { data, error } = await authenticatedUser.client
-      .from('vignette_encounter_definition')
+      .from('vignette_monster')
       .select(
-        'id, name, slug, description, source_monster_type, source_nemesis_id, source_quarry_id, published'
+        'id, monster_name, multi_monster, source_monster_type, source_nemesis_id, source_quarry_id'
       )
-      .in('slug', EXPECTED_FIXTURE_SLUGS)
-      .order('sort_order')
+      .in('monster_name', EXPECTED_FIXTURE_NAMES)
+      .order('monster_name')
 
     expect(error).toBeNull()
 
-    const definitions = (data ?? []) as FixtureDefinition[]
-    expect(definitions).toHaveLength(EXPECTED_FIXTURE_SLUGS.length)
-    expect(definitions.every((definition) => definition.published)).toBe(true)
-    expect(
-      definitions.every((definition) => definition.name.startsWith('[Fixture]'))
-    ).toBe(true)
-    expect(
-      definitions.every((definition) =>
-        definition.description?.startsWith('Fixture-only')
-      )
-    ).toBe(true)
-
-    const definitionBySlug = toMapBySlug(definitions)
-    const singleMonsterDefinition = definitionBySlug.get(
-      SINGLE_MONSTER_FIXTURE_SLUG
-    )
-    const multiMonsterDefinition = definitionBySlug.get(
-      MULTI_MONSTER_FIXTURE_SLUG
+    const monsters = (data ?? []) as FixtureMonster[]
+    expect(monsters).toHaveLength(EXPECTED_FIXTURE_NAMES.length)
+    expect(monsters.map((monster) => monster.monster_name)).toEqual(
+      sorted([...EXPECTED_FIXTURE_NAMES])
     )
 
-    expect(singleMonsterDefinition).toBeDefined()
-    expect(multiMonsterDefinition).toBeDefined()
-    if (!singleMonsterDefinition || !multiMonsterDefinition) {
-      throw new Error('Expected vignette fixture definitions were not seeded.')
-    }
-
-    expect(singleMonsterDefinition.source_monster_type).toBe('QUARRY')
-    expect(singleMonsterDefinition.source_nemesis_id).toBeNull()
-    expect(singleMonsterDefinition.source_quarry_id).not.toBeNull()
-
-    expect(multiMonsterDefinition.source_monster_type).toBe('NEMESIS')
-    expect(multiMonsterDefinition.source_nemesis_id).not.toBeNull()
-    expect(multiMonsterDefinition.source_quarry_id).toBeNull()
-
-    const { data: quarrySource, error: quarrySourceError } = await admin
-      .from('quarry')
-      .select('monster_name, multi_monster')
-      .eq('id', singleMonsterDefinition.source_quarry_id)
-      .single()
-    expect(quarrySourceError).toBeNull()
-    expect(quarrySource).toMatchObject({
-      monster_name: 'White Lion',
-      multi_monster: false
+    const monsterByName = toMapByName(monsters)
+    expect(monsterByName.get(KILLENIUM_BUTCHER_FIXTURE_NAME)).toMatchObject({
+      multi_monster: false,
+      source_monster_type: 'NEMESIS',
+      source_quarry_id: null
+    })
+    expect(monsterByName.get(SCREAMING_NUKALOPE_FIXTURE_NAME)).toMatchObject({
+      multi_monster: false,
+      source_monster_type: 'QUARRY',
+      source_nemesis_id: null
+    })
+    expect(monsterByName.get(WHITE_GIGALION_FIXTURE_NAME)).toMatchObject({
+      multi_monster: false,
+      source_monster_type: 'QUARRY',
+      source_nemesis_id: null
     })
 
-    const { data: nemesisSource, error: nemesisSourceError } = await admin
-      .from('nemesis')
-      .select('monster_name, multi_monster')
-      .eq('id', multiMonsterDefinition.source_nemesis_id)
-      .single()
-    expect(nemesisSourceError).toBeNull()
-    expect(nemesisSource).toMatchObject({
-      monster_name: 'Red Witches',
-      multi_monster: true
-    })
+    await expectSourceMonsterName(
+      'nemesis',
+      monsterByName.get(KILLENIUM_BUTCHER_FIXTURE_NAME)!.source_nemesis_id!,
+      KILLENIUM_BUTCHER_FIXTURE_NAME
+    )
+    await expectSourceMonsterName(
+      'quarry',
+      monsterByName.get(SCREAMING_NUKALOPE_FIXTURE_NAME)!.source_quarry_id!,
+      SCREAMING_NUKALOPE_FIXTURE_NAME
+    )
+    await expectSourceMonsterName(
+      'quarry',
+      monsterByName.get(WHITE_GIGALION_FIXTURE_NAME)!.source_quarry_id!,
+      WHITE_GIGALION_FIXTURE_NAME
+    )
   })
 
-  it('seeds level moods, traits, and survivor statuses for every fixture level', async () => {
-    const definitions = await getFixtureDefinitions()
-    const definitionIds = definitions.map((definition) => definition.id)
-
+  it('seeds the Killenium Butcher vignette monster level', async () => {
+    const monsters = await getFixtureMonsters()
+    const killeniumButcher = toMapByName(monsters).get(
+      KILLENIUM_BUTCHER_FIXTURE_NAME
+    )!
     const { data, error } = await admin
-      .from('vignette_encounter_level')
-      .select('id, vignette_encounter_definition_id, level_number')
-      .in('vignette_encounter_definition_id', definitionIds)
-      .order('sort_order')
+      .from('vignette_monster_level')
+      .select(
+        'vignette_monster_id, level_number, movement, speed, accuracy, evasion, damage, toughness, life, ai_deck_remaining'
+      )
+      .eq('vignette_monster_id', killeniumButcher.id)
+
+    expect(error).toBeNull()
+    expect((data ?? []) as FixtureMonsterLevel[]).toEqual([
+      {
+        vignette_monster_id: killeniumButcher.id,
+        level_number: 2,
+        movement: 5,
+        speed: 1,
+        accuracy: 0,
+        evasion: 0,
+        damage: 1,
+        toughness: 13,
+        life: 0,
+        ai_deck_remaining: 15
+      }
+    ])
+  })
+
+  it('seeds four survivor presets for each fixture monster', async () => {
+    const monsters = await getFixtureMonsters()
+    const monsterById = toMapById(monsters)
+    const { data, error } = await admin
+      .from('vignette_survivor')
+      .select('vignette_monster_id, survivor_name')
+      .in(
+        'vignette_monster_id',
+        monsters.map((monster) => monster.id)
+      )
+      .order('survivor_name')
 
     expect(error).toBeNull()
 
-    const levels = (data ?? []) as FixtureLevel[]
-    expect(levels).toHaveLength(4)
-    expect(countBy(levels, 'vignette_encounter_definition_id')).toEqual(
-      new Map(definitionIds.map((definitionId) => [definitionId, 2]))
+    const survivors = (data ?? []) as FixtureSurvivor[]
+    expect(survivors).toHaveLength(12)
+    expect(countBy(survivors, 'vignette_monster_id')).toEqual(
+      new Map(monsters.map((monster) => [monster.id, 4]))
     )
 
-    const levelIds = levels.map((level) => level.id)
-    const [moodResult, traitResult, survivorStatusResult] = await Promise.all([
-      admin
-        .from('vignette_encounter_level_mood')
-        .select('vignette_encounter_level_id')
-        .in('vignette_encounter_level_id', levelIds),
-      admin
-        .from('vignette_encounter_level_trait')
-        .select('vignette_encounter_level_id')
-        .in('vignette_encounter_level_id', levelIds),
-      admin
-        .from('vignette_encounter_level_survivor_status')
-        .select('vignette_encounter_level_id')
-        .in('vignette_encounter_level_id', levelIds)
-    ])
-
-    expect(moodResult.error).toBeNull()
-    expect(traitResult.error).toBeNull()
-    expect(survivorStatusResult.error).toBeNull()
-
-    expect(levelIdsFrom(moodResult.data)).toEqual(sorted(levelIds))
-    expect(levelIdsFrom(traitResult.data)).toEqual(sorted(levelIds))
-    expect(levelIdsFrom(survivorStatusResult.data)).toEqual(sorted(levelIds))
-  })
-
-  it('seeds survivor templates, survivor template links, and gear grids', async () => {
-    const definitions = await getFixtureDefinitions()
-    const definitionBySlug = toMapBySlug(definitions)
-    const singleMonsterDefinition = definitionBySlug.get(
-      SINGLE_MONSTER_FIXTURE_SLUG
-    )
-    const multiMonsterDefinition = definitionBySlug.get(
-      MULTI_MONSTER_FIXTURE_SLUG
-    )
-
-    expect(singleMonsterDefinition).toBeDefined()
-    expect(multiMonsterDefinition).toBeDefined()
-    if (!singleMonsterDefinition || !multiMonsterDefinition) {
-      throw new Error('Expected vignette fixture definitions were not seeded.')
+    const survivorNamesByMonster = new Map<string, string[]>()
+    for (const survivor of survivors) {
+      const monsterName = monsterById.get(
+        survivor.vignette_monster_id
+      )!.monster_name
+      survivorNamesByMonster.set(monsterName, [
+        ...(survivorNamesByMonster.get(monsterName) ?? []),
+        survivor.survivor_name
+      ])
     }
 
-    const definitionIds = definitions.map((definition) => definition.id)
-    const { data, error } = await admin
-      .from('vignette_survivor_template')
-      .select('id, vignette_encounter_definition_id, survivor_name, notes')
-      .in('vignette_encounter_definition_id', definitionIds)
-      .order('sort_order')
-
-    expect(error).toBeNull()
-
-    const survivorTemplates = (data ?? []) as FixtureSurvivorTemplate[]
-    expect(survivorTemplates).toHaveLength(5)
     expect(
-      survivorTemplates.every((template) =>
-        template.survivor_name.startsWith('[Fixture]')
-      )
-    ).toBe(true)
+      sorted(survivorNamesByMonster.get(KILLENIUM_BUTCHER_FIXTURE_NAME) ?? [])
+    ).toEqual(['Brave', 'Forgot', 'Hollow', 'Red'])
     expect(
-      survivorTemplates.every((template) =>
-        template.notes.startsWith('Fixture-only')
-      )
-    ).toBe(true)
-
-    const survivorTemplateCounts = countBy(
-      survivorTemplates,
-      'vignette_encounter_definition_id'
-    )
-    expect(survivorTemplateCounts.get(singleMonsterDefinition.id)).toBe(2)
-    expect(survivorTemplateCounts.get(multiMonsterDefinition.id)).toBe(3)
-
-    const survivorTemplateIds = survivorTemplates.map((template) => template.id)
-    const [
-      gearGridResult,
-      fightingArtResult,
-      secretFightingArtResult,
-      disorderResult,
-      abilityImpairmentResult,
-      survivorStatusResult
-    ] = await Promise.all([
-      admin
-        .from('vignette_survivor_template_gear_grid')
-        .select('vignette_survivor_template_id')
-        .in('vignette_survivor_template_id', survivorTemplateIds),
-      admin
-        .from('vignette_survivor_template_fighting_art')
-        .select('vignette_survivor_template_id')
-        .in('vignette_survivor_template_id', survivorTemplateIds),
-      admin
-        .from('vignette_survivor_template_secret_fighting_art')
-        .select('vignette_survivor_template_id')
-        .in('vignette_survivor_template_id', survivorTemplateIds),
-      admin
-        .from('vignette_survivor_template_disorder')
-        .select('vignette_survivor_template_id')
-        .in('vignette_survivor_template_id', survivorTemplateIds),
-      admin
-        .from('vignette_survivor_template_ability_impairment')
-        .select('vignette_survivor_template_id')
-        .in('vignette_survivor_template_id', survivorTemplateIds),
-      admin
-        .from('vignette_survivor_template_survivor_status')
-        .select('vignette_survivor_template_id')
-        .in('vignette_survivor_template_id', survivorTemplateIds)
-    ])
-
-    expect(gearGridResult.error).toBeNull()
-    expect(fightingArtResult.error).toBeNull()
-    expect(secretFightingArtResult.error).toBeNull()
-    expect(disorderResult.error).toBeNull()
-    expect(abilityImpairmentResult.error).toBeNull()
-    expect(survivorStatusResult.error).toBeNull()
-
-    expect(survivorTemplateIdsFrom(gearGridResult.data)).toEqual(
-      sorted(survivorTemplateIds)
-    )
-    expect((fightingArtResult.data ?? []).length).toBeGreaterThan(0)
-    expect((secretFightingArtResult.data ?? []).length).toBeGreaterThan(0)
-    expect((disorderResult.data ?? []).length).toBeGreaterThan(0)
-    expect((abilityImpairmentResult.data ?? []).length).toBeGreaterThan(0)
-    expect((survivorStatusResult.data ?? []).length).toBeGreaterThan(0)
+      sorted(survivorNamesByMonster.get(SCREAMING_NUKALOPE_FIXTURE_NAME) ?? [])
+    ).toEqual(['Ashbloom', 'Ashroot', 'Gnostin', 'Monday'])
+    expect(
+      sorted(survivorNamesByMonster.get(WHITE_GIGALION_FIXTURE_NAME) ?? [])
+    ).toEqual(['Breccia', 'Gadrock', 'Hungry Basalt', 'Rock Knight'])
   })
 })
 
-async function getFixtureDefinitions(): Promise<FixtureDefinition[]> {
+async function getFixtureMonsters(): Promise<FixtureMonster[]> {
   const { data, error } = await admin
-    .from('vignette_encounter_definition')
+    .from('vignette_monster')
     .select(
-      'id, name, slug, description, source_monster_type, source_nemesis_id, source_quarry_id, published'
+      'id, monster_name, multi_monster, source_monster_type, source_nemesis_id, source_quarry_id'
     )
-    .in('slug', EXPECTED_FIXTURE_SLUGS)
-    .order('sort_order')
+    .in('monster_name', EXPECTED_FIXTURE_NAMES)
 
   expect(error).toBeNull()
-  const definitions = (data ?? []) as FixtureDefinition[]
-  expect(definitions).toHaveLength(EXPECTED_FIXTURE_SLUGS.length)
+  const monsters = (data ?? []) as FixtureMonster[]
+  expect(monsters).toHaveLength(EXPECTED_FIXTURE_NAMES.length)
 
-  return definitions
+  return monsters
 }
 
-function toMapBySlug(
-  definitions: FixtureDefinition[]
-): Map<string, FixtureDefinition> {
-  return new Map(definitions.map((definition) => [definition.slug, definition]))
+async function expectSourceMonsterName(
+  tableName: 'nemesis' | 'quarry',
+  sourceMonsterId: string,
+  expectedMonsterName: string
+): Promise<void> {
+  const { data, error } = await admin
+    .from(tableName)
+    .select('monster_name')
+    .eq('id', sourceMonsterId)
+    .single()
+
+  expect(error).toBeNull()
+  expect(data).toEqual({ monster_name: expectedMonsterName })
+}
+
+function toMapByName(monsters: FixtureMonster[]): Map<string, FixtureMonster> {
+  return new Map(monsters.map((monster) => [monster.monster_name, monster]))
+}
+
+function toMapById<Item extends { id: string }>(
+  items: Item[]
+): Map<string, Item> {
+  return new Map(items.map((item) => [item.id, item]))
 }
 
 function countBy<
@@ -306,16 +234,6 @@ function countBy<
   }, new Map<string, number>())
 }
 
-function levelIdsFrom(rows: LevelJunctionRow[] | null): string[] {
-  return sorted((rows ?? []).map((row) => row.vignette_encounter_level_id))
-}
-
-function survivorTemplateIdsFrom(
-  rows: SurvivorTemplateJunctionRow[] | null
-): string[] {
-  return sorted((rows ?? []).map((row) => row.vignette_survivor_template_id))
-}
-
-function sorted(values: string[]): string[] {
-  return [...new Set(values)].sort()
+function sorted(values: readonly string[]): string[] {
+  return [...values].sort()
 }

--- a/__tests__/integration/vignette-seed-fixtures.test.ts
+++ b/__tests__/integration/vignette-seed-fixtures.test.ts
@@ -134,7 +134,7 @@ describe('Vignette seed fixtures', () => {
         evasion: 0,
         damage: 1,
         toughness: 13,
-        life: 0,
+        life: null,
         ai_deck_remaining: 15
       }
     ])

--- a/__tests__/integration/vignette-seed-fixtures.test.ts
+++ b/__tests__/integration/vignette-seed-fixtures.test.ts
@@ -1,0 +1,321 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const SINGLE_MONSTER_FIXTURE_SLUG = 'fixture-lantern-raked-lion'
+const MULTI_MONSTER_FIXTURE_SLUG = 'fixture-three-witches-at-the-door'
+const EXPECTED_FIXTURE_SLUGS = [
+  SINGLE_MONSTER_FIXTURE_SLUG,
+  MULTI_MONSTER_FIXTURE_SLUG
+] as const
+
+interface FixtureDefinition {
+  id: string
+  name: string
+  slug: string
+  description: string | null
+  source_monster_type: 'NEMESIS' | 'QUARRY'
+  source_nemesis_id: string | null
+  source_quarry_id: string | null
+  published: boolean
+}
+
+interface FixtureLevel {
+  id: string
+  vignette_encounter_definition_id: string
+  level_number: number
+}
+
+interface FixtureSurvivorTemplate {
+  id: string
+  vignette_encounter_definition_id: string
+  survivor_name: string
+  notes: string
+}
+
+interface LevelJunctionRow {
+  vignette_encounter_level_id: string
+}
+
+interface SurvivorTemplateJunctionRow {
+  vignette_survivor_template_id: string
+}
+
+/**
+ * Integration — Vignette Seed Fixtures
+ *
+ * Locks down the fixture-only vignette encounter catalog rows seeded for
+ * VIG-01.06. These rows intentionally exercise published quarry and nemesis
+ * source relationships, single and multi-monster source data, level setup
+ * junctions, survivor templates, and gear-grid templates.
+ */
+describe('Vignette seed fixtures', () => {
+  let authenticatedUser: TestUser
+
+  beforeAll(async () => {
+    authenticatedUser = await createTestUser()
+  })
+
+  afterAll(async () => {
+    if (authenticatedUser) await deleteTestUser(authenticatedUser.id)
+  })
+
+  it('seeds visible published fixture definitions for single and multi-monster sources', async () => {
+    const { data, error } = await authenticatedUser.client
+      .from('vignette_encounter_definition')
+      .select(
+        'id, name, slug, description, source_monster_type, source_nemesis_id, source_quarry_id, published'
+      )
+      .in('slug', EXPECTED_FIXTURE_SLUGS)
+      .order('sort_order')
+
+    expect(error).toBeNull()
+
+    const definitions = (data ?? []) as FixtureDefinition[]
+    expect(definitions).toHaveLength(EXPECTED_FIXTURE_SLUGS.length)
+    expect(definitions.every((definition) => definition.published)).toBe(true)
+    expect(
+      definitions.every((definition) => definition.name.startsWith('[Fixture]'))
+    ).toBe(true)
+    expect(
+      definitions.every((definition) =>
+        definition.description?.startsWith('Fixture-only')
+      )
+    ).toBe(true)
+
+    const definitionBySlug = toMapBySlug(definitions)
+    const singleMonsterDefinition = definitionBySlug.get(
+      SINGLE_MONSTER_FIXTURE_SLUG
+    )
+    const multiMonsterDefinition = definitionBySlug.get(
+      MULTI_MONSTER_FIXTURE_SLUG
+    )
+
+    expect(singleMonsterDefinition).toBeDefined()
+    expect(multiMonsterDefinition).toBeDefined()
+    if (!singleMonsterDefinition || !multiMonsterDefinition) {
+      throw new Error('Expected vignette fixture definitions were not seeded.')
+    }
+
+    expect(singleMonsterDefinition.source_monster_type).toBe('QUARRY')
+    expect(singleMonsterDefinition.source_nemesis_id).toBeNull()
+    expect(singleMonsterDefinition.source_quarry_id).not.toBeNull()
+
+    expect(multiMonsterDefinition.source_monster_type).toBe('NEMESIS')
+    expect(multiMonsterDefinition.source_nemesis_id).not.toBeNull()
+    expect(multiMonsterDefinition.source_quarry_id).toBeNull()
+
+    const { data: quarrySource, error: quarrySourceError } = await admin
+      .from('quarry')
+      .select('monster_name, multi_monster')
+      .eq('id', singleMonsterDefinition.source_quarry_id)
+      .single()
+    expect(quarrySourceError).toBeNull()
+    expect(quarrySource).toMatchObject({
+      monster_name: 'White Lion',
+      multi_monster: false
+    })
+
+    const { data: nemesisSource, error: nemesisSourceError } = await admin
+      .from('nemesis')
+      .select('monster_name, multi_monster')
+      .eq('id', multiMonsterDefinition.source_nemesis_id)
+      .single()
+    expect(nemesisSourceError).toBeNull()
+    expect(nemesisSource).toMatchObject({
+      monster_name: 'Red Witches',
+      multi_monster: true
+    })
+  })
+
+  it('seeds level moods, traits, and survivor statuses for every fixture level', async () => {
+    const definitions = await getFixtureDefinitions()
+    const definitionIds = definitions.map((definition) => definition.id)
+
+    const { data, error } = await admin
+      .from('vignette_encounter_level')
+      .select('id, vignette_encounter_definition_id, level_number')
+      .in('vignette_encounter_definition_id', definitionIds)
+      .order('sort_order')
+
+    expect(error).toBeNull()
+
+    const levels = (data ?? []) as FixtureLevel[]
+    expect(levels).toHaveLength(4)
+    expect(countBy(levels, 'vignette_encounter_definition_id')).toEqual(
+      new Map(definitionIds.map((definitionId) => [definitionId, 2]))
+    )
+
+    const levelIds = levels.map((level) => level.id)
+    const [moodResult, traitResult, survivorStatusResult] = await Promise.all([
+      admin
+        .from('vignette_encounter_level_mood')
+        .select('vignette_encounter_level_id')
+        .in('vignette_encounter_level_id', levelIds),
+      admin
+        .from('vignette_encounter_level_trait')
+        .select('vignette_encounter_level_id')
+        .in('vignette_encounter_level_id', levelIds),
+      admin
+        .from('vignette_encounter_level_survivor_status')
+        .select('vignette_encounter_level_id')
+        .in('vignette_encounter_level_id', levelIds)
+    ])
+
+    expect(moodResult.error).toBeNull()
+    expect(traitResult.error).toBeNull()
+    expect(survivorStatusResult.error).toBeNull()
+
+    expect(levelIdsFrom(moodResult.data)).toEqual(sorted(levelIds))
+    expect(levelIdsFrom(traitResult.data)).toEqual(sorted(levelIds))
+    expect(levelIdsFrom(survivorStatusResult.data)).toEqual(sorted(levelIds))
+  })
+
+  it('seeds survivor templates, survivor template links, and gear grids', async () => {
+    const definitions = await getFixtureDefinitions()
+    const definitionBySlug = toMapBySlug(definitions)
+    const singleMonsterDefinition = definitionBySlug.get(
+      SINGLE_MONSTER_FIXTURE_SLUG
+    )
+    const multiMonsterDefinition = definitionBySlug.get(
+      MULTI_MONSTER_FIXTURE_SLUG
+    )
+
+    expect(singleMonsterDefinition).toBeDefined()
+    expect(multiMonsterDefinition).toBeDefined()
+    if (!singleMonsterDefinition || !multiMonsterDefinition) {
+      throw new Error('Expected vignette fixture definitions were not seeded.')
+    }
+
+    const definitionIds = definitions.map((definition) => definition.id)
+    const { data, error } = await admin
+      .from('vignette_survivor_template')
+      .select('id, vignette_encounter_definition_id, survivor_name, notes')
+      .in('vignette_encounter_definition_id', definitionIds)
+      .order('sort_order')
+
+    expect(error).toBeNull()
+
+    const survivorTemplates = (data ?? []) as FixtureSurvivorTemplate[]
+    expect(survivorTemplates).toHaveLength(5)
+    expect(
+      survivorTemplates.every((template) =>
+        template.survivor_name.startsWith('[Fixture]')
+      )
+    ).toBe(true)
+    expect(
+      survivorTemplates.every((template) =>
+        template.notes.startsWith('Fixture-only')
+      )
+    ).toBe(true)
+
+    const survivorTemplateCounts = countBy(
+      survivorTemplates,
+      'vignette_encounter_definition_id'
+    )
+    expect(survivorTemplateCounts.get(singleMonsterDefinition.id)).toBe(2)
+    expect(survivorTemplateCounts.get(multiMonsterDefinition.id)).toBe(3)
+
+    const survivorTemplateIds = survivorTemplates.map((template) => template.id)
+    const [
+      gearGridResult,
+      fightingArtResult,
+      secretFightingArtResult,
+      disorderResult,
+      abilityImpairmentResult,
+      survivorStatusResult
+    ] = await Promise.all([
+      admin
+        .from('vignette_survivor_template_gear_grid')
+        .select('vignette_survivor_template_id')
+        .in('vignette_survivor_template_id', survivorTemplateIds),
+      admin
+        .from('vignette_survivor_template_fighting_art')
+        .select('vignette_survivor_template_id')
+        .in('vignette_survivor_template_id', survivorTemplateIds),
+      admin
+        .from('vignette_survivor_template_secret_fighting_art')
+        .select('vignette_survivor_template_id')
+        .in('vignette_survivor_template_id', survivorTemplateIds),
+      admin
+        .from('vignette_survivor_template_disorder')
+        .select('vignette_survivor_template_id')
+        .in('vignette_survivor_template_id', survivorTemplateIds),
+      admin
+        .from('vignette_survivor_template_ability_impairment')
+        .select('vignette_survivor_template_id')
+        .in('vignette_survivor_template_id', survivorTemplateIds),
+      admin
+        .from('vignette_survivor_template_survivor_status')
+        .select('vignette_survivor_template_id')
+        .in('vignette_survivor_template_id', survivorTemplateIds)
+    ])
+
+    expect(gearGridResult.error).toBeNull()
+    expect(fightingArtResult.error).toBeNull()
+    expect(secretFightingArtResult.error).toBeNull()
+    expect(disorderResult.error).toBeNull()
+    expect(abilityImpairmentResult.error).toBeNull()
+    expect(survivorStatusResult.error).toBeNull()
+
+    expect(survivorTemplateIdsFrom(gearGridResult.data)).toEqual(
+      sorted(survivorTemplateIds)
+    )
+    expect((fightingArtResult.data ?? []).length).toBeGreaterThan(0)
+    expect((secretFightingArtResult.data ?? []).length).toBeGreaterThan(0)
+    expect((disorderResult.data ?? []).length).toBeGreaterThan(0)
+    expect((abilityImpairmentResult.data ?? []).length).toBeGreaterThan(0)
+    expect((survivorStatusResult.data ?? []).length).toBeGreaterThan(0)
+  })
+})
+
+async function getFixtureDefinitions(): Promise<FixtureDefinition[]> {
+  const { data, error } = await admin
+    .from('vignette_encounter_definition')
+    .select(
+      'id, name, slug, description, source_monster_type, source_nemesis_id, source_quarry_id, published'
+    )
+    .in('slug', EXPECTED_FIXTURE_SLUGS)
+    .order('sort_order')
+
+  expect(error).toBeNull()
+  const definitions = (data ?? []) as FixtureDefinition[]
+  expect(definitions).toHaveLength(EXPECTED_FIXTURE_SLUGS.length)
+
+  return definitions
+}
+
+function toMapBySlug(
+  definitions: FixtureDefinition[]
+): Map<string, FixtureDefinition> {
+  return new Map(definitions.map((definition) => [definition.slug, definition]))
+}
+
+function countBy<
+  Item extends Record<Property, string>,
+  Property extends string
+>(items: Item[], property: Property): Map<string, number> {
+  return items.reduce((counts, item) => {
+    const currentCount = counts.get(item[property]) ?? 0
+    counts.set(item[property], currentCount + 1)
+    return counts
+  }, new Map<string, number>())
+}
+
+function levelIdsFrom(rows: LevelJunctionRow[] | null): string[] {
+  return sorted((rows ?? []).map((row) => row.vignette_encounter_level_id))
+}
+
+function survivorTemplateIdsFrom(
+  rows: SurvivorTemplateJunctionRow[] | null
+): string[] {
+  return sorted((rows ?? []).map((row) => row.vignette_survivor_template_id))
+}
+
+function sorted(values: string[]): string[] {
+  return [...new Set(values)].sort()
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5582,307 +5582,291 @@ export type Database = {
       vignette_encounter: {
         Row: {
           created_at: string
-          ended_at: string | null
           id: string
+          level_number: number
           notes: string
-          round: number
-          status: string
           turn: Database["public"]["Enums"]["showdown_turn"]
           updated_at: string
           user_id: string
-          vignette_encounter_definition_id: string
-          vignette_encounter_level_id: string
+          vignette_monster_id: string
         }
         Insert: {
           created_at?: string
-          ended_at?: string | null
           id?: string
+          level_number: number
           notes?: string
-          round?: number
-          status?: string
           turn?: Database["public"]["Enums"]["showdown_turn"]
           updated_at?: string
           user_id: string
-          vignette_encounter_definition_id: string
-          vignette_encounter_level_id: string
+          vignette_monster_id: string
         }
         Update: {
           created_at?: string
-          ended_at?: string | null
           id?: string
+          level_number?: number
           notes?: string
-          round?: number
-          status?: string
           turn?: Database["public"]["Enums"]["showdown_turn"]
           updated_at?: string
           user_id?: string
-          vignette_encounter_definition_id?: string
-          vignette_encounter_level_id?: string
+          vignette_monster_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_encounter_vignette_encounter_definition_id_fkey"
-            columns: ["vignette_encounter_definition_id"]
+            foreignKeyName: "vignette_encounter_vignette_monster_id_fkey"
+            columns: ["vignette_monster_id"]
             isOneToOne: false
-            referencedRelation: "vignette_encounter_definition"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "vignette_encounter_vignette_encounter_level_id_fkey"
-            columns: ["vignette_encounter_level_id"]
-            isOneToOne: false
-            referencedRelation: "vignette_encounter_level"
+            referencedRelation: "vignette_monster"
             referencedColumns: ["id"]
           },
         ]
       }
-      vignette_encounter_definition: {
+      vignette_encounter_ai_deck: {
         Row: {
+          advanced_cards: number
+          basic_cards: number
           created_at: string
-          description: string | null
           id: string
-          name: string
-          published: boolean
-          slug: string
-          sort_order: number
-          source_monster_type: string
-          source_nemesis_id: string | null
-          source_quarry_id: string | null
+          legendary_cards: number
+          overtone_cards: number
           updated_at: string
+          vignette_encounter_id: string
         }
         Insert: {
+          advanced_cards?: number
+          basic_cards?: number
           created_at?: string
-          description?: string | null
           id?: string
-          name: string
-          published?: boolean
-          slug: string
-          sort_order?: number
-          source_monster_type: string
-          source_nemesis_id?: string | null
-          source_quarry_id?: string | null
+          legendary_cards?: number
+          overtone_cards?: number
           updated_at?: string
+          vignette_encounter_id: string
         }
         Update: {
+          advanced_cards?: number
+          basic_cards?: number
           created_at?: string
-          description?: string | null
           id?: string
-          name?: string
-          published?: boolean
-          slug?: string
-          sort_order?: number
-          source_monster_type?: string
-          source_nemesis_id?: string | null
-          source_quarry_id?: string | null
+          legendary_cards?: number
+          overtone_cards?: number
           updated_at?: string
+          vignette_encounter_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_encounter_definition_source_nemesis_id_fkey"
-            columns: ["source_nemesis_id"]
+            foreignKeyName: "vignette_encounter_ai_deck_vignette_encounter_id_fkey"
+            columns: ["vignette_encounter_id"]
             isOneToOne: false
-            referencedRelation: "nemesis"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "vignette_encounter_definition_source_quarry_id_fkey"
-            columns: ["source_quarry_id"]
-            isOneToOne: false
-            referencedRelation: "quarry"
+            referencedRelation: "vignette_encounter"
             referencedColumns: ["id"]
           },
         ]
       }
-      vignette_encounter_gear_grid: {
-        Row: {
-          column_number: number
-          created_at: string
-          gear_id: string
-          id: string
-          row_number: number
-          updated_at: string
-          vignette_encounter_survivor_id: string
-        }
-        Insert: {
-          column_number: number
-          created_at?: string
-          gear_id: string
-          id?: string
-          row_number: number
-          updated_at?: string
-          vignette_encounter_survivor_id: string
-        }
-        Update: {
-          column_number?: number
-          created_at?: string
-          gear_id?: string
-          id?: string
-          row_number?: number
-          updated_at?: string
-          vignette_encounter_survivor_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "vignette_encounter_gear_grid_gear_id_fkey"
-            columns: ["gear_id"]
-            isOneToOne: false
-            referencedRelation: "gear"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "vignette_encounter_gear_grid_vignette_encounter_survivor_i_fkey"
-            columns: ["vignette_encounter_survivor_id"]
-            isOneToOne: false
-            referencedRelation: "vignette_encounter_survivor"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      vignette_encounter_level: {
+      vignette_encounter_monster: {
         Row: {
           accuracy: number
-          ai_deck_size: number | null
-          basic_action: string | null
+          accuracy_tokens: number
+          ai_card_drawn: boolean
+          ai_deck_id: string
+          ai_deck_remaining: number
           created_at: string
           damage: number
+          damage_tokens: number
           evasion: number
-          hit_location_deck_size: number | null
+          evasion_tokens: number
           id: string
-          level_number: number
+          knocked_down: boolean
+          luck: number
+          luck_tokens: number
+          monster_name: string | null
           movement: number
-          sort_order: number
-          special_rules: string | null
+          movement_tokens: number
+          notes: string
+          source_vignette_monster_level_id: string | null
           speed: number
+          speed_tokens: number
+          strength: number
+          strength_tokens: number
           toughness: number
+          toughness_tokens: number
           updated_at: string
-          vignette_encounter_definition_id: string
-          wounds: number | null
+          vignette_encounter_id: string
+          wounds: number
         }
         Insert: {
           accuracy?: number
-          ai_deck_size?: number | null
-          basic_action?: string | null
+          accuracy_tokens?: number
+          ai_card_drawn?: boolean
+          ai_deck_id: string
+          ai_deck_remaining?: number
           created_at?: string
           damage?: number
+          damage_tokens?: number
           evasion?: number
-          hit_location_deck_size?: number | null
+          evasion_tokens?: number
           id?: string
-          level_number: number
+          knocked_down?: boolean
+          luck?: number
+          luck_tokens?: number
+          monster_name?: string | null
           movement?: number
-          sort_order?: number
-          special_rules?: string | null
+          movement_tokens?: number
+          notes?: string
+          source_vignette_monster_level_id?: string | null
           speed?: number
+          speed_tokens?: number
+          strength?: number
+          strength_tokens?: number
           toughness?: number
+          toughness_tokens?: number
           updated_at?: string
-          vignette_encounter_definition_id: string
-          wounds?: number | null
+          vignette_encounter_id: string
+          wounds?: number
         }
         Update: {
           accuracy?: number
-          ai_deck_size?: number | null
-          basic_action?: string | null
+          accuracy_tokens?: number
+          ai_card_drawn?: boolean
+          ai_deck_id?: string
+          ai_deck_remaining?: number
           created_at?: string
           damage?: number
+          damage_tokens?: number
           evasion?: number
-          hit_location_deck_size?: number | null
+          evasion_tokens?: number
           id?: string
-          level_number?: number
+          knocked_down?: boolean
+          luck?: number
+          luck_tokens?: number
+          monster_name?: string | null
           movement?: number
-          sort_order?: number
-          special_rules?: string | null
+          movement_tokens?: number
+          notes?: string
+          source_vignette_monster_level_id?: string | null
           speed?: number
+          speed_tokens?: number
+          strength?: number
+          strength_tokens?: number
           toughness?: number
+          toughness_tokens?: number
           updated_at?: string
-          vignette_encounter_definition_id?: string
-          wounds?: number | null
+          vignette_encounter_id?: string
+          wounds?: number
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_encounter_level_vignette_encounter_definition_id_fkey"
-            columns: ["vignette_encounter_definition_id"]
+            foreignKeyName: "vignette_encounter_monster_ai_deck_id_fkey"
+            columns: ["ai_deck_id"]
+            isOneToOne: true
+            referencedRelation: "vignette_encounter_ai_deck"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_monster_source_vignette_monster_level_i_fkey"
+            columns: ["source_vignette_monster_level_id"]
             isOneToOne: false
-            referencedRelation: "vignette_encounter_definition"
+            referencedRelation: "vignette_monster_level"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_monster_vignette_encounter_id_fkey"
+            columns: ["vignette_encounter_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter"
             referencedColumns: ["id"]
           },
         ]
       }
-      vignette_encounter_level_mood: {
+      vignette_encounter_monster_mood: {
         Row: {
           created_at: string
           id: string
           mood_id: string
-          sort_order: number
+          source_vignette_monster_level_mood_id: string | null
           updated_at: string
-          vignette_encounter_level_id: string
+          vignette_encounter_monster_id: string
         }
         Insert: {
           created_at?: string
           id?: string
           mood_id: string
-          sort_order?: number
+          source_vignette_monster_level_mood_id?: string | null
           updated_at?: string
-          vignette_encounter_level_id: string
+          vignette_encounter_monster_id: string
         }
         Update: {
           created_at?: string
           id?: string
           mood_id?: string
-          sort_order?: number
+          source_vignette_monster_level_mood_id?: string | null
           updated_at?: string
-          vignette_encounter_level_id?: string
+          vignette_encounter_monster_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_encounter_level_mood_mood_id_fkey"
+            foreignKeyName: "vignette_encounter_monster_mo_source_vignette_monster_leve_fkey"
+            columns: ["source_vignette_monster_level_mood_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_monster_level_mood"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_monster_mo_vignette_encounter_monster_i_fkey"
+            columns: ["vignette_encounter_monster_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_monster"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_monster_mood_mood_id_fkey"
             columns: ["mood_id"]
             isOneToOne: false
             referencedRelation: "mood"
             referencedColumns: ["id"]
           },
-          {
-            foreignKeyName: "vignette_encounter_level_mood_vignette_encounter_level_id_fkey"
-            columns: ["vignette_encounter_level_id"]
-            isOneToOne: false
-            referencedRelation: "vignette_encounter_level"
-            referencedColumns: ["id"]
-          },
         ]
       }
-      vignette_encounter_level_survivor_status: {
+      vignette_encounter_monster_survivor_status: {
         Row: {
           created_at: string
           id: string
-          sort_order: number
+          source_vignette_monster_level_survivor_status_id: string | null
           survivor_status_id: string
           updated_at: string
-          vignette_encounter_level_id: string
+          vignette_encounter_monster_id: string
         }
         Insert: {
           created_at?: string
           id?: string
-          sort_order?: number
+          source_vignette_monster_level_survivor_status_id?: string | null
           survivor_status_id: string
           updated_at?: string
-          vignette_encounter_level_id: string
+          vignette_encounter_monster_id: string
         }
         Update: {
           created_at?: string
           id?: string
-          sort_order?: number
+          source_vignette_monster_level_survivor_status_id?: string | null
           survivor_status_id?: string
           updated_at?: string
-          vignette_encounter_level_id?: string
+          vignette_encounter_monster_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_encounter_level_survi_vignette_encounter_level_id_fkey"
-            columns: ["vignette_encounter_level_id"]
+            foreignKeyName: "vignette_encounter_monster_su_source_vignette_monster_leve_fkey"
+            columns: ["source_vignette_monster_level_survivor_status_id"]
             isOneToOne: false
-            referencedRelation: "vignette_encounter_level"
+            referencedRelation: "vignette_monster_level_survivor_status"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "vignette_encounter_level_survivor_statu_survivor_status_id_fkey"
+            foreignKeyName: "vignette_encounter_monster_su_vignette_encounter_monster_i_fkey"
+            columns: ["vignette_encounter_monster_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_monster"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_monster_survivor_sta_survivor_status_id_fkey"
             columns: ["survivor_status_id"]
             isOneToOne: false
             referencedRelation: "survivor_status"
@@ -5890,88 +5874,51 @@ export type Database = {
           },
         ]
       }
-      vignette_encounter_level_trait: {
+      vignette_encounter_monster_trait: {
         Row: {
           created_at: string
           id: string
-          sort_order: number
+          source_vignette_monster_level_trait_id: string | null
           trait_id: string
           updated_at: string
-          vignette_encounter_level_id: string
+          vignette_encounter_monster_id: string
         }
         Insert: {
           created_at?: string
           id?: string
-          sort_order?: number
+          source_vignette_monster_level_trait_id?: string | null
           trait_id: string
           updated_at?: string
-          vignette_encounter_level_id: string
+          vignette_encounter_monster_id: string
         }
         Update: {
           created_at?: string
           id?: string
-          sort_order?: number
+          source_vignette_monster_level_trait_id?: string | null
           trait_id?: string
           updated_at?: string
-          vignette_encounter_level_id?: string
+          vignette_encounter_monster_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_encounter_level_trait_trait_id_fkey"
+            foreignKeyName: "vignette_encounter_monster_tr_source_vignette_monster_leve_fkey"
+            columns: ["source_vignette_monster_level_trait_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_monster_level_trait"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_monster_tr_vignette_encounter_monster_i_fkey"
+            columns: ["vignette_encounter_monster_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_monster"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_monster_trait_trait_id_fkey"
             columns: ["trait_id"]
             isOneToOne: false
             referencedRelation: "trait"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "vignette_encounter_level_trait_vignette_encounter_level_id_fkey"
-            columns: ["vignette_encounter_level_id"]
-            isOneToOne: false
-            referencedRelation: "vignette_encounter_level"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      vignette_encounter_monster: {
-        Row: {
-          created_at: string
-          current_ai_cards: number | null
-          current_hit_location_cards: number | null
-          current_wounds: number | null
-          id: string
-          knocked_down: boolean
-          notes: string
-          updated_at: string
-          vignette_encounter_id: string
-        }
-        Insert: {
-          created_at?: string
-          current_ai_cards?: number | null
-          current_hit_location_cards?: number | null
-          current_wounds?: number | null
-          id?: string
-          knocked_down?: boolean
-          notes?: string
-          updated_at?: string
-          vignette_encounter_id: string
-        }
-        Update: {
-          created_at?: string
-          current_ai_cards?: number | null
-          current_hit_location_cards?: number | null
-          current_wounds?: number | null
-          id?: string
-          knocked_down?: boolean
-          notes?: string
-          updated_at?: string
-          vignette_encounter_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "vignette_encounter_monster_vignette_encounter_id_fkey"
-            columns: ["vignette_encounter_id"]
-            isOneToOne: true
-            referencedRelation: "vignette_encounter"
             referencedColumns: ["id"]
           },
         ]
@@ -5979,20 +5926,23 @@ export type Database = {
       vignette_encounter_shared_user: {
         Row: {
           created_at: string
-          created_by: string
+          id: string
           shared_user_id: string
+          updated_at: string
           vignette_encounter_id: string
         }
         Insert: {
           created_at?: string
-          created_by: string
+          id?: string
           shared_user_id: string
+          updated_at?: string
           vignette_encounter_id: string
         }
         Update: {
           created_at?: string
-          created_by?: string
+          id?: string
           shared_user_id?: string
+          updated_at?: string
           vignette_encounter_id?: string
         }
         Relationships: [
@@ -6048,8 +5998,10 @@ export type Database = {
           movement_tokens: number
           movement_used: boolean
           notes: string
+          priority_target: boolean
           retired: boolean
-          sort_order: number
+          scout: boolean
+          source_vignette_survivor_id: string | null
           speed: number
           speed_tokens: number
           strength: number
@@ -6061,7 +6013,7 @@ export type Database = {
           understanding: number
           updated_at: string
           vignette_encounter_id: string
-          vignette_survivor_template_id: string | null
+          vignette_monster_id: string
           waist_armor: number
           waist_heavy_damage: boolean
           waist_light_damage: boolean
@@ -6103,8 +6055,10 @@ export type Database = {
           movement_tokens?: number
           movement_used?: boolean
           notes?: string
+          priority_target?: boolean
           retired?: boolean
-          sort_order?: number
+          scout?: boolean
+          source_vignette_survivor_id?: string | null
           speed?: number
           speed_tokens?: number
           strength?: number
@@ -6116,7 +6070,7 @@ export type Database = {
           understanding?: number
           updated_at?: string
           vignette_encounter_id: string
-          vignette_survivor_template_id?: string | null
+          vignette_monster_id: string
           waist_armor?: number
           waist_heavy_damage?: boolean
           waist_light_damage?: boolean
@@ -6158,8 +6112,10 @@ export type Database = {
           movement_tokens?: number
           movement_used?: boolean
           notes?: string
+          priority_target?: boolean
           retired?: boolean
-          sort_order?: number
+          scout?: boolean
+          source_vignette_survivor_id?: string | null
           speed?: number
           speed_tokens?: number
           strength?: number
@@ -6171,7 +6127,7 @@ export type Database = {
           understanding?: number
           updated_at?: string
           vignette_encounter_id?: string
-          vignette_survivor_template_id?: string | null
+          vignette_monster_id?: string
           waist_armor?: number
           waist_heavy_damage?: boolean
           waist_light_damage?: boolean
@@ -6180,6 +6136,13 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "vignette_encounter_survivor_source_vignette_survivor_id_fkey"
+            columns: ["source_vignette_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "vignette_encounter_survivor_vignette_encounter_id_fkey"
             columns: ["vignette_encounter_id"]
             isOneToOne: false
@@ -6187,10 +6150,10 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "vignette_encounter_survivor_vignette_survivor_template_id_fkey"
-            columns: ["vignette_survivor_template_id"]
+            foreignKeyName: "vignette_encounter_survivor_vignette_monster_id_fkey"
+            columns: ["vignette_monster_id"]
             isOneToOne: false
-            referencedRelation: "vignette_survivor_template"
+            referencedRelation: "vignette_monster"
             referencedColumns: ["id"]
           },
           {
@@ -6207,7 +6170,7 @@ export type Database = {
           ability_impairment_id: string
           created_at: string
           id: string
-          sort_order: number
+          source_vignette_survivor_ability_impairment_id: string | null
           updated_at: string
           vignette_encounter_survivor_id: string
         }
@@ -6215,7 +6178,7 @@ export type Database = {
           ability_impairment_id: string
           created_at?: string
           id?: string
-          sort_order?: number
+          source_vignette_survivor_ability_impairment_id?: string | null
           updated_at?: string
           vignette_encounter_survivor_id: string
         }
@@ -6223,11 +6186,18 @@ export type Database = {
           ability_impairment_id?: string
           created_at?: string
           id?: string
-          sort_order?: number
+          source_vignette_survivor_ability_impairment_id?: string | null
           updated_at?: string
           vignette_encounter_survivor_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor_a_source_vignette_survivor_abi_fkey"
+            columns: ["source_vignette_survivor_ability_impairment_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor_ability_impairment"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "vignette_encounter_survivor_a_vignette_encounter_survivor__fkey"
             columns: ["vignette_encounter_survivor_id"]
@@ -6249,7 +6219,7 @@ export type Database = {
           created_at: string
           disorder_id: string
           id: string
-          sort_order: number
+          source_vignette_survivor_disorder_id: string | null
           updated_at: string
           vignette_encounter_survivor_id: string
         }
@@ -6257,7 +6227,7 @@ export type Database = {
           created_at?: string
           disorder_id: string
           id?: string
-          sort_order?: number
+          source_vignette_survivor_disorder_id?: string | null
           updated_at?: string
           vignette_encounter_survivor_id: string
         }
@@ -6265,11 +6235,18 @@ export type Database = {
           created_at?: string
           disorder_id?: string
           id?: string
-          sort_order?: number
+          source_vignette_survivor_disorder_id?: string | null
           updated_at?: string
           vignette_encounter_survivor_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor_d_source_vignette_survivor_dis_fkey"
+            columns: ["source_vignette_survivor_disorder_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor_disorder"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "vignette_encounter_survivor_d_vignette_encounter_survivor__fkey"
             columns: ["vignette_encounter_survivor_id"]
@@ -6291,7 +6268,7 @@ export type Database = {
           created_at: string
           fighting_art_id: string
           id: string
-          sort_order: number
+          source_vignette_survivor_fighting_art_id: string | null
           updated_at: string
           vignette_encounter_survivor_id: string
         }
@@ -6299,7 +6276,7 @@ export type Database = {
           created_at?: string
           fighting_art_id: string
           id?: string
-          sort_order?: number
+          source_vignette_survivor_fighting_art_id?: string | null
           updated_at?: string
           vignette_encounter_survivor_id: string
         }
@@ -6307,11 +6284,18 @@ export type Database = {
           created_at?: string
           fighting_art_id?: string
           id?: string
-          sort_order?: number
+          source_vignette_survivor_fighting_art_id?: string | null
           updated_at?: string
           vignette_encounter_survivor_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor_f_source_vignette_survivor_fig_fkey"
+            columns: ["source_vignette_survivor_fighting_art_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor_fighting_art"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "vignette_encounter_survivor_f_vignette_encounter_survivor__fkey"
             columns: ["vignette_encounter_survivor_id"]
@@ -6328,12 +6312,67 @@ export type Database = {
           },
         ]
       }
+      vignette_encounter_survivor_gear_grid: {
+        Row: {
+          column_number: number
+          created_at: string
+          gear_id: string
+          id: string
+          row_number: number
+          source_vignette_survivor_gear_grid_id: string | null
+          updated_at: string
+          vignette_encounter_survivor_id: string
+        }
+        Insert: {
+          column_number: number
+          created_at?: string
+          gear_id: string
+          id?: string
+          row_number: number
+          source_vignette_survivor_gear_grid_id?: string | null
+          updated_at?: string
+          vignette_encounter_survivor_id: string
+        }
+        Update: {
+          column_number?: number
+          created_at?: string
+          gear_id?: string
+          id?: string
+          row_number?: number
+          source_vignette_survivor_gear_grid_id?: string | null
+          updated_at?: string
+          vignette_encounter_survivor_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor_g_source_vignette_survivor_gea_fkey"
+            columns: ["source_vignette_survivor_gear_grid_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor_gear_grid"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_survivor_g_vignette_encounter_survivor__fkey"
+            columns: ["vignette_encounter_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_encounter_survivor"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_encounter_survivor_gear_grid_gear_id_fkey"
+            columns: ["gear_id"]
+            isOneToOne: false
+            referencedRelation: "gear"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       vignette_encounter_survivor_secret_fighting_art: {
         Row: {
           created_at: string
           id: string
           secret_fighting_art_id: string
-          sort_order: number
+          source_vignette_survivor_secret_fighting_art_id: string | null
           updated_at: string
           vignette_encounter_survivor_id: string
         }
@@ -6341,7 +6380,7 @@ export type Database = {
           created_at?: string
           id?: string
           secret_fighting_art_id: string
-          sort_order?: number
+          source_vignette_survivor_secret_fighting_art_id?: string | null
           updated_at?: string
           vignette_encounter_survivor_id: string
         }
@@ -6349,11 +6388,18 @@ export type Database = {
           created_at?: string
           id?: string
           secret_fighting_art_id?: string
-          sort_order?: number
+          source_vignette_survivor_secret_fighting_art_id?: string | null
           updated_at?: string
           vignette_encounter_survivor_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "vignette_encounter_survivor_s_source_vignette_survivor_sec_fkey"
+            columns: ["source_vignette_survivor_secret_fighting_art_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor_secret_fighting_art"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "vignette_encounter_survivor_s_vignette_encounter_survivor__fkey"
             columns: ["vignette_encounter_survivor_id"]
@@ -6370,41 +6416,226 @@ export type Database = {
           },
         ]
       }
-      vignette_encounter_survivor_status: {
+      vignette_monster: {
         Row: {
           created_at: string
           id: string
-          sort_order: number
-          survivor_status_id: string
+          monster_name: string
+          multi_monster: boolean
+          source_monster_type: string
+          source_nemesis_id: string | null
+          source_quarry_id: string | null
           updated_at: string
-          vignette_encounter_survivor_id: string
         }
         Insert: {
           created_at?: string
           id?: string
-          sort_order?: number
-          survivor_status_id: string
+          monster_name: string
+          multi_monster?: boolean
+          source_monster_type: string
+          source_nemesis_id?: string | null
+          source_quarry_id?: string | null
           updated_at?: string
-          vignette_encounter_survivor_id: string
         }
         Update: {
           created_at?: string
           id?: string
-          sort_order?: number
-          survivor_status_id?: string
+          monster_name?: string
+          multi_monster?: boolean
+          source_monster_type?: string
+          source_nemesis_id?: string | null
+          source_quarry_id?: string | null
           updated_at?: string
-          vignette_encounter_survivor_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_encounter_survivor__vignette_encounter_survivor__fkey1"
-            columns: ["vignette_encounter_survivor_id"]
+            foreignKeyName: "vignette_monster_source_nemesis_id_fkey"
+            columns: ["source_nemesis_id"]
             isOneToOne: false
-            referencedRelation: "vignette_encounter_survivor"
+            referencedRelation: "nemesis"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "vignette_encounter_survivor_status_survivor_status_id_fkey"
+            foreignKeyName: "vignette_monster_source_quarry_id_fkey"
+            columns: ["source_quarry_id"]
+            isOneToOne: false
+            referencedRelation: "quarry"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_monster_level: {
+        Row: {
+          accuracy: number
+          accuracy_tokens: number
+          advanced_cards: number
+          ai_deck_remaining: number
+          basic_cards: number
+          created_at: string
+          damage: number
+          damage_tokens: number
+          evasion: number
+          evasion_tokens: number
+          id: string
+          legendary_cards: number
+          level_number: number
+          life: number | null
+          luck: number
+          luck_tokens: number
+          movement: number
+          movement_tokens: number
+          overtone_cards: number
+          speed: number
+          speed_tokens: number
+          strength: number
+          strength_tokens: number
+          sub_monster_name: string | null
+          toughness: number
+          toughness_tokens: number
+          updated_at: string
+          vignette_monster_id: string
+        }
+        Insert: {
+          accuracy?: number
+          accuracy_tokens?: number
+          advanced_cards?: number
+          ai_deck_remaining?: number
+          basic_cards?: number
+          created_at?: string
+          damage?: number
+          damage_tokens?: number
+          evasion?: number
+          evasion_tokens?: number
+          id?: string
+          legendary_cards?: number
+          level_number: number
+          life?: number | null
+          luck?: number
+          luck_tokens?: number
+          movement?: number
+          movement_tokens?: number
+          overtone_cards?: number
+          speed?: number
+          speed_tokens?: number
+          strength?: number
+          strength_tokens?: number
+          sub_monster_name?: string | null
+          toughness?: number
+          toughness_tokens?: number
+          updated_at?: string
+          vignette_monster_id: string
+        }
+        Update: {
+          accuracy?: number
+          accuracy_tokens?: number
+          advanced_cards?: number
+          ai_deck_remaining?: number
+          basic_cards?: number
+          created_at?: string
+          damage?: number
+          damage_tokens?: number
+          evasion?: number
+          evasion_tokens?: number
+          id?: string
+          legendary_cards?: number
+          level_number?: number
+          life?: number | null
+          luck?: number
+          luck_tokens?: number
+          movement?: number
+          movement_tokens?: number
+          overtone_cards?: number
+          speed?: number
+          speed_tokens?: number
+          strength?: number
+          strength_tokens?: number
+          sub_monster_name?: string | null
+          toughness?: number
+          toughness_tokens?: number
+          updated_at?: string
+          vignette_monster_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_monster_level_vignette_monster_id_fkey"
+            columns: ["vignette_monster_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_monster"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_monster_level_mood: {
+        Row: {
+          created_at: string
+          id: string
+          mood_id: string
+          updated_at: string
+          vignette_monster_level_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          mood_id: string
+          updated_at?: string
+          vignette_monster_level_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          mood_id?: string
+          updated_at?: string
+          vignette_monster_level_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_monster_level_mood_mood_id_fkey"
+            columns: ["mood_id"]
+            isOneToOne: false
+            referencedRelation: "mood"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_monster_level_mood_vignette_monster_level_id_fkey"
+            columns: ["vignette_monster_level_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_monster_level"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_monster_level_survivor_status: {
+        Row: {
+          created_at: string
+          id: string
+          survivor_status_id: string
+          updated_at: string
+          vignette_monster_level_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          survivor_status_id: string
+          updated_at?: string
+          vignette_monster_level_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          survivor_status_id?: string
+          updated_at?: string
+          vignette_monster_level_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_monster_level_survivor__vignette_monster_level_id_fkey"
+            columns: ["vignette_monster_level_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_monster_level"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_monster_level_survivor_status_survivor_status_id_fkey"
             columns: ["survivor_status_id"]
             isOneToOne: false
             referencedRelation: "survivor_status"
@@ -6412,7 +6643,46 @@ export type Database = {
           },
         ]
       }
-      vignette_survivor_template: {
+      vignette_monster_level_trait: {
+        Row: {
+          created_at: string
+          id: string
+          trait_id: string
+          updated_at: string
+          vignette_monster_level_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          trait_id: string
+          updated_at?: string
+          vignette_monster_level_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          trait_id?: string
+          updated_at?: string
+          vignette_monster_level_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vignette_monster_level_trait_trait_id_fkey"
+            columns: ["trait_id"]
+            isOneToOne: false
+            referencedRelation: "trait"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vignette_monster_level_trait_vignette_monster_level_id_fkey"
+            columns: ["vignette_monster_level_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_monster_level"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vignette_survivor: {
         Row: {
           accuracy: number
           arm_armor: number
@@ -6428,7 +6698,6 @@ export type Database = {
           luck: number
           movement: number
           notes: string
-          sort_order: number
           speed: number
           strength: number
           survival: number
@@ -6436,7 +6705,7 @@ export type Database = {
           survivor_type: Database["public"]["Enums"]["survivor_type"]
           understanding: number
           updated_at: string
-          vignette_encounter_definition_id: string
+          vignette_monster_id: string
           waist_armor: number
           weapon_proficiency: number
           weapon_type_id: string | null
@@ -6456,7 +6725,6 @@ export type Database = {
           luck?: number
           movement?: number
           notes?: string
-          sort_order?: number
           speed?: number
           strength?: number
           survival?: number
@@ -6464,7 +6732,7 @@ export type Database = {
           survivor_type?: Database["public"]["Enums"]["survivor_type"]
           understanding?: number
           updated_at?: string
-          vignette_encounter_definition_id: string
+          vignette_monster_id: string
           waist_armor?: number
           weapon_proficiency?: number
           weapon_type_id?: string | null
@@ -6484,7 +6752,6 @@ export type Database = {
           luck?: number
           movement?: number
           notes?: string
-          sort_order?: number
           speed?: number
           strength?: number
           survival?: number
@@ -6492,21 +6759,21 @@ export type Database = {
           survivor_type?: Database["public"]["Enums"]["survivor_type"]
           understanding?: number
           updated_at?: string
-          vignette_encounter_definition_id?: string
+          vignette_monster_id?: string
           waist_armor?: number
           weapon_proficiency?: number
           weapon_type_id?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_survivor_template_vignette_encounter_definition_i_fkey"
-            columns: ["vignette_encounter_definition_id"]
+            foreignKeyName: "vignette_survivor_vignette_monster_id_fkey"
+            columns: ["vignette_monster_id"]
             isOneToOne: false
-            referencedRelation: "vignette_encounter_definition"
+            referencedRelation: "vignette_monster"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "vignette_survivor_template_weapon_type_id_fkey"
+            foreignKeyName: "vignette_survivor_weapon_type_id_fkey"
             columns: ["weapon_type_id"]
             isOneToOne: false
             referencedRelation: "weapon_type"
@@ -6514,133 +6781,124 @@ export type Database = {
           },
         ]
       }
-      vignette_survivor_template_ability_impairment: {
+      vignette_survivor_ability_impairment: {
         Row: {
           ability_impairment_id: string
           created_at: string
           id: string
-          sort_order: number
           updated_at: string
-          vignette_survivor_template_id: string
+          vignette_survivor_id: string
         }
         Insert: {
           ability_impairment_id: string
           created_at?: string
           id?: string
-          sort_order?: number
           updated_at?: string
-          vignette_survivor_template_id: string
+          vignette_survivor_id: string
         }
         Update: {
           ability_impairment_id?: string
           created_at?: string
           id?: string
-          sort_order?: number
           updated_at?: string
-          vignette_survivor_template_id?: string
+          vignette_survivor_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_survivor_template_ab_vignette_survivor_template_i_fkey"
-            columns: ["vignette_survivor_template_id"]
-            isOneToOne: false
-            referencedRelation: "vignette_survivor_template"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "vignette_survivor_template_ability_i_ability_impairment_id_fkey"
+            foreignKeyName: "vignette_survivor_ability_impairment_ability_impairment_id_fkey"
             columns: ["ability_impairment_id"]
             isOneToOne: false
             referencedRelation: "ability_impairment"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "vignette_survivor_ability_impairment_vignette_survivor_id_fkey"
+            columns: ["vignette_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor"
+            referencedColumns: ["id"]
+          },
         ]
       }
-      vignette_survivor_template_disorder: {
+      vignette_survivor_disorder: {
         Row: {
           created_at: string
           disorder_id: string
           id: string
-          sort_order: number
           updated_at: string
-          vignette_survivor_template_id: string
+          vignette_survivor_id: string
         }
         Insert: {
           created_at?: string
           disorder_id: string
           id?: string
-          sort_order?: number
           updated_at?: string
-          vignette_survivor_template_id: string
+          vignette_survivor_id: string
         }
         Update: {
           created_at?: string
           disorder_id?: string
           id?: string
-          sort_order?: number
           updated_at?: string
-          vignette_survivor_template_id?: string
+          vignette_survivor_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_survivor_template_di_vignette_survivor_template_i_fkey"
-            columns: ["vignette_survivor_template_id"]
-            isOneToOne: false
-            referencedRelation: "vignette_survivor_template"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "vignette_survivor_template_disorder_disorder_id_fkey"
+            foreignKeyName: "vignette_survivor_disorder_disorder_id_fkey"
             columns: ["disorder_id"]
             isOneToOne: false
             referencedRelation: "disorder"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "vignette_survivor_disorder_vignette_survivor_id_fkey"
+            columns: ["vignette_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor"
+            referencedColumns: ["id"]
+          },
         ]
       }
-      vignette_survivor_template_fighting_art: {
+      vignette_survivor_fighting_art: {
         Row: {
           created_at: string
           fighting_art_id: string
           id: string
-          sort_order: number
           updated_at: string
-          vignette_survivor_template_id: string
+          vignette_survivor_id: string
         }
         Insert: {
           created_at?: string
           fighting_art_id: string
           id?: string
-          sort_order?: number
           updated_at?: string
-          vignette_survivor_template_id: string
+          vignette_survivor_id: string
         }
         Update: {
           created_at?: string
           fighting_art_id?: string
           id?: string
-          sort_order?: number
           updated_at?: string
-          vignette_survivor_template_id?: string
+          vignette_survivor_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_survivor_template_fi_vignette_survivor_template_i_fkey"
-            columns: ["vignette_survivor_template_id"]
-            isOneToOne: false
-            referencedRelation: "vignette_survivor_template"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "vignette_survivor_template_fighting_art_fighting_art_id_fkey"
+            foreignKeyName: "vignette_survivor_fighting_art_fighting_art_id_fkey"
             columns: ["fighting_art_id"]
             isOneToOne: false
             referencedRelation: "fighting_art"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "vignette_survivor_fighting_art_vignette_survivor_id_fkey"
+            columns: ["vignette_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor"
+            referencedColumns: ["id"]
+          },
         ]
       }
-      vignette_survivor_template_gear_grid: {
+      vignette_survivor_gear_grid: {
         Row: {
           column_number: number
           created_at: string
@@ -6648,7 +6906,7 @@ export type Database = {
           id: string
           row_number: number
           updated_at: string
-          vignette_survivor_template_id: string
+          vignette_survivor_id: string
         }
         Insert: {
           column_number: number
@@ -6657,7 +6915,7 @@ export type Database = {
           id?: string
           row_number: number
           updated_at?: string
-          vignette_survivor_template_id: string
+          vignette_survivor_id: string
         }
         Update: {
           column_number?: number
@@ -6666,105 +6924,60 @@ export type Database = {
           id?: string
           row_number?: number
           updated_at?: string
-          vignette_survivor_template_id?: string
+          vignette_survivor_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_survivor_template_ge_vignette_survivor_template_i_fkey"
-            columns: ["vignette_survivor_template_id"]
-            isOneToOne: false
-            referencedRelation: "vignette_survivor_template"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "vignette_survivor_template_gear_grid_gear_id_fkey"
+            foreignKeyName: "vignette_survivor_gear_grid_gear_id_fkey"
             columns: ["gear_id"]
             isOneToOne: false
             referencedRelation: "gear"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "vignette_survivor_gear_grid_vignette_survivor_id_fkey"
+            columns: ["vignette_survivor_id"]
+            isOneToOne: false
+            referencedRelation: "vignette_survivor"
+            referencedColumns: ["id"]
+          },
         ]
       }
-      vignette_survivor_template_secret_fighting_art: {
+      vignette_survivor_secret_fighting_art: {
         Row: {
           created_at: string
           id: string
           secret_fighting_art_id: string
-          sort_order: number
           updated_at: string
-          vignette_survivor_template_id: string
+          vignette_survivor_id: string
         }
         Insert: {
           created_at?: string
           id?: string
           secret_fighting_art_id: string
-          sort_order?: number
           updated_at?: string
-          vignette_survivor_template_id: string
+          vignette_survivor_id: string
         }
         Update: {
           created_at?: string
           id?: string
           secret_fighting_art_id?: string
-          sort_order?: number
           updated_at?: string
-          vignette_survivor_template_id?: string
+          vignette_survivor_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "vignette_survivor_template_se_vignette_survivor_template_i_fkey"
-            columns: ["vignette_survivor_template_id"]
-            isOneToOne: false
-            referencedRelation: "vignette_survivor_template"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "vignette_survivor_template_secret_f_secret_fighting_art_id_fkey"
+            foreignKeyName: "vignette_survivor_secret_fighting_a_secret_fighting_art_id_fkey"
             columns: ["secret_fighting_art_id"]
             isOneToOne: false
             referencedRelation: "secret_fighting_art"
             referencedColumns: ["id"]
           },
-        ]
-      }
-      vignette_survivor_template_survivor_status: {
-        Row: {
-          created_at: string
-          id: string
-          sort_order: number
-          survivor_status_id: string
-          updated_at: string
-          vignette_survivor_template_id: string
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          sort_order?: number
-          survivor_status_id: string
-          updated_at?: string
-          vignette_survivor_template_id: string
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          sort_order?: number
-          survivor_status_id?: string
-          updated_at?: string
-          vignette_survivor_template_id?: string
-        }
-        Relationships: [
           {
-            foreignKeyName: "vignette_survivor_template_su_vignette_survivor_template_i_fkey"
-            columns: ["vignette_survivor_template_id"]
+            foreignKeyName: "vignette_survivor_secret_fighting_art_vignette_survivor_id_fkey"
+            columns: ["vignette_survivor_id"]
             isOneToOne: false
-            referencedRelation: "vignette_survivor_template"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "vignette_survivor_template_survivor_sta_survivor_status_id_fkey"
-            columns: ["survivor_status_id"]
-            isOneToOne: false
-            referencedRelation: "survivor_status"
+            referencedRelation: "vignette_survivor"
             referencedColumns: ["id"]
           },
         ]
@@ -6991,11 +7204,9 @@ export type Database = {
       }
       can_update_vignette_encounter_as_collaborator: {
         Args: {
-          proposed_definition_id: string
-          proposed_ended_at: string
-          proposed_level_id: string
-          proposed_status: string
+          proposed_level_number: number
           proposed_user_id: string
+          proposed_vignette_monster_id: string
           target_vignette_encounter: string
         }
         Returns: boolean
@@ -7003,6 +7214,13 @@ export type Database = {
       check_username_available: {
         Args: { desired_username: string }
         Returns: boolean
+      }
+      create_vignette_encounter_from_catalog: {
+        Args: {
+          target_level_number: number
+          target_vignette_monster_id: string
+        }
+        Returns: string
       }
       get_admin_adoption_metrics: { Args: never; Returns: Json }
       get_settlement_collaborators: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.91.2",
+  "version": "0.91.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.91.2",
+      "version": "0.91.3",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.91.2",
+  "version": "0.91.3",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260613000006_vignette_source_level_links.sql
+++ b/supabase/migrations/20260613000006_vignette_source_level_links.sql
@@ -1,0 +1,212 @@
+--------------------------------------------------------------------------------
+-- Vignette Source Level Links
+-- Connects each vignette level to one or more concrete quarry_level/nemesis_level
+-- rows, and lets active vignette encounters track multiple copied monsters.
+--------------------------------------------------------------------------------
+create table vignette_encounter_level_monster (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_level_id uuid not null references vignette_encounter_level(id) on delete cascade,
+	source_nemesis_level_id uuid references nemesis_level(id) on delete restrict,
+	source_quarry_level_id uuid references quarry_level(id) on delete restrict,
+	sort_order int not null default 0,
+	-- Constraints
+	constraint vignette_encounter_level_monster_source_presence check (
+		(
+			source_nemesis_level_id is not null
+			and source_quarry_level_id is null
+		)
+		or (
+			source_quarry_level_id is not null
+			and source_nemesis_level_id is null
+		)
+	),
+	unique (vignette_encounter_level_id, source_nemesis_level_id),
+	unique (vignette_encounter_level_id, source_quarry_level_id)
+);
+
+alter table vignette_encounter_monster
+drop constraint vignette_encounter_monster_vignette_encounter_id_key;
+
+alter table vignette_encounter_monster
+add column vignette_encounter_level_monster_id uuid references vignette_encounter_level_monster(id) on delete set null,
+add column sort_order int not null default 0;
+
+--------------------------------------------------------------------------------
+-- Validation
+--------------------------------------------------------------------------------
+create or replace function public.validate_vignette_encounter_level_monster_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+declare
+	definition_source_monster_type text;
+	definition_source_nemesis_id uuid;
+	definition_source_quarry_id uuid;
+	vignette_level_number int;
+	source_nemesis_id uuid;
+	source_quarry_id uuid;
+	source_level_number int;
+begin
+	select ved.source_monster_type,
+		ved.source_nemesis_id,
+		ved.source_quarry_id,
+		vel.level_number
+	into definition_source_monster_type,
+		definition_source_nemesis_id,
+		definition_source_quarry_id,
+		vignette_level_number
+	from vignette_encounter_level vel
+		join vignette_encounter_definition ved on ved.id = vel.vignette_encounter_definition_id
+	where vel.id = new.vignette_encounter_level_id;
+
+	if not found then
+		raise exception 'Invalid vignette encounter level source reference' using errcode = '23503';
+	end if;
+
+	if new.source_nemesis_level_id is not null then
+		select nemesis_id,
+			level_number
+		into source_nemesis_id,
+			source_level_number
+		from nemesis_level
+		where id = new.source_nemesis_level_id;
+
+		if not found then
+			raise exception 'Invalid nemesis level source reference' using errcode = '23503';
+		end if;
+
+		if definition_source_monster_type <> 'NEMESIS'
+			or source_nemesis_id is distinct
+			from definition_source_nemesis_id then
+			raise exception 'Nemesis level source must belong to the vignette definition source nemesis' using errcode = '23514';
+		end if;
+	else
+		select quarry_id,
+			level_number
+		into source_quarry_id,
+			source_level_number
+		from quarry_level
+		where id = new.source_quarry_level_id;
+
+		if not found then
+			raise exception 'Invalid quarry level source reference' using errcode = '23503';
+		end if;
+
+		if definition_source_monster_type <> 'QUARRY'
+			or source_quarry_id is distinct
+			from definition_source_quarry_id then
+			raise exception 'Quarry level source must belong to the vignette definition source quarry' using errcode = '23514';
+		end if;
+	end if;
+
+	if source_level_number <> vignette_level_number then
+		raise exception 'Vignette level number must match the source monster level number' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_monster_level_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+declare
+	encounter_level_id uuid;
+	source_vignette_level_id uuid;
+begin
+	if new.vignette_encounter_level_monster_id is null then
+		return new;
+	end if;
+
+	select vignette_encounter_level_id
+	into encounter_level_id
+	from vignette_encounter
+	where id = new.vignette_encounter_id;
+
+	if not found then
+		raise exception 'Invalid vignette encounter monster parent reference' using errcode = '23503';
+	end if;
+
+	select vignette_encounter_level_id
+	into source_vignette_level_id
+	from vignette_encounter_level_monster
+	where id = new.vignette_encounter_level_monster_id;
+
+	if not found then
+		raise exception 'Invalid vignette encounter level monster source reference' using errcode = '23503';
+	end if;
+
+	if source_vignette_level_id is distinct
+	from encounter_level_id then
+		raise exception 'Active vignette monster source must belong to the selected vignette encounter level' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+revoke all on function public.validate_vignette_encounter_level_monster_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_level_monster_source()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_monster_level_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_monster_level_source()
+from anon,
+	authenticated;
+
+create trigger validate_vignette_encounter_level_monster_source before
+insert
+	or
+update on vignette_encounter_level_monster for each row execute function public.validate_vignette_encounter_level_monster_source();
+
+create trigger validate_vignette_encounter_monster_level_source before
+insert
+	or
+update on vignette_encounter_monster for each row execute function public.validate_vignette_encounter_monster_level_source();
+
+--------------------------------------------------------------------------------
+-- Row Level Security
+--------------------------------------------------------------------------------
+alter table vignette_encounter_level_monster enable row level security;
+
+create policy "Allow select for authenticated and published" on vignette_encounter_level_monster for
+select to authenticated using (
+		exists (
+			select 1
+			from vignette_encounter_level vel
+				join vignette_encounter_definition ved on ved.id = vel.vignette_encounter_definition_id
+			where vel.id = vignette_encounter_level_id
+				and ved.published
+		)
+	);
+
+--------------------------------------------------------------------------------
+-- Data API Privileges
+--------------------------------------------------------------------------------
+grant select on table vignette_encounter_level_monster to authenticated;
+revoke insert, update, delete on table vignette_encounter_level_monster from authenticated;
+
+--------------------------------------------------------------------------------
+-- Indexes
+--------------------------------------------------------------------------------
+create index idx_vignette_encounter_level_monster_level on vignette_encounter_level_monster(vignette_encounter_level_id);
+create index idx_vignette_encounter_level_monster_nemesis_level on vignette_encounter_level_monster(source_nemesis_level_id)
+where source_nemesis_level_id is not null;
+create index idx_vignette_encounter_level_monster_quarry_level on vignette_encounter_level_monster(source_quarry_level_id)
+where source_quarry_level_id is not null;
+
+create unique index idx_vignette_encounter_monster_source_unique on vignette_encounter_monster(vignette_encounter_id, vignette_encounter_level_monster_id)
+where vignette_encounter_level_monster_id is not null;
+create index idx_vignette_encounter_monster_encounter on vignette_encounter_monster(vignette_encounter_id);
+create index idx_vignette_encounter_monster_level_monster on vignette_encounter_monster(vignette_encounter_level_monster_id)
+where vignette_encounter_level_monster_id is not null;
+
+--------------------------------------------------------------------------------
+-- Triggers
+--------------------------------------------------------------------------------
+create trigger set_updated_at before
+update on vignette_encounter_level_monster for each row execute function update_updated_at();

--- a/supabase/migrations/20260616010944_reshape_vignette_tables.sql
+++ b/supabase/migrations/20260616010944_reshape_vignette_tables.sql
@@ -1,0 +1,1062 @@
+--------------------------------------------------------------------------------
+-- Reshape Vignette Encounter Tables
+-- Vignette tables are empty in current environments, so this migration drops
+-- the provisional VIG-01 tables and recreates the final catalog and active
+-- encounter schema directly.
+--------------------------------------------------------------------------------
+
+do $$
+declare
+	vignette_table_name text;
+	vignette_realtime_tables text [] := array [
+		'vignette_encounter',
+		'vignette_encounter_ai_deck',
+		'vignette_encounter_monster',
+		'vignette_encounter_survivor',
+		'vignette_encounter_survivor_fighting_art',
+		'vignette_encounter_survivor_secret_fighting_art',
+		'vignette_encounter_survivor_disorder',
+		'vignette_encounter_survivor_ability_impairment',
+		'vignette_encounter_survivor_status',
+		'vignette_encounter_gear_grid',
+		'vignette_encounter_survivor_gear_grid',
+		'vignette_encounter_shared_user'
+	];
+begin
+	if exists (
+		select 1
+		from pg_publication
+		where pubname = 'supabase_realtime'
+	) then
+		foreach vignette_table_name in array vignette_realtime_tables loop
+			if exists (
+				select 1
+				from pg_publication_tables
+				where pubname = 'supabase_realtime'
+					and schemaname = 'public'
+					and tablename = vignette_table_name
+			) then
+				execute format(
+					'alter publication supabase_realtime drop table public.%I',
+					vignette_table_name
+				);
+			end if;
+		end loop;
+	end if;
+end $$;
+
+drop function if exists public.can_update_vignette_encounter_as_collaborator(uuid, uuid, uuid, uuid, text, timestamptz) cascade;
+drop function if exists public.can_update_vignette_encounter_as_collaborator(uuid, uuid, uuid, int) cascade;
+drop function if exists public.can_access_active_vignette_encounter(uuid) cascade;
+drop function if exists public.is_active_vignette_encounter_owner(uuid) cascade;
+drop function if exists public.is_vignette_encounter_collaborator(uuid) cascade;
+drop function if exists public.is_vignette_encounter_owner(uuid) cascade;
+drop function if exists public.can_share_vignette_encounters(uuid) cascade;
+drop function if exists public.validate_vignette_encounter_level_monster_source() cascade;
+drop function if exists public.validate_vignette_encounter_monster_level_source() cascade;
+drop function if exists public.validate_vignette_encounter_level() cascade;
+drop function if exists public.validate_vignette_encounter_monster_ai_deck() cascade;
+drop function if exists public.validate_vignette_encounter_survivor_monster() cascade;
+
+drop table if exists
+	public.vignette_encounter_shared_user,
+	public.vignette_encounter_survivor_gear_grid,
+	public.vignette_encounter_gear_grid,
+	public.vignette_encounter_survivor_status,
+	public.vignette_encounter_survivor_ability_impairment,
+	public.vignette_encounter_survivor_disorder,
+	public.vignette_encounter_survivor_secret_fighting_art,
+	public.vignette_encounter_survivor_fighting_art,
+	public.vignette_encounter_survivor,
+	public.vignette_encounter_monster,
+	public.vignette_encounter_ai_deck,
+	public.vignette_encounter,
+	public.vignette_survivor_gear_grid,
+	public.vignette_survivor_template_gear_grid,
+	public.vignette_survivor_ability_impairment,
+	public.vignette_survivor_template_ability_impairment,
+	public.vignette_survivor_disorder,
+	public.vignette_survivor_template_disorder,
+	public.vignette_survivor_secret_fighting_art,
+	public.vignette_survivor_template_secret_fighting_art,
+	public.vignette_survivor_fighting_art,
+	public.vignette_survivor_template_fighting_art,
+	public.vignette_survivor_template_survivor_status,
+	public.vignette_survivor,
+	public.vignette_survivor_template,
+	public.vignette_monster_level_survivor_status,
+	public.vignette_encounter_level_survivor_status,
+	public.vignette_monster_level_trait,
+	public.vignette_encounter_level_trait,
+	public.vignette_monster_level_mood,
+	public.vignette_encounter_level_mood,
+	public.vignette_encounter_level_monster,
+	public.vignette_monster_level,
+	public.vignette_encounter_level,
+	public.vignette_monster,
+	public.vignette_encounter_definition cascade;
+
+--------------------------------------------------------------------------------
+-- Vignette Monster Catalog
+--------------------------------------------------------------------------------
+create table public.vignette_monster (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	monster_name varchar not null,
+	multi_monster boolean not null default false,
+	source_monster_type text not null check (source_monster_type in ('NEMESIS', 'QUARRY')),
+	source_nemesis_id uuid references public.nemesis(id) on delete restrict,
+	source_quarry_id uuid references public.quarry(id) on delete restrict,
+	-- Constraints
+	constraint vignette_monster_source_presence check (
+		(
+			source_monster_type = 'NEMESIS'
+			and source_nemesis_id is not null
+			and source_quarry_id is null
+		)
+		or (
+			source_monster_type = 'QUARRY'
+			and source_quarry_id is not null
+			and source_nemesis_id is null
+		)
+	)
+);
+
+--------------------------------------------------------------------------------
+-- Vignette Monster Level Catalog
+--------------------------------------------------------------------------------
+create table public.vignette_monster_level (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- AI Deck Data
+	ai_deck_remaining int not null default 0 check (ai_deck_remaining >= 0),
+	basic_cards int not null default 0 check (basic_cards >= 0),
+	advanced_cards int not null default 0 check (advanced_cards >= 0),
+	legendary_cards int not null default 0 check (legendary_cards >= 0),
+	overtone_cards int not null default 0 check (overtone_cards >= 0),
+	-- Base Data
+	accuracy int not null default 0,
+	accuracy_tokens int not null default 0,
+	damage int not null default 0,
+	damage_tokens int not null default 0,
+	evasion int not null default 0,
+	evasion_tokens int not null default 0,
+	level_number int not null check (level_number between 1 and 4),
+	life int check (
+		life is null
+		or life >= 0
+	),
+	luck int not null default 0,
+	luck_tokens int not null default 0,
+	movement int not null default 1,
+	movement_tokens int not null default 0,
+	sub_monster_name varchar,
+	speed int not null default 0,
+	speed_tokens int not null default 0,
+	strength int not null default 0,
+	strength_tokens int not null default 0,
+	toughness int not null default 0,
+	toughness_tokens int not null default 0,
+	vignette_monster_id uuid not null references public.vignette_monster(id) on delete cascade
+);
+
+create table public.vignette_monster_level_mood (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	mood_id uuid not null references public.mood(id) on delete restrict,
+	vignette_monster_level_id uuid not null references public.vignette_monster_level(id) on delete cascade,
+	-- Constraints
+	unique (vignette_monster_level_id, mood_id)
+);
+
+create table public.vignette_monster_level_trait (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	trait_id uuid not null references public.trait(id) on delete restrict,
+	vignette_monster_level_id uuid not null references public.vignette_monster_level(id) on delete cascade,
+	-- Constraints
+	unique (vignette_monster_level_id, trait_id)
+);
+
+create table public.vignette_monster_level_survivor_status (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	survivor_status_id uuid not null references public.survivor_status(id) on delete restrict,
+	vignette_monster_level_id uuid not null references public.vignette_monster_level(id) on delete cascade,
+	-- Constraints
+	unique (vignette_monster_level_id, survivor_status_id)
+);
+
+--------------------------------------------------------------------------------
+-- Vignette Survivor Catalog
+--------------------------------------------------------------------------------
+create table public.vignette_survivor (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_monster_id uuid not null references public.vignette_monster(id) on delete cascade,
+	survivor_name varchar not null check (char_length(survivor_name) <= 100),
+	survivor_type survivor_type not null default 'CORE',
+	gender gender,
+	movement int not null default 5,
+	accuracy int not null default 0,
+	strength int not null default 0,
+	evasion int not null default 0,
+	luck int not null default 0,
+	speed int not null default 0,
+	survival int not null default 0 check (survival >= 0),
+	insanity int not null default 0 check (insanity >= 0),
+	courage int not null default 0 check (courage >= 0),
+	understanding int not null default 0 check (understanding >= 0),
+	weapon_proficiency int not null default 0 check (
+		weapon_proficiency >= 0
+		and weapon_proficiency <= 8
+	),
+	weapon_type_id uuid references public.weapon_type(id) on delete set null,
+	arm_armor int not null default 0 check (arm_armor >= 0),
+	body_armor int not null default 0 check (body_armor >= 0),
+	head_armor int not null default 0 check (head_armor >= 0),
+	leg_armor int not null default 0 check (leg_armor >= 0),
+	waist_armor int not null default 0 check (waist_armor >= 0),
+	notes text not null default ''
+);
+
+create table public.vignette_survivor_ability_impairment (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_survivor_id uuid not null references public.vignette_survivor(id) on delete cascade,
+	ability_impairment_id uuid not null references public.ability_impairment(id) on delete restrict,
+	-- Constraints
+	unique (vignette_survivor_id, ability_impairment_id)
+);
+
+create table public.vignette_survivor_disorder (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_survivor_id uuid not null references public.vignette_survivor(id) on delete cascade,
+	disorder_id uuid not null references public.disorder(id) on delete restrict,
+	-- Constraints
+	unique (vignette_survivor_id, disorder_id)
+);
+
+create table public.vignette_survivor_fighting_art (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_survivor_id uuid not null references public.vignette_survivor(id) on delete cascade,
+	fighting_art_id uuid not null references public.fighting_art(id) on delete restrict,
+	-- Constraints
+	unique (vignette_survivor_id, fighting_art_id)
+);
+
+create table public.vignette_survivor_secret_fighting_art (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	secret_fighting_art_id uuid not null references public.secret_fighting_art(id) on delete restrict,
+	vignette_survivor_id uuid not null references public.vignette_survivor(id) on delete cascade,
+	-- Constraints
+	unique (vignette_survivor_id, secret_fighting_art_id)
+);
+
+create table public.vignette_survivor_gear_grid (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_survivor_id uuid not null references public.vignette_survivor(id) on delete cascade,
+	gear_id uuid not null references public.gear(id) on delete restrict,
+	row_number int not null check (row_number between 0 and 2),
+	column_number int not null check (column_number between 0 and 2),
+	-- Constraints
+	unique (vignette_survivor_id, row_number, column_number)
+);
+
+--------------------------------------------------------------------------------
+-- Active Vignette Encounter Tables
+--------------------------------------------------------------------------------
+create table public.vignette_encounter (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Owner Data
+	user_id uuid not null references auth.users(id) on delete cascade,
+	-- Data
+	vignette_monster_id uuid not null references public.vignette_monster(id) on delete restrict,
+	level_number int not null check (level_number between 1 and 4),
+	turn showdown_turn not null default 'MONSTER',
+	notes text not null default ''
+);
+
+create table public.vignette_encounter_ai_deck (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	basic_cards int not null default 0 check (basic_cards >= 0),
+	advanced_cards int not null default 0 check (advanced_cards >= 0),
+	legendary_cards int not null default 0 check (legendary_cards >= 0),
+	overtone_cards int not null default 0 check (overtone_cards >= 0),
+	vignette_encounter_id uuid not null references public.vignette_encounter(id) on delete cascade
+);
+
+create table public.vignette_encounter_monster (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	accuracy int not null default 0,
+	accuracy_tokens int not null default 0,
+	ai_card_drawn boolean not null default false,
+	ai_deck_id uuid not null references public.vignette_encounter_ai_deck(id) on delete cascade,
+	ai_deck_remaining int not null default 0 check (ai_deck_remaining >= 0),
+	damage int not null default 0,
+	damage_tokens int not null default 0,
+	evasion int not null default 0,
+	evasion_tokens int not null default 0,
+	knocked_down boolean not null default false,
+	luck int not null default 0,
+	luck_tokens int not null default 0,
+	monster_name varchar,
+	movement int not null default 1,
+	movement_tokens int not null default 0,
+	notes text not null default '',
+	speed int not null default 0,
+	speed_tokens int not null default 0,
+	strength int not null default 0,
+	strength_tokens int not null default 0,
+	toughness int not null default 0,
+	toughness_tokens int not null default 0,
+	vignette_encounter_id uuid not null references public.vignette_encounter(id) on delete cascade,
+	wounds int not null default 0 check (wounds >= 0),
+	-- Constraints
+	unique (ai_deck_id)
+);
+
+create table public.vignette_encounter_survivor (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_monster_id uuid not null references public.vignette_monster(id) on delete restrict,
+	vignette_encounter_id uuid not null references public.vignette_encounter(id) on delete cascade,
+	survivor_name varchar not null check (char_length(survivor_name) <= 100),
+	survivor_type survivor_type not null default 'CORE',
+	gender gender,
+	movement int not null default 5,
+	accuracy int not null default 0,
+	strength int not null default 0,
+	evasion int not null default 0,
+	luck int not null default 0,
+	speed int not null default 0,
+	survival int not null default 0 check (survival >= 0),
+	insanity int not null default 0 check (insanity >= 0),
+	courage int not null default 0 check (courage >= 0),
+	understanding int not null default 0 check (understanding >= 0),
+	weapon_proficiency int not null default 0 check (
+		weapon_proficiency >= 0
+		and weapon_proficiency <= 8
+	),
+	weapon_type_id uuid references public.weapon_type(id) on delete set null,
+	arm_armor int not null default 0 check (arm_armor >= 0),
+	body_armor int not null default 0 check (body_armor >= 0),
+	head_armor int not null default 0 check (head_armor >= 0),
+	leg_armor int not null default 0 check (leg_armor >= 0),
+	waist_armor int not null default 0 check (waist_armor >= 0),
+	notes text not null default ''
+);
+
+create table public.vignette_encounter_survivor_ability_impairment (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references public.vignette_encounter_survivor(id) on delete cascade,
+	ability_impairment_id uuid not null references public.ability_impairment(id) on delete restrict,
+	-- Constraints
+	unique (vignette_encounter_survivor_id, ability_impairment_id)
+);
+
+create table public.vignette_encounter_survivor_disorder (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references public.vignette_encounter_survivor(id) on delete cascade,
+	disorder_id uuid not null references public.disorder(id) on delete restrict,
+	-- Constraints
+	unique (vignette_encounter_survivor_id, disorder_id)
+);
+
+create table public.vignette_encounter_survivor_fighting_art (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references public.vignette_encounter_survivor(id) on delete cascade,
+	fighting_art_id uuid not null references public.fighting_art(id) on delete restrict,
+	-- Constraints
+	unique (vignette_encounter_survivor_id, fighting_art_id)
+);
+
+create table public.vignette_encounter_survivor_secret_fighting_art (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references public.vignette_encounter_survivor(id) on delete cascade,
+	secret_fighting_art_id uuid not null references public.secret_fighting_art(id) on delete restrict,
+	-- Constraints
+	unique (vignette_encounter_survivor_id, secret_fighting_art_id)
+);
+
+create table public.vignette_encounter_survivor_gear_grid (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_survivor_id uuid not null references public.vignette_encounter_survivor(id) on delete cascade,
+	gear_id uuid not null references public.gear(id) on delete restrict,
+	row_number int not null check (row_number between 0 and 2),
+	column_number int not null check (column_number between 0 and 2),
+	-- Constraints
+	unique (vignette_encounter_survivor_id, row_number, column_number)
+);
+
+create table public.vignette_encounter_shared_user (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_id uuid not null references public.vignette_encounter(id) on delete cascade,
+	shared_user_id uuid not null references auth.users(id) on delete cascade,
+	-- Constraints
+	unique (vignette_encounter_id, shared_user_id),
+	constraint fk_vignette_encounter_shared_user_settings foreign key (shared_user_id) references public.user_settings(user_id) on delete cascade
+);
+
+--------------------------------------------------------------------------------
+-- Validation Helpers
+--------------------------------------------------------------------------------
+create or replace function public.validate_vignette_encounter_level() returns trigger language plpgsql security invoker
+set search_path = public as $$
+begin
+	if not exists (
+		select 1
+		from vignette_monster_level vml
+		where vml.vignette_monster_id = new.vignette_monster_id
+			and vml.level_number = new.level_number
+	) then
+		raise exception 'Vignette encounter level must belong to the selected vignette monster' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_monster_ai_deck() returns trigger language plpgsql security invoker
+set search_path = public as $$
+begin
+	if not exists (
+		select 1
+		from vignette_encounter_ai_deck vead
+		where vead.id = new.ai_deck_id
+			and vead.vignette_encounter_id = new.vignette_encounter_id
+	) then
+		raise exception 'Vignette encounter monster AI deck must belong to the same encounter' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_survivor_monster() returns trigger language plpgsql security invoker
+set search_path = public as $$
+begin
+	if not exists (
+		select 1
+		from vignette_encounter ve
+		where ve.id = new.vignette_encounter_id
+			and ve.vignette_monster_id = new.vignette_monster_id
+	) then
+		raise exception 'Vignette encounter survivor must belong to the selected vignette monster' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+revoke all on function public.validate_vignette_encounter_level()
+from public;
+revoke execute on function public.validate_vignette_encounter_level()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_monster_ai_deck()
+from public;
+revoke execute on function public.validate_vignette_encounter_monster_ai_deck()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_survivor_monster()
+from public;
+revoke execute on function public.validate_vignette_encounter_survivor_monster()
+from anon,
+	authenticated;
+
+create trigger validate_vignette_encounter_level before
+insert
+	or
+update on public.vignette_encounter for each row execute function public.validate_vignette_encounter_level();
+
+create trigger validate_vignette_encounter_monster_ai_deck before
+insert
+	or
+update on public.vignette_encounter_monster for each row execute function public.validate_vignette_encounter_monster_ai_deck();
+
+create trigger validate_vignette_encounter_survivor_monster before
+insert
+	or
+update on public.vignette_encounter_survivor for each row execute function public.validate_vignette_encounter_survivor_monster();
+
+--------------------------------------------------------------------------------
+-- Sharing And Access Helpers
+--------------------------------------------------------------------------------
+create or replace function public.is_vignette_encounter_owner(target_vignette_encounter uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select exists (
+		select 1
+		from public.vignette_encounter ve
+		where ve.id = target_vignette_encounter
+			and ve.user_id = (
+				select auth.uid()
+			)
+	);
+$$;
+
+create or replace function public.is_vignette_encounter_collaborator(target_vignette_encounter uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select exists (
+		select 1
+		from public.vignette_encounter_shared_user vesu
+		where vesu.vignette_encounter_id = target_vignette_encounter
+			and vesu.shared_user_id = (
+				select auth.uid()
+			)
+	);
+$$;
+
+create or replace function public.is_active_vignette_encounter_owner(target_vignette_encounter uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select public.is_vignette_encounter_owner(target_vignette_encounter);
+$$;
+
+create or replace function public.can_access_active_vignette_encounter(target_vignette_encounter uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select public.is_vignette_encounter_owner(target_vignette_encounter)
+	or public.is_vignette_encounter_collaborator(target_vignette_encounter);
+$$;
+
+create or replace function public.can_update_vignette_encounter_as_collaborator(
+	target_vignette_encounter uuid,
+	proposed_user_id uuid,
+	proposed_vignette_monster_id uuid,
+	proposed_level_number int
+) returns boolean language sql stable security definer
+set search_path = '' as $$
+select exists (
+		select 1
+		from public.vignette_encounter ve
+		where ve.id = target_vignette_encounter
+			and ve.user_id = proposed_user_id
+			and ve.vignette_monster_id = proposed_vignette_monster_id
+			and ve.level_number = proposed_level_number
+			and exists (
+				select 1
+				from public.vignette_encounter_shared_user vesu
+				where vesu.vignette_encounter_id = ve.id
+					and vesu.shared_user_id = (
+						select auth.uid()
+					)
+			)
+	);
+$$;
+
+create or replace function public.can_share_vignette_encounters(target_user_id uuid) returns boolean language sql stable security definer
+set search_path = '' as $$
+select coalesce(
+		(
+			select us.plan_id = 'lantern_hoard'
+			from public.user_subscription us
+			where us.user_id = target_user_id
+				and target_user_id = (
+					select auth.uid()
+				)
+				and us.status in ('active', 'trialing')
+		),
+		false
+	);
+$$;
+
+revoke all on function public.is_vignette_encounter_owner(uuid)
+from public;
+revoke execute on function public.is_vignette_encounter_owner(uuid)
+from anon;
+grant execute on function public.is_vignette_encounter_owner(uuid) to authenticated;
+
+revoke all on function public.is_vignette_encounter_collaborator(uuid)
+from public;
+revoke execute on function public.is_vignette_encounter_collaborator(uuid)
+from anon;
+grant execute on function public.is_vignette_encounter_collaborator(uuid) to authenticated;
+
+revoke all on function public.is_active_vignette_encounter_owner(uuid)
+from public;
+revoke execute on function public.is_active_vignette_encounter_owner(uuid)
+from anon;
+grant execute on function public.is_active_vignette_encounter_owner(uuid) to authenticated;
+
+revoke all on function public.can_access_active_vignette_encounter(uuid)
+from public;
+revoke execute on function public.can_access_active_vignette_encounter(uuid)
+from anon;
+grant execute on function public.can_access_active_vignette_encounter(uuid) to authenticated;
+
+revoke all on function public.can_update_vignette_encounter_as_collaborator(uuid, uuid, uuid, int)
+from public;
+revoke execute on function public.can_update_vignette_encounter_as_collaborator(uuid, uuid, uuid, int)
+from anon;
+grant execute on function public.can_update_vignette_encounter_as_collaborator(uuid, uuid, uuid, int) to authenticated;
+
+revoke all on function public.can_share_vignette_encounters(uuid)
+from public;
+revoke execute on function public.can_share_vignette_encounters(uuid)
+from anon;
+grant execute on function public.can_share_vignette_encounters(uuid) to authenticated;
+
+--------------------------------------------------------------------------------
+-- Row Level Security
+--------------------------------------------------------------------------------
+alter table public.vignette_monster enable row level security;
+alter table public.vignette_monster_level enable row level security;
+alter table public.vignette_monster_level_mood enable row level security;
+alter table public.vignette_monster_level_trait enable row level security;
+alter table public.vignette_monster_level_survivor_status enable row level security;
+alter table public.vignette_survivor enable row level security;
+alter table public.vignette_survivor_ability_impairment enable row level security;
+alter table public.vignette_survivor_disorder enable row level security;
+alter table public.vignette_survivor_fighting_art enable row level security;
+alter table public.vignette_survivor_secret_fighting_art enable row level security;
+alter table public.vignette_survivor_gear_grid enable row level security;
+alter table public.vignette_encounter enable row level security;
+alter table public.vignette_encounter_ai_deck enable row level security;
+alter table public.vignette_encounter_monster enable row level security;
+alter table public.vignette_encounter_survivor enable row level security;
+alter table public.vignette_encounter_survivor_ability_impairment enable row level security;
+alter table public.vignette_encounter_survivor_disorder enable row level security;
+alter table public.vignette_encounter_survivor_fighting_art enable row level security;
+alter table public.vignette_encounter_survivor_secret_fighting_art enable row level security;
+alter table public.vignette_encounter_survivor_gear_grid enable row level security;
+alter table public.vignette_encounter_shared_user enable row level security;
+
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_monster',
+		'vignette_monster_level',
+		'vignette_monster_level_mood',
+		'vignette_monster_level_trait',
+		'vignette_monster_level_survivor_status',
+		'vignette_survivor',
+		'vignette_survivor_ability_impairment',
+		'vignette_survivor_disorder',
+		'vignette_survivor_fighting_art',
+		'vignette_survivor_secret_fighting_art',
+		'vignette_survivor_gear_grid'
+	] loop
+		execute format(
+			'create policy "Allow select for authenticated" on public.%I for select to authenticated using (true)',
+			table_name
+		);
+	end loop;
+end $$;
+
+create policy "Allow select for active member" on public.vignette_encounter for
+select to authenticated using (public.can_access_active_vignette_encounter(id));
+
+create policy "Allow insert for owner" on public.vignette_encounter for
+insert to authenticated with check (
+		user_id = (
+			select auth.uid()
+		)
+		and exists (
+			select 1
+			from public.vignette_monster_level vml
+			where vml.vignette_monster_id = vignette_encounter.vignette_monster_id
+				and vml.level_number = vignette_encounter.level_number
+		)
+	);
+
+create policy "Allow update for active member" on public.vignette_encounter for
+update to authenticated using (public.can_access_active_vignette_encounter(id)) with check (
+		(
+			user_id = (
+				select auth.uid()
+			)
+			and exists (
+				select 1
+				from public.vignette_monster_level vml
+				where vml.vignette_monster_id = vignette_encounter.vignette_monster_id
+					and vml.level_number = vignette_encounter.level_number
+			)
+		)
+		or public.can_update_vignette_encounter_as_collaborator(
+			id,
+			user_id,
+			vignette_monster_id,
+			level_number
+		)
+	);
+
+create policy "Allow delete for active owner" on public.vignette_encounter for delete to authenticated using (public.is_active_vignette_encounter_owner(id));
+
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_encounter_ai_deck',
+		'vignette_encounter_monster',
+		'vignette_encounter_survivor'
+	] loop
+		execute format(
+			'create policy "Allow select for active member" on public.%1$I for select to authenticated using (public.can_access_active_vignette_encounter(vignette_encounter_id))',
+			table_name
+		);
+
+		execute format(
+			'create policy "Allow insert for active owner" on public.%1$I for insert to authenticated with check (public.is_active_vignette_encounter_owner(vignette_encounter_id))',
+			table_name
+		);
+
+		execute format(
+			'create policy "Allow update for active member" on public.%1$I for update to authenticated using (public.can_access_active_vignette_encounter(vignette_encounter_id)) with check (public.can_access_active_vignette_encounter(vignette_encounter_id))',
+			table_name
+		);
+
+		execute format(
+			'create policy "Allow delete for active owner" on public.%1$I for delete to authenticated using (public.is_active_vignette_encounter_owner(vignette_encounter_id))',
+			table_name
+		);
+	end loop;
+end $$;
+
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_encounter_survivor_ability_impairment',
+		'vignette_encounter_survivor_disorder',
+		'vignette_encounter_survivor_fighting_art',
+		'vignette_encounter_survivor_secret_fighting_art',
+		'vignette_encounter_survivor_gear_grid'
+	] loop
+		execute format(
+			$sql$create policy "Allow select for active member" on public.%1$I for
+select to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.can_access_active_vignette_encounter(ves.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow insert for active owner" on public.%1$I for
+insert to authenticated with check (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.is_active_vignette_encounter_owner(ves.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow update for active member" on public.%1$I for
+update to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.can_access_active_vignette_encounter(ves.vignette_encounter_id)
+	)
+) with check (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.can_access_active_vignette_encounter(ves.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow delete for active owner" on public.%1$I for delete to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.is_active_vignette_encounter_owner(ves.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+	end loop;
+end $$;
+
+create policy "Allow insert for entitled owner" on public.vignette_encounter_shared_user for
+insert to authenticated with check (
+		public.is_vignette_encounter_owner(vignette_encounter_id)
+		and shared_user_id <> (
+			select auth.uid()
+		)
+		and public.can_share_vignette_encounters(
+			(
+				select auth.uid()
+			)
+		)
+	);
+
+create policy "Allow select for owner" on public.vignette_encounter_shared_user for
+select to authenticated using (public.is_vignette_encounter_owner(vignette_encounter_id));
+
+create policy "Allow select for shared" on public.vignette_encounter_shared_user for
+select to authenticated using (
+		shared_user_id = (
+			select auth.uid()
+		)
+	);
+
+create policy "Allow delete for owner" on public.vignette_encounter_shared_user for delete to authenticated using (public.is_vignette_encounter_owner(vignette_encounter_id));
+
+--------------------------------------------------------------------------------
+-- Data API Privileges
+--------------------------------------------------------------------------------
+grant select on table public.vignette_monster to authenticated;
+grant select on table public.vignette_monster_level to authenticated;
+grant select on table public.vignette_monster_level_mood to authenticated;
+grant select on table public.vignette_monster_level_trait to authenticated;
+grant select on table public.vignette_monster_level_survivor_status to authenticated;
+grant select on table public.vignette_survivor to authenticated;
+grant select on table public.vignette_survivor_ability_impairment to authenticated;
+grant select on table public.vignette_survivor_disorder to authenticated;
+grant select on table public.vignette_survivor_fighting_art to authenticated;
+grant select on table public.vignette_survivor_secret_fighting_art to authenticated;
+grant select on table public.vignette_survivor_gear_grid to authenticated;
+
+revoke insert, update, delete on table public.vignette_monster from authenticated;
+revoke insert, update, delete on table public.vignette_monster_level from authenticated;
+revoke insert, update, delete on table public.vignette_monster_level_mood from authenticated;
+revoke insert, update, delete on table public.vignette_monster_level_trait from authenticated;
+revoke insert, update, delete on table public.vignette_monster_level_survivor_status from authenticated;
+revoke insert, update, delete on table public.vignette_survivor from authenticated;
+revoke insert, update, delete on table public.vignette_survivor_ability_impairment from authenticated;
+revoke insert, update, delete on table public.vignette_survivor_disorder from authenticated;
+revoke insert, update, delete on table public.vignette_survivor_fighting_art from authenticated;
+revoke insert, update, delete on table public.vignette_survivor_secret_fighting_art from authenticated;
+revoke insert, update, delete on table public.vignette_survivor_gear_grid from authenticated;
+
+grant select, insert, update, delete on table public.vignette_encounter to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_ai_deck to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_monster to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor_ability_impairment to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor_disorder to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor_fighting_art to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor_secret_fighting_art to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor_gear_grid to authenticated;
+grant select, insert, delete on table public.vignette_encounter_shared_user to authenticated;
+revoke update on table public.vignette_encounter_shared_user from authenticated;
+
+--------------------------------------------------------------------------------
+-- Indexes
+--------------------------------------------------------------------------------
+create index idx_vignette_monster_source_nemesis on public.vignette_monster(source_nemesis_id)
+where source_nemesis_id is not null;
+create index idx_vignette_monster_source_quarry on public.vignette_monster(source_quarry_id)
+where source_quarry_id is not null;
+create index idx_vignette_monster_monster_name on public.vignette_monster(monster_name);
+
+create index idx_vignette_monster_level_monster on public.vignette_monster_level(vignette_monster_id);
+create index idx_vignette_monster_level_number on public.vignette_monster_level(level_number);
+
+create index idx_vignette_monster_level_mood_level on public.vignette_monster_level_mood(vignette_monster_level_id);
+create index idx_vignette_monster_level_mood_mood on public.vignette_monster_level_mood(mood_id);
+create index idx_vignette_monster_level_trait_level on public.vignette_monster_level_trait(vignette_monster_level_id);
+create index idx_vignette_monster_level_trait_trait on public.vignette_monster_level_trait(trait_id);
+create index idx_vignette_monster_level_survivor_status_level on public.vignette_monster_level_survivor_status(vignette_monster_level_id);
+create index idx_vignette_monster_level_survivor_status_status on public.vignette_monster_level_survivor_status(survivor_status_id);
+
+create index idx_vignette_survivor_monster on public.vignette_survivor(vignette_monster_id);
+create index idx_vignette_survivor_weapon_type on public.vignette_survivor(weapon_type_id);
+create index idx_vignette_survivor_ability_impairment_survivor on public.vignette_survivor_ability_impairment(vignette_survivor_id);
+create index idx_vignette_survivor_ability_impairment_ability on public.vignette_survivor_ability_impairment(ability_impairment_id);
+create index idx_vignette_survivor_disorder_survivor on public.vignette_survivor_disorder(vignette_survivor_id);
+create index idx_vignette_survivor_disorder_disorder on public.vignette_survivor_disorder(disorder_id);
+create index idx_vignette_survivor_fighting_art_survivor on public.vignette_survivor_fighting_art(vignette_survivor_id);
+create index idx_vignette_survivor_fighting_art_art on public.vignette_survivor_fighting_art(fighting_art_id);
+create index idx_vignette_survivor_secret_fighting_art_survivor on public.vignette_survivor_secret_fighting_art(vignette_survivor_id);
+create index idx_vignette_survivor_secret_fighting_art_art on public.vignette_survivor_secret_fighting_art(secret_fighting_art_id);
+create index idx_vignette_survivor_gear_grid_survivor on public.vignette_survivor_gear_grid(vignette_survivor_id);
+create index idx_vignette_survivor_gear_grid_gear on public.vignette_survivor_gear_grid(gear_id);
+
+create unique index one_active_vignette_encounter_per_user on public.vignette_encounter(user_id);
+create index idx_vignette_encounter_user on public.vignette_encounter(user_id);
+create index idx_vignette_encounter_monster_template on public.vignette_encounter(vignette_monster_id);
+create index idx_vignette_encounter_level_number on public.vignette_encounter(level_number);
+
+create index idx_vignette_encounter_ai_deck_encounter on public.vignette_encounter_ai_deck(vignette_encounter_id);
+create index idx_vignette_encounter_monster_encounter on public.vignette_encounter_monster(vignette_encounter_id);
+create index idx_vignette_encounter_monster_ai_deck on public.vignette_encounter_monster(ai_deck_id);
+
+create index idx_vignette_encounter_survivor_monster on public.vignette_encounter_survivor(vignette_monster_id);
+create index idx_vignette_encounter_survivor_encounter on public.vignette_encounter_survivor(vignette_encounter_id);
+create index idx_vignette_encounter_survivor_weapon_type on public.vignette_encounter_survivor(weapon_type_id);
+create index idx_vignette_encounter_survivor_ability_impairment_survivor on public.vignette_encounter_survivor_ability_impairment(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_survivor_ability_impairment_ability on public.vignette_encounter_survivor_ability_impairment(ability_impairment_id);
+create index idx_vignette_encounter_survivor_disorder_survivor on public.vignette_encounter_survivor_disorder(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_survivor_disorder_disorder on public.vignette_encounter_survivor_disorder(disorder_id);
+create index idx_vignette_encounter_survivor_fighting_art_survivor on public.vignette_encounter_survivor_fighting_art(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_survivor_fighting_art_art on public.vignette_encounter_survivor_fighting_art(fighting_art_id);
+create index idx_vignette_encounter_survivor_secret_fighting_art_survivor on public.vignette_encounter_survivor_secret_fighting_art(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_survivor_secret_fighting_art_art on public.vignette_encounter_survivor_secret_fighting_art(secret_fighting_art_id);
+create index idx_vignette_encounter_survivor_gear_grid_survivor on public.vignette_encounter_survivor_gear_grid(vignette_encounter_survivor_id);
+create index idx_vignette_encounter_survivor_gear_grid_gear on public.vignette_encounter_survivor_gear_grid(gear_id);
+
+create index idx_vignette_encounter_shared_user_vignette_encounter on public.vignette_encounter_shared_user(vignette_encounter_id);
+create index idx_vignette_encounter_shared_user_shared_user on public.vignette_encounter_shared_user(shared_user_id);
+
+--------------------------------------------------------------------------------
+-- Updated At Triggers
+--------------------------------------------------------------------------------
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_monster',
+		'vignette_monster_level',
+		'vignette_monster_level_mood',
+		'vignette_monster_level_trait',
+		'vignette_monster_level_survivor_status',
+		'vignette_survivor',
+		'vignette_survivor_ability_impairment',
+		'vignette_survivor_disorder',
+		'vignette_survivor_fighting_art',
+		'vignette_survivor_secret_fighting_art',
+		'vignette_survivor_gear_grid',
+		'vignette_encounter',
+		'vignette_encounter_ai_deck',
+		'vignette_encounter_monster',
+		'vignette_encounter_survivor',
+		'vignette_encounter_survivor_ability_impairment',
+		'vignette_encounter_survivor_disorder',
+		'vignette_encounter_survivor_fighting_art',
+		'vignette_encounter_survivor_secret_fighting_art',
+		'vignette_encounter_survivor_gear_grid',
+		'vignette_encounter_shared_user'
+	] loop
+		execute format(
+			'create trigger set_updated_at before update on public.%I for each row execute function public.update_updated_at()',
+			table_name
+		);
+	end loop;
+end $$;
+
+--------------------------------------------------------------------------------
+-- Realtime Publication
+--------------------------------------------------------------------------------
+do $$
+declare
+	vignette_table_name text;
+	vignette_realtime_tables text [] := array [
+		'vignette_encounter',
+		'vignette_encounter_ai_deck',
+		'vignette_encounter_monster',
+		'vignette_encounter_survivor',
+		'vignette_encounter_survivor_ability_impairment',
+		'vignette_encounter_survivor_disorder',
+		'vignette_encounter_survivor_fighting_art',
+		'vignette_encounter_survivor_secret_fighting_art',
+		'vignette_encounter_survivor_gear_grid',
+		'vignette_encounter_shared_user'
+	];
+begin
+	if exists (
+		select 1
+		from pg_publication
+		where pubname = 'supabase_realtime'
+	) then
+		foreach vignette_table_name in array vignette_realtime_tables loop
+			if not exists (
+				select 1
+				from pg_publication_tables
+				where pubname = 'supabase_realtime'
+					and schemaname = 'public'
+					and tablename = vignette_table_name
+			) then
+				execute format(
+					'alter publication supabase_realtime add table public.%I',
+					vignette_table_name
+				);
+			end if;
+		end loop;
+	end if;
+end $$;

--- a/supabase/migrations/20260617015955_vignette_encounter_monster_state_tables.sql
+++ b/supabase/migrations/20260617015955_vignette_encounter_monster_state_tables.sql
@@ -1,0 +1,180 @@
+--------------------------------------------------------------------------------
+-- Active Vignette Encounter Monster State Tables
+-- Tracks mutable mood, trait, and survivor-status cards attached to copied
+-- monsters during a live vignette encounter.
+--------------------------------------------------------------------------------
+create table public.vignette_encounter_monster_mood (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_monster_id uuid not null references public.vignette_encounter_monster(id) on delete cascade,
+	mood_id uuid not null references public.mood(id) on delete restrict,
+	-- Constraints
+	unique (vignette_encounter_monster_id, mood_id)
+);
+
+create table public.vignette_encounter_monster_trait (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_monster_id uuid not null references public.vignette_encounter_monster(id) on delete cascade,
+	trait_id uuid not null references public.trait(id) on delete restrict,
+	-- Constraints
+	unique (vignette_encounter_monster_id, trait_id)
+);
+
+create table public.vignette_encounter_monster_survivor_status (
+	-- Metadata
+	id uuid primary key default gen_random_uuid(),
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	-- Data
+	vignette_encounter_monster_id uuid not null references public.vignette_encounter_monster(id) on delete cascade,
+	survivor_status_id uuid not null references public.survivor_status(id) on delete restrict,
+	-- Constraints
+	unique (vignette_encounter_monster_id, survivor_status_id)
+);
+
+--------------------------------------------------------------------------------
+-- Row Level Security
+--------------------------------------------------------------------------------
+alter table public.vignette_encounter_monster_mood enable row level security;
+alter table public.vignette_encounter_monster_trait enable row level security;
+alter table public.vignette_encounter_monster_survivor_status enable row level security;
+
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_encounter_monster_mood',
+		'vignette_encounter_monster_trait',
+		'vignette_encounter_monster_survivor_status'
+	] loop
+		execute format(
+			$sql$create policy "Allow select for active member" on public.%1$I for
+select to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_monster vem
+		where vem.id = %1$I.vignette_encounter_monster_id
+			and public.can_access_active_vignette_encounter(vem.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow insert for active owner" on public.%1$I for
+insert to authenticated with check (
+	exists (
+		select 1
+		from public.vignette_encounter_monster vem
+		where vem.id = %1$I.vignette_encounter_monster_id
+			and public.is_active_vignette_encounter_owner(vem.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow update for active member" on public.%1$I for
+update to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_monster vem
+		where vem.id = %1$I.vignette_encounter_monster_id
+			and public.can_access_active_vignette_encounter(vem.vignette_encounter_id)
+	)
+) with check (
+	exists (
+		select 1
+		from public.vignette_encounter_monster vem
+		where vem.id = %1$I.vignette_encounter_monster_id
+			and public.can_access_active_vignette_encounter(vem.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow delete for active owner" on public.%1$I for delete to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_monster vem
+		where vem.id = %1$I.vignette_encounter_monster_id
+			and public.is_active_vignette_encounter_owner(vem.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+	end loop;
+end $$;
+
+--------------------------------------------------------------------------------
+-- Data API Privileges
+--------------------------------------------------------------------------------
+grant select, insert, update, delete on table public.vignette_encounter_monster_mood to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_monster_trait to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_monster_survivor_status to authenticated;
+
+--------------------------------------------------------------------------------
+-- Indexes
+--------------------------------------------------------------------------------
+create index idx_vignette_encounter_monster_mood_monster on public.vignette_encounter_monster_mood(vignette_encounter_monster_id);
+create index idx_vignette_encounter_monster_mood_mood on public.vignette_encounter_monster_mood(mood_id);
+create index idx_vignette_encounter_monster_trait_monster on public.vignette_encounter_monster_trait(vignette_encounter_monster_id);
+create index idx_vignette_encounter_monster_trait_trait on public.vignette_encounter_monster_trait(trait_id);
+create index idx_vignette_encounter_monster_survivor_status_monster on public.vignette_encounter_monster_survivor_status(vignette_encounter_monster_id);
+create index idx_vignette_encounter_monster_survivor_status_status on public.vignette_encounter_monster_survivor_status(survivor_status_id);
+
+alter table public.vignette_encounter_monster_mood replica identity full;
+alter table public.vignette_encounter_monster_trait replica identity full;
+alter table public.vignette_encounter_monster_survivor_status replica identity full;
+
+--------------------------------------------------------------------------------
+-- Updated At Triggers
+--------------------------------------------------------------------------------
+create trigger set_updated_at before
+update on public.vignette_encounter_monster_mood for each row execute function public.update_updated_at();
+create trigger set_updated_at before
+update on public.vignette_encounter_monster_trait for each row execute function public.update_updated_at();
+create trigger set_updated_at before
+update on public.vignette_encounter_monster_survivor_status for each row execute function public.update_updated_at();
+
+--------------------------------------------------------------------------------
+-- Realtime Publication
+--------------------------------------------------------------------------------
+do $$
+declare
+	table_name text;
+begin
+	if exists (
+		select 1
+		from pg_publication
+		where pubname = 'supabase_realtime'
+	) then
+		foreach table_name in array array[
+			'vignette_encounter_monster_mood',
+			'vignette_encounter_monster_trait',
+			'vignette_encounter_monster_survivor_status'
+		] loop
+			if not exists (
+				select 1
+				from pg_publication_tables
+				where pubname = 'supabase_realtime'
+					and schemaname = 'public'
+					and tablename = table_name
+			) then
+				execute format(
+					'alter publication supabase_realtime add table public.%I',
+					table_name
+				);
+			end if;
+		end loop;
+	end if;
+end $$;

--- a/supabase/migrations/20260617022842_vignette_active_play_state.sql
+++ b/supabase/migrations/20260617022842_vignette_active_play_state.sql
@@ -1,0 +1,1044 @@
+--------------------------------------------------------------------------------
+-- Vignette Active Play State
+-- Adds live survivor state, source-aware copied rows, member CRUD for active
+-- gameplay children, and a transactional catalog-copy RPC.
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+-- Source Links And Live Survivor State
+--------------------------------------------------------------------------------
+alter table public.vignette_encounter_monster
+	add column source_vignette_monster_level_id uuid references public.vignette_monster_level(id) on delete set null;
+
+alter table public.vignette_encounter_monster_mood
+	add column source_vignette_monster_level_mood_id uuid references public.vignette_monster_level_mood(id) on delete set null;
+
+alter table public.vignette_encounter_monster_trait
+	add column source_vignette_monster_level_trait_id uuid references public.vignette_monster_level_trait(id) on delete set null;
+
+alter table public.vignette_encounter_monster_survivor_status
+	add column source_vignette_monster_level_survivor_status_id uuid references public.vignette_monster_level_survivor_status(id) on delete set null;
+
+alter table public.vignette_encounter_survivor
+	add column source_vignette_survivor_id uuid references public.vignette_survivor(id) on delete set null,
+	add column arm_light_damage boolean not null default false,
+	add column arm_heavy_damage boolean not null default false,
+	add column body_light_damage boolean not null default false,
+	add column body_heavy_damage boolean not null default false,
+	add column brain_light_damage boolean not null default false,
+	add column head_heavy_damage boolean not null default false,
+	add column leg_light_damage boolean not null default false,
+	add column leg_heavy_damage boolean not null default false,
+	add column waist_light_damage boolean not null default false,
+	add column waist_heavy_damage boolean not null default false,
+	add column accuracy_tokens int not null default 0,
+	add column activation_used boolean not null default false,
+	add column bleeding_tokens int not null default 0 check (bleeding_tokens >= 0),
+	add column block_tokens int not null default 0,
+	add column deflect_tokens int not null default 0,
+	add column evasion_tokens int not null default 0,
+	add column insanity_tokens int not null default 0,
+	add column knocked_down boolean not null default false,
+	add column luck_tokens int not null default 0,
+	add column movement_tokens int not null default 0,
+	add column movement_used boolean not null default false,
+	add column priority_target boolean not null default false,
+	add column scout boolean not null default false,
+	add column speed_tokens int not null default 0,
+	add column strength_tokens int not null default 0,
+	add column survival_tokens int not null default 0,
+	add column dead boolean not null default false,
+	add column retired boolean not null default false;
+
+alter table public.vignette_encounter_survivor_ability_impairment
+	add column source_vignette_survivor_ability_impairment_id uuid references public.vignette_survivor_ability_impairment(id) on delete set null;
+
+alter table public.vignette_encounter_survivor_disorder
+	add column source_vignette_survivor_disorder_id uuid references public.vignette_survivor_disorder(id) on delete set null;
+
+alter table public.vignette_encounter_survivor_fighting_art
+	add column source_vignette_survivor_fighting_art_id uuid references public.vignette_survivor_fighting_art(id) on delete set null;
+
+alter table public.vignette_encounter_survivor_secret_fighting_art
+	add column source_vignette_survivor_secret_fighting_art_id uuid references public.vignette_survivor_secret_fighting_art(id) on delete set null;
+
+alter table public.vignette_encounter_survivor_gear_grid
+	add column source_vignette_survivor_gear_grid_id uuid references public.vignette_survivor_gear_grid(id) on delete set null;
+
+create unique index idx_vignette_encounter_monster_source_unique on public.vignette_encounter_monster(vignette_encounter_id, source_vignette_monster_level_id)
+where source_vignette_monster_level_id is not null;
+create index idx_vignette_encounter_monster_source_level on public.vignette_encounter_monster(source_vignette_monster_level_id)
+where source_vignette_monster_level_id is not null;
+
+create unique index idx_vignette_encounter_monster_mood_source_unique on public.vignette_encounter_monster_mood(vignette_encounter_monster_id, source_vignette_monster_level_mood_id)
+where source_vignette_monster_level_mood_id is not null;
+create index idx_vignette_encounter_monster_mood_source on public.vignette_encounter_monster_mood(source_vignette_monster_level_mood_id)
+where source_vignette_monster_level_mood_id is not null;
+
+create unique index idx_vignette_encounter_monster_trait_source_unique on public.vignette_encounter_monster_trait(vignette_encounter_monster_id, source_vignette_monster_level_trait_id)
+where source_vignette_monster_level_trait_id is not null;
+create index idx_vignette_encounter_monster_trait_source on public.vignette_encounter_monster_trait(source_vignette_monster_level_trait_id)
+where source_vignette_monster_level_trait_id is not null;
+
+create unique index idx_vignette_encounter_monster_survivor_status_source_unique on public.vignette_encounter_monster_survivor_status(vignette_encounter_monster_id, source_vignette_monster_level_survivor_status_id)
+where source_vignette_monster_level_survivor_status_id is not null;
+create index idx_vignette_encounter_monster_survivor_status_source on public.vignette_encounter_monster_survivor_status(source_vignette_monster_level_survivor_status_id)
+where source_vignette_monster_level_survivor_status_id is not null;
+
+create unique index idx_vignette_encounter_survivor_source_unique on public.vignette_encounter_survivor(vignette_encounter_id, source_vignette_survivor_id)
+where source_vignette_survivor_id is not null;
+create index idx_vignette_encounter_survivor_source on public.vignette_encounter_survivor(source_vignette_survivor_id)
+where source_vignette_survivor_id is not null;
+
+create unique index idx_vignette_encounter_survivor_ability_source_unique on public.vignette_encounter_survivor_ability_impairment(vignette_encounter_survivor_id, source_vignette_survivor_ability_impairment_id)
+where source_vignette_survivor_ability_impairment_id is not null;
+create index idx_vignette_encounter_survivor_ability_source on public.vignette_encounter_survivor_ability_impairment(source_vignette_survivor_ability_impairment_id)
+where source_vignette_survivor_ability_impairment_id is not null;
+
+create unique index idx_vignette_encounter_survivor_disorder_source_unique on public.vignette_encounter_survivor_disorder(vignette_encounter_survivor_id, source_vignette_survivor_disorder_id)
+where source_vignette_survivor_disorder_id is not null;
+create index idx_vignette_encounter_survivor_disorder_source on public.vignette_encounter_survivor_disorder(source_vignette_survivor_disorder_id)
+where source_vignette_survivor_disorder_id is not null;
+
+create unique index idx_vignette_encounter_survivor_fighting_art_source_unique on public.vignette_encounter_survivor_fighting_art(vignette_encounter_survivor_id, source_vignette_survivor_fighting_art_id)
+where source_vignette_survivor_fighting_art_id is not null;
+create index idx_vignette_encounter_survivor_fighting_art_source on public.vignette_encounter_survivor_fighting_art(source_vignette_survivor_fighting_art_id)
+where source_vignette_survivor_fighting_art_id is not null;
+
+create unique index idx_vignette_encounter_survivor_secret_fighting_art_source_unique on public.vignette_encounter_survivor_secret_fighting_art(vignette_encounter_survivor_id, source_vignette_survivor_secret_fighting_art_id)
+where source_vignette_survivor_secret_fighting_art_id is not null;
+create index idx_vignette_encounter_survivor_secret_fighting_art_source on public.vignette_encounter_survivor_secret_fighting_art(source_vignette_survivor_secret_fighting_art_id)
+where source_vignette_survivor_secret_fighting_art_id is not null;
+
+create unique index idx_vignette_encounter_survivor_gear_grid_source_unique on public.vignette_encounter_survivor_gear_grid(vignette_encounter_survivor_id, source_vignette_survivor_gear_grid_id)
+where source_vignette_survivor_gear_grid_id is not null;
+create index idx_vignette_encounter_survivor_gear_grid_source on public.vignette_encounter_survivor_gear_grid(source_vignette_survivor_gear_grid_id)
+where source_vignette_survivor_gear_grid_id is not null;
+
+--------------------------------------------------------------------------------
+-- Source Validation
+--------------------------------------------------------------------------------
+create or replace function public.validate_vignette_encounter_monster_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+begin
+	if new.source_vignette_monster_level_id is null then
+		return new;
+	end if;
+
+	if not exists (
+		select 1
+		from public.vignette_encounter ve
+			join public.vignette_monster_level vml on vml.id = new.source_vignette_monster_level_id
+		where ve.id = new.vignette_encounter_id
+			and vml.vignette_monster_id = ve.vignette_monster_id
+			and vml.level_number = ve.level_number
+	) then
+		raise exception 'Active vignette monster source must belong to the selected vignette monster level' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_monster_mood_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+declare
+	active_source_level_id uuid;
+begin
+	select vem.source_vignette_monster_level_id
+	into active_source_level_id
+	from public.vignette_encounter_monster vem
+	where vem.id = new.vignette_encounter_monster_id;
+
+	if not found then
+		raise exception 'Active vignette monster state must reference an existing active monster' using errcode = '23503';
+	end if;
+
+	if new.source_vignette_monster_level_mood_id is not null
+		and (
+			active_source_level_id is null
+			or not exists (
+				select 1
+				from public.vignette_monster_level_mood vmlm
+				where vmlm.id = new.source_vignette_monster_level_mood_id
+					and vmlm.vignette_monster_level_id = active_source_level_id
+					and vmlm.mood_id = new.mood_id
+			)
+		) then
+		raise exception 'Active vignette monster mood source must belong to the active monster source level' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_monster_trait_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+declare
+	active_source_level_id uuid;
+begin
+	select vem.source_vignette_monster_level_id
+	into active_source_level_id
+	from public.vignette_encounter_monster vem
+	where vem.id = new.vignette_encounter_monster_id;
+
+	if not found then
+		raise exception 'Active vignette monster state must reference an existing active monster' using errcode = '23503';
+	end if;
+
+	if new.source_vignette_monster_level_trait_id is not null
+		and (
+			active_source_level_id is null
+			or not exists (
+				select 1
+				from public.vignette_monster_level_trait vmlt
+				where vmlt.id = new.source_vignette_monster_level_trait_id
+					and vmlt.vignette_monster_level_id = active_source_level_id
+					and vmlt.trait_id = new.trait_id
+			)
+		) then
+		raise exception 'Active vignette monster trait source must belong to the active monster source level' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_monster_survivor_status_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+declare
+	active_source_level_id uuid;
+begin
+	select vem.source_vignette_monster_level_id
+	into active_source_level_id
+	from public.vignette_encounter_monster vem
+	where vem.id = new.vignette_encounter_monster_id;
+
+	if not found then
+		raise exception 'Active vignette monster state must reference an existing active monster' using errcode = '23503';
+	end if;
+
+	if new.source_vignette_monster_level_survivor_status_id is not null
+		and (
+			active_source_level_id is null
+			or not exists (
+				select 1
+				from public.vignette_monster_level_survivor_status vmlss
+				where vmlss.id = new.source_vignette_monster_level_survivor_status_id
+					and vmlss.vignette_monster_level_id = active_source_level_id
+					and vmlss.survivor_status_id = new.survivor_status_id
+			)
+		) then
+		raise exception 'Active vignette monster survivor status source must belong to the active monster source level' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_survivor_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+begin
+	if new.source_vignette_survivor_id is null then
+		return new;
+	end if;
+
+	if not exists (
+		select 1
+		from public.vignette_survivor vs
+		where vs.id = new.source_vignette_survivor_id
+			and vs.vignette_monster_id = new.vignette_monster_id
+	) then
+		raise exception 'Active vignette survivor source must belong to the selected vignette monster' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_survivor_ability_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+declare
+	active_source_survivor_id uuid;
+begin
+	select ves.source_vignette_survivor_id
+	into active_source_survivor_id
+	from public.vignette_encounter_survivor ves
+	where ves.id = new.vignette_encounter_survivor_id;
+
+	if not found then
+		raise exception 'Active vignette survivor child row must reference an existing active survivor' using errcode = '23503';
+	end if;
+
+	if new.source_vignette_survivor_ability_impairment_id is not null
+		and (
+			active_source_survivor_id is null
+			or not exists (
+				select 1
+				from public.vignette_survivor_ability_impairment vsai
+				where vsai.id = new.source_vignette_survivor_ability_impairment_id
+					and vsai.vignette_survivor_id = active_source_survivor_id
+					and vsai.ability_impairment_id = new.ability_impairment_id
+			)
+		) then
+		raise exception 'Active vignette survivor ability impairment source must belong to the active survivor source' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_survivor_disorder_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+declare
+	active_source_survivor_id uuid;
+begin
+	select ves.source_vignette_survivor_id
+	into active_source_survivor_id
+	from public.vignette_encounter_survivor ves
+	where ves.id = new.vignette_encounter_survivor_id;
+
+	if not found then
+		raise exception 'Active vignette survivor child row must reference an existing active survivor' using errcode = '23503';
+	end if;
+
+	if new.source_vignette_survivor_disorder_id is not null
+		and (
+			active_source_survivor_id is null
+			or not exists (
+				select 1
+				from public.vignette_survivor_disorder vsd
+				where vsd.id = new.source_vignette_survivor_disorder_id
+					and vsd.vignette_survivor_id = active_source_survivor_id
+					and vsd.disorder_id = new.disorder_id
+			)
+		) then
+		raise exception 'Active vignette survivor disorder source must belong to the active survivor source' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_survivor_fighting_art_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+declare
+	active_source_survivor_id uuid;
+begin
+	select ves.source_vignette_survivor_id
+	into active_source_survivor_id
+	from public.vignette_encounter_survivor ves
+	where ves.id = new.vignette_encounter_survivor_id;
+
+	if not found then
+		raise exception 'Active vignette survivor child row must reference an existing active survivor' using errcode = '23503';
+	end if;
+
+	if new.source_vignette_survivor_fighting_art_id is not null
+		and (
+			active_source_survivor_id is null
+			or not exists (
+				select 1
+				from public.vignette_survivor_fighting_art vsfa
+				where vsfa.id = new.source_vignette_survivor_fighting_art_id
+					and vsfa.vignette_survivor_id = active_source_survivor_id
+					and vsfa.fighting_art_id = new.fighting_art_id
+			)
+		) then
+		raise exception 'Active vignette survivor fighting art source must belong to the active survivor source' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_survivor_secret_fighting_art_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+declare
+	active_source_survivor_id uuid;
+begin
+	select ves.source_vignette_survivor_id
+	into active_source_survivor_id
+	from public.vignette_encounter_survivor ves
+	where ves.id = new.vignette_encounter_survivor_id;
+
+	if not found then
+		raise exception 'Active vignette survivor child row must reference an existing active survivor' using errcode = '23503';
+	end if;
+
+	if new.source_vignette_survivor_secret_fighting_art_id is not null
+		and (
+			active_source_survivor_id is null
+			or not exists (
+				select 1
+				from public.vignette_survivor_secret_fighting_art vssfa
+				where vssfa.id = new.source_vignette_survivor_secret_fighting_art_id
+					and vssfa.vignette_survivor_id = active_source_survivor_id
+					and vssfa.secret_fighting_art_id = new.secret_fighting_art_id
+			)
+		) then
+		raise exception 'Active vignette survivor secret fighting art source must belong to the active survivor source' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+create or replace function public.validate_vignette_encounter_survivor_gear_grid_source() returns trigger language plpgsql security invoker
+set search_path = public as $$
+declare
+	active_source_survivor_id uuid;
+begin
+	select ves.source_vignette_survivor_id
+	into active_source_survivor_id
+	from public.vignette_encounter_survivor ves
+	where ves.id = new.vignette_encounter_survivor_id;
+
+	if not found then
+		raise exception 'Active vignette survivor child row must reference an existing active survivor' using errcode = '23503';
+	end if;
+
+	if new.source_vignette_survivor_gear_grid_id is not null
+		and (
+			active_source_survivor_id is null
+			or not exists (
+				select 1
+				from public.vignette_survivor_gear_grid vsgg
+				where vsgg.id = new.source_vignette_survivor_gear_grid_id
+					and vsgg.vignette_survivor_id = active_source_survivor_id
+					and vsgg.gear_id = new.gear_id
+			)
+		) then
+		raise exception 'Active vignette survivor gear source must belong to the active survivor source' using errcode = '23514';
+	end if;
+
+	return new;
+end;
+$$;
+
+revoke all on function public.validate_vignette_encounter_monster_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_monster_source()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_monster_mood_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_monster_mood_source()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_monster_trait_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_monster_trait_source()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_monster_survivor_status_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_monster_survivor_status_source()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_survivor_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_survivor_source()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_survivor_ability_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_survivor_ability_source()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_survivor_disorder_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_survivor_disorder_source()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_survivor_fighting_art_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_survivor_fighting_art_source()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_survivor_secret_fighting_art_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_survivor_secret_fighting_art_source()
+from anon,
+	authenticated;
+
+revoke all on function public.validate_vignette_encounter_survivor_gear_grid_source()
+from public;
+revoke execute on function public.validate_vignette_encounter_survivor_gear_grid_source()
+from anon,
+	authenticated;
+
+create trigger validate_vignette_encounter_monster_source before
+insert
+	or
+update on public.vignette_encounter_monster for each row execute function public.validate_vignette_encounter_monster_source();
+
+create trigger validate_vignette_encounter_monster_mood_source before
+insert
+	or
+update on public.vignette_encounter_monster_mood for each row execute function public.validate_vignette_encounter_monster_mood_source();
+
+create trigger validate_vignette_encounter_monster_trait_source before
+insert
+	or
+update on public.vignette_encounter_monster_trait for each row execute function public.validate_vignette_encounter_monster_trait_source();
+
+create trigger validate_vignette_encounter_monster_survivor_status_source before
+insert
+	or
+update on public.vignette_encounter_monster_survivor_status for each row execute function public.validate_vignette_encounter_monster_survivor_status_source();
+
+create trigger validate_vignette_encounter_survivor_source before
+insert
+	or
+update on public.vignette_encounter_survivor for each row execute function public.validate_vignette_encounter_survivor_source();
+
+create trigger validate_vignette_encounter_survivor_ability_source before
+insert
+	or
+update on public.vignette_encounter_survivor_ability_impairment for each row execute function public.validate_vignette_encounter_survivor_ability_source();
+
+create trigger validate_vignette_encounter_survivor_disorder_source before
+insert
+	or
+update on public.vignette_encounter_survivor_disorder for each row execute function public.validate_vignette_encounter_survivor_disorder_source();
+
+create trigger validate_vignette_encounter_survivor_fighting_art_source before
+insert
+	or
+update on public.vignette_encounter_survivor_fighting_art for each row execute function public.validate_vignette_encounter_survivor_fighting_art_source();
+
+create trigger validate_vignette_encounter_survivor_secret_fighting_art_source before
+insert
+	or
+update on public.vignette_encounter_survivor_secret_fighting_art for each row execute function public.validate_vignette_encounter_survivor_secret_fighting_art_source();
+
+create trigger validate_vignette_encounter_survivor_gear_grid_source before
+insert
+	or
+update on public.vignette_encounter_survivor_gear_grid for each row execute function public.validate_vignette_encounter_survivor_gear_grid_source();
+
+--------------------------------------------------------------------------------
+-- Active Gameplay RLS
+--------------------------------------------------------------------------------
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_encounter_ai_deck',
+		'vignette_encounter_monster',
+		'vignette_encounter_survivor'
+	] loop
+		execute format(
+			'drop policy if exists "Allow insert for active owner" on public.%I',
+			table_name
+		);
+		execute format(
+			'drop policy if exists "Allow delete for active owner" on public.%I',
+			table_name
+		);
+		execute format(
+			'drop policy if exists "Allow insert for active member" on public.%I',
+			table_name
+		);
+		execute format(
+			'drop policy if exists "Allow delete for active member" on public.%I',
+			table_name
+		);
+
+		execute format(
+			'create policy "Allow insert for active member" on public.%1$I for insert to authenticated with check (public.can_access_active_vignette_encounter(vignette_encounter_id))',
+			table_name
+		);
+		execute format(
+			'create policy "Allow delete for active member" on public.%1$I for delete to authenticated using (public.can_access_active_vignette_encounter(vignette_encounter_id))',
+			table_name
+		);
+	end loop;
+end $$;
+
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_encounter_survivor_ability_impairment',
+		'vignette_encounter_survivor_disorder',
+		'vignette_encounter_survivor_fighting_art',
+		'vignette_encounter_survivor_secret_fighting_art',
+		'vignette_encounter_survivor_gear_grid'
+	] loop
+		execute format(
+			'drop policy if exists "Allow insert for active owner" on public.%I',
+			table_name
+		);
+		execute format(
+			'drop policy if exists "Allow delete for active owner" on public.%I',
+			table_name
+		);
+		execute format(
+			'drop policy if exists "Allow insert for active member" on public.%I',
+			table_name
+		);
+		execute format(
+			'drop policy if exists "Allow delete for active member" on public.%I',
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow insert for active member" on public.%1$I for
+insert to authenticated with check (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.can_access_active_vignette_encounter(ves.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+		execute format(
+			$sql$create policy "Allow delete for active member" on public.%1$I for delete to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_survivor ves
+		where ves.id = %1$I.vignette_encounter_survivor_id
+			and public.can_access_active_vignette_encounter(ves.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+	end loop;
+end $$;
+
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_encounter_monster_mood',
+		'vignette_encounter_monster_trait',
+		'vignette_encounter_monster_survivor_status'
+	] loop
+		execute format(
+			'drop policy if exists "Allow insert for active owner" on public.%I',
+			table_name
+		);
+		execute format(
+			'drop policy if exists "Allow delete for active owner" on public.%I',
+			table_name
+		);
+		execute format(
+			'drop policy if exists "Allow insert for active member" on public.%I',
+			table_name
+		);
+		execute format(
+			'drop policy if exists "Allow delete for active member" on public.%I',
+			table_name
+		);
+
+		execute format(
+			$sql$create policy "Allow insert for active member" on public.%1$I for
+insert to authenticated with check (
+	exists (
+		select 1
+		from public.vignette_encounter_monster vem
+		where vem.id = %1$I.vignette_encounter_monster_id
+			and public.can_access_active_vignette_encounter(vem.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+		execute format(
+			$sql$create policy "Allow delete for active member" on public.%1$I for delete to authenticated using (
+	exists (
+		select 1
+		from public.vignette_encounter_monster vem
+		where vem.id = %1$I.vignette_encounter_monster_id
+			and public.can_access_active_vignette_encounter(vem.vignette_encounter_id)
+	)
+)$sql$,
+			table_name
+		);
+	end loop;
+end $$;
+
+--------------------------------------------------------------------------------
+-- Data API Privileges
+--------------------------------------------------------------------------------
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_monster',
+		'vignette_monster_level',
+		'vignette_monster_level_mood',
+		'vignette_monster_level_trait',
+		'vignette_monster_level_survivor_status',
+		'vignette_survivor',
+		'vignette_survivor_ability_impairment',
+		'vignette_survivor_disorder',
+		'vignette_survivor_fighting_art',
+		'vignette_survivor_secret_fighting_art',
+		'vignette_survivor_gear_grid',
+		'vignette_encounter',
+		'vignette_encounter_ai_deck',
+		'vignette_encounter_monster',
+		'vignette_encounter_monster_mood',
+		'vignette_encounter_monster_trait',
+		'vignette_encounter_monster_survivor_status',
+		'vignette_encounter_survivor',
+		'vignette_encounter_survivor_ability_impairment',
+		'vignette_encounter_survivor_disorder',
+		'vignette_encounter_survivor_fighting_art',
+		'vignette_encounter_survivor_secret_fighting_art',
+		'vignette_encounter_survivor_gear_grid',
+		'vignette_encounter_shared_user'
+	] loop
+		execute format('revoke all privileges on table public.%I from anon', table_name);
+		execute format('revoke all privileges on table public.%I from authenticated', table_name);
+	end loop;
+end $$;
+
+grant select on table public.vignette_monster to authenticated;
+grant select on table public.vignette_monster_level to authenticated;
+grant select on table public.vignette_monster_level_mood to authenticated;
+grant select on table public.vignette_monster_level_trait to authenticated;
+grant select on table public.vignette_monster_level_survivor_status to authenticated;
+grant select on table public.vignette_survivor to authenticated;
+grant select on table public.vignette_survivor_ability_impairment to authenticated;
+grant select on table public.vignette_survivor_disorder to authenticated;
+grant select on table public.vignette_survivor_fighting_art to authenticated;
+grant select on table public.vignette_survivor_secret_fighting_art to authenticated;
+grant select on table public.vignette_survivor_gear_grid to authenticated;
+
+grant select, insert, update, delete on table public.vignette_encounter to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_ai_deck to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_monster to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_monster_mood to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_monster_trait to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_monster_survivor_status to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor_ability_impairment to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor_disorder to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor_fighting_art to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor_secret_fighting_art to authenticated;
+grant select, insert, update, delete on table public.vignette_encounter_survivor_gear_grid to authenticated;
+grant select, insert, delete on table public.vignette_encounter_shared_user to authenticated;
+
+--------------------------------------------------------------------------------
+-- Realtime Delete Payloads
+--------------------------------------------------------------------------------
+do $$
+declare
+	table_name text;
+begin
+	foreach table_name in array array[
+		'vignette_encounter',
+		'vignette_encounter_ai_deck',
+		'vignette_encounter_monster',
+		'vignette_encounter_monster_mood',
+		'vignette_encounter_monster_trait',
+		'vignette_encounter_monster_survivor_status',
+		'vignette_encounter_survivor',
+		'vignette_encounter_survivor_ability_impairment',
+		'vignette_encounter_survivor_disorder',
+		'vignette_encounter_survivor_fighting_art',
+		'vignette_encounter_survivor_secret_fighting_art',
+		'vignette_encounter_survivor_gear_grid',
+		'vignette_encounter_shared_user'
+	] loop
+		execute format('alter table public.%I replica identity full', table_name);
+	end loop;
+end $$;
+
+--------------------------------------------------------------------------------
+-- Catalog Copy RPC
+--------------------------------------------------------------------------------
+create or replace function public.create_vignette_encounter_from_catalog(
+	target_vignette_monster_id uuid,
+	target_level_number int
+) returns uuid language plpgsql security invoker
+set search_path = public as $$
+declare
+	current_user_id uuid := auth.uid();
+	created_encounter_id uuid;
+	created_ai_deck_id uuid;
+	created_monster_id uuid;
+	created_survivor_id uuid;
+	monster_level record;
+	source_survivor record;
+begin
+	if current_user_id is null then
+		raise exception 'Authenticated user is required to create a vignette encounter' using errcode = '42501';
+	end if;
+
+	if not exists (
+		select 1
+		from public.vignette_monster_level vml
+		where vml.vignette_monster_id = target_vignette_monster_id
+			and vml.level_number = target_level_number
+	) then
+		raise exception 'Vignette monster level does not exist' using errcode = '23514';
+	end if;
+
+	insert into public.vignette_encounter (
+		user_id,
+		vignette_monster_id,
+		level_number
+	)
+	values (
+		current_user_id,
+		target_vignette_monster_id,
+		target_level_number
+	)
+	returning id into created_encounter_id;
+
+	for monster_level in
+		select vml.*,
+			vm.monster_name as catalog_monster_name
+		from public.vignette_monster_level vml
+			join public.vignette_monster vm on vm.id = vml.vignette_monster_id
+		where vml.vignette_monster_id = target_vignette_monster_id
+			and vml.level_number = target_level_number
+		order by vml.sub_monster_name nulls first,
+			vml.id
+	loop
+		insert into public.vignette_encounter_ai_deck (
+			advanced_cards,
+			basic_cards,
+			legendary_cards,
+			overtone_cards,
+			vignette_encounter_id
+		)
+		values (
+			monster_level.advanced_cards,
+			monster_level.basic_cards,
+			monster_level.legendary_cards,
+			monster_level.overtone_cards,
+			created_encounter_id
+		)
+		returning id into created_ai_deck_id;
+
+		insert into public.vignette_encounter_monster (
+			accuracy,
+			accuracy_tokens,
+			ai_deck_id,
+			ai_deck_remaining,
+			damage,
+			damage_tokens,
+			evasion,
+			evasion_tokens,
+			luck,
+			luck_tokens,
+			monster_name,
+			movement,
+			movement_tokens,
+			source_vignette_monster_level_id,
+			speed,
+			speed_tokens,
+			strength,
+			strength_tokens,
+			toughness,
+			toughness_tokens,
+			vignette_encounter_id
+		)
+		values (
+			monster_level.accuracy,
+			monster_level.accuracy_tokens,
+			created_ai_deck_id,
+			monster_level.ai_deck_remaining,
+			monster_level.damage,
+			monster_level.damage_tokens,
+			monster_level.evasion,
+			monster_level.evasion_tokens,
+			monster_level.luck,
+			monster_level.luck_tokens,
+			coalesce(monster_level.sub_monster_name, monster_level.catalog_monster_name),
+			monster_level.movement,
+			monster_level.movement_tokens,
+			monster_level.id,
+			monster_level.speed,
+			monster_level.speed_tokens,
+			monster_level.strength,
+			monster_level.strength_tokens,
+			monster_level.toughness,
+			monster_level.toughness_tokens,
+			created_encounter_id
+		)
+		returning id into created_monster_id;
+
+		insert into public.vignette_encounter_monster_mood (
+			vignette_encounter_monster_id,
+			mood_id,
+			source_vignette_monster_level_mood_id
+		)
+		select created_monster_id,
+			vmlm.mood_id,
+			vmlm.id
+		from public.vignette_monster_level_mood vmlm
+		where vmlm.vignette_monster_level_id = monster_level.id;
+
+		insert into public.vignette_encounter_monster_trait (
+			vignette_encounter_monster_id,
+			trait_id,
+			source_vignette_monster_level_trait_id
+		)
+		select created_monster_id,
+			vmlt.trait_id,
+			vmlt.id
+		from public.vignette_monster_level_trait vmlt
+		where vmlt.vignette_monster_level_id = monster_level.id;
+
+		insert into public.vignette_encounter_monster_survivor_status (
+			vignette_encounter_monster_id,
+			survivor_status_id,
+			source_vignette_monster_level_survivor_status_id
+		)
+		select created_monster_id,
+			vmlss.survivor_status_id,
+			vmlss.id
+		from public.vignette_monster_level_survivor_status vmlss
+		where vmlss.vignette_monster_level_id = monster_level.id;
+	end loop;
+
+	for source_survivor in
+		select *
+		from public.vignette_survivor vs
+		where vs.vignette_monster_id = target_vignette_monster_id
+		order by vs.survivor_name,
+			vs.id
+	loop
+		insert into public.vignette_encounter_survivor (
+			accuracy,
+			arm_armor,
+			body_armor,
+			courage,
+			evasion,
+			gender,
+			head_armor,
+			insanity,
+			leg_armor,
+			luck,
+			movement,
+			notes,
+			source_vignette_survivor_id,
+			speed,
+			strength,
+			survival,
+			survivor_name,
+			survivor_type,
+			understanding,
+			vignette_encounter_id,
+			vignette_monster_id,
+			waist_armor,
+			weapon_proficiency,
+			weapon_type_id
+		)
+		values (
+			source_survivor.accuracy,
+			source_survivor.arm_armor,
+			source_survivor.body_armor,
+			source_survivor.courage,
+			source_survivor.evasion,
+			source_survivor.gender,
+			source_survivor.head_armor,
+			source_survivor.insanity,
+			source_survivor.leg_armor,
+			source_survivor.luck,
+			source_survivor.movement,
+			source_survivor.notes,
+			source_survivor.id,
+			source_survivor.speed,
+			source_survivor.strength,
+			source_survivor.survival,
+			source_survivor.survivor_name,
+			source_survivor.survivor_type,
+			source_survivor.understanding,
+			created_encounter_id,
+			target_vignette_monster_id,
+			source_survivor.waist_armor,
+			source_survivor.weapon_proficiency,
+			source_survivor.weapon_type_id
+		)
+		returning id into created_survivor_id;
+
+		insert into public.vignette_encounter_survivor_ability_impairment (
+			vignette_encounter_survivor_id,
+			ability_impairment_id,
+			source_vignette_survivor_ability_impairment_id
+		)
+		select created_survivor_id,
+			vsai.ability_impairment_id,
+			vsai.id
+		from public.vignette_survivor_ability_impairment vsai
+		where vsai.vignette_survivor_id = source_survivor.id;
+
+		insert into public.vignette_encounter_survivor_disorder (
+			vignette_encounter_survivor_id,
+			disorder_id,
+			source_vignette_survivor_disorder_id
+		)
+		select created_survivor_id,
+			vsd.disorder_id,
+			vsd.id
+		from public.vignette_survivor_disorder vsd
+		where vsd.vignette_survivor_id = source_survivor.id;
+
+		insert into public.vignette_encounter_survivor_fighting_art (
+			vignette_encounter_survivor_id,
+			fighting_art_id,
+			source_vignette_survivor_fighting_art_id
+		)
+		select created_survivor_id,
+			vsfa.fighting_art_id,
+			vsfa.id
+		from public.vignette_survivor_fighting_art vsfa
+		where vsfa.vignette_survivor_id = source_survivor.id;
+
+		insert into public.vignette_encounter_survivor_secret_fighting_art (
+			vignette_encounter_survivor_id,
+			secret_fighting_art_id,
+			source_vignette_survivor_secret_fighting_art_id
+		)
+		select created_survivor_id,
+			vssfa.secret_fighting_art_id,
+			vssfa.id
+		from public.vignette_survivor_secret_fighting_art vssfa
+		where vssfa.vignette_survivor_id = source_survivor.id;
+
+		insert into public.vignette_encounter_survivor_gear_grid (
+			vignette_encounter_survivor_id,
+			gear_id,
+			row_number,
+			column_number,
+			source_vignette_survivor_gear_grid_id
+		)
+		select created_survivor_id,
+			vsgg.gear_id,
+			vsgg.row_number,
+			vsgg.column_number,
+			vsgg.id
+		from public.vignette_survivor_gear_grid vsgg
+		where vsgg.vignette_survivor_id = source_survivor.id;
+	end loop;
+
+	return created_encounter_id;
+end;
+$$;
+
+revoke all on function public.create_vignette_encounter_from_catalog(uuid, int)
+from public;
+revoke execute on function public.create_vignette_encounter_from_catalog(uuid, int)
+from anon;
+grant execute on function public.create_vignette_encounter_from_catalog(uuid, int) to authenticated;

--- a/supabase/migrations/20260618015634_grant_service_role_public_access.sql
+++ b/supabase/migrations/20260618015634_grant_service_role_public_access.sql
@@ -1,0 +1,18 @@
+--------------------------------------------------------------------------------
+-- Grant Service Role Public Schema Access
+--
+-- The service_role JWT bypasses RLS, but PostgREST still requires the
+-- underlying SQL role to have table/function privileges. CI starts from a fresh
+-- local stack, so make those privileges explicit instead of relying on implicit
+-- local defaults or legacy admin RLS policies.
+--------------------------------------------------------------------------------
+
+grant usage on schema public to service_role;
+
+grant all privileges on all tables in schema public to service_role;
+grant all privileges on all sequences in schema public to service_role;
+grant execute on all functions in schema public to service_role;
+
+alter default privileges in schema public grant all privileges on tables to service_role;
+alter default privileges in schema public grant all privileges on sequences to service_role;
+alter default privileges in schema public grant execute on functions to service_role;

--- a/supabase/seeds/026_vignette_encounter_fixtures.sql
+++ b/supabase/seeds/026_vignette_encounter_fixtures.sql
@@ -1,0 +1,538 @@
+--------------------------------------------------------------------------------
+-- Vignette Encounter Fixture Data
+-- Clearly marked fixture-only one-shots for integration and UI development.
+--------------------------------------------------------------------------------
+do $$
+declare
+	white_lion_id uuid;
+	red_witches_id uuid;
+	feeding_time_id uuid;
+	frantic_spinning_id uuid;
+	necrotoxins_id uuid;
+	aleatoric_melody_id uuid;
+	cunning_id uuid;
+	merciless_id uuid;
+	boiling_blood_id uuid;
+	discouraging_presence_id uuid;
+	red_initiate_id uuid;
+	witching_cloak_id uuid;
+	battle_tempo_id uuid;
+	bloody_hands_id uuid;
+	dreaded_decade_id uuid;
+	polarized_aura_id uuid;
+	somatic_static_id uuid;
+	sword_id uuid;
+	dagger_id uuid;
+	lantern_id uuid;
+	shield_id uuid;
+	spear_id uuid;
+	founding_stone_id uuid;
+	cloth_id uuid;
+	bone_dagger_id uuid;
+	skull_helm_id uuid;
+	rawhide_headband_id uuid;
+	white_lion_gauntlet_id uuid;
+	king_spear_id uuid;
+	lantern_sword_id uuid;
+	gorment_mask_id uuid;
+	leader_id uuid;
+	mighty_strike_id uuid;
+	strategist_id uuid;
+	acrobatics_id uuid;
+	tough_id uuid;
+	red_fist_id uuid;
+	kings_step_id uuid;
+	synchronized_strike_id uuid;
+	fear_of_the_dark_id uuid;
+	cowardice_id uuid;
+	brain_smog_id uuid;
+	veteran_id uuid;
+	servant_of_fate_id uuid;
+	revenant_id uuid;
+begin
+	select id into strict white_lion_id
+	from quarry
+	where monster_name = 'White Lion'
+		and not custom;
+
+	select id into strict red_witches_id
+	from nemesis
+	where monster_name = 'Red Witches'
+		and not custom
+		and multi_monster;
+
+	select id into strict feeding_time_id from mood where mood_name = 'Feeding Time' and not custom;
+	select id into strict frantic_spinning_id from mood where mood_name = 'Frantic Spinning' and not custom;
+	select id into strict necrotoxins_id from mood where mood_name = 'Necrotoxins' and not custom;
+	select id into strict aleatoric_melody_id from mood where mood_name = 'Aleatoric Melody' and not custom;
+
+	select id into strict cunning_id from trait where trait_name = 'Cunning' and not custom;
+	select id into strict merciless_id from trait where trait_name = 'Merciless' and not custom;
+	select id into strict boiling_blood_id from trait where trait_name = 'Boiling Blood' and not custom;
+	select id into strict discouraging_presence_id from trait where trait_name = 'Discouraging Presence' and not custom;
+	select id into strict red_initiate_id from trait where trait_name = 'Red Initiate' and not custom;
+	select id into strict witching_cloak_id from trait where trait_name = 'Witching Cloak' and not custom;
+
+	select id into strict battle_tempo_id from survivor_status where survivor_status_name = 'Battle Tempo' and not custom;
+	select id into strict bloody_hands_id from survivor_status where survivor_status_name = 'Bloody Hands' and not custom;
+	select id into strict dreaded_decade_id from survivor_status where survivor_status_name = 'Dreaded Decade' and not custom;
+	select id into strict polarized_aura_id from survivor_status where survivor_status_name = 'Polarized Aura' and not custom;
+	select id into strict somatic_static_id from survivor_status where survivor_status_name = 'Somatic Static' and not custom;
+
+	select id into strict sword_id from weapon_type where weapon_type_name = 'Sword' and not custom;
+	select id into strict dagger_id from weapon_type where weapon_type_name = 'Dagger' and not custom;
+	select id into strict lantern_id from weapon_type where weapon_type_name = 'Lantern' and not custom;
+	select id into strict shield_id from weapon_type where weapon_type_name = 'Shield' and not custom;
+	select id into strict spear_id from weapon_type where weapon_type_name = 'Spear' and not custom;
+
+	select id into strict founding_stone_id from gear where gear_name = 'Founding Stone' and not custom;
+	select id into strict cloth_id from gear where gear_name = 'Cloth' and not custom;
+	select id into strict bone_dagger_id from gear where gear_name = 'Bone Dagger' and not custom;
+	select id into strict skull_helm_id from gear where gear_name = 'Skull Helm' and not custom;
+	select id into strict rawhide_headband_id from gear where gear_name = 'Rawhide Headband' and not custom;
+	select id into strict white_lion_gauntlet_id from gear where gear_name = 'White Lion Gauntlet' and not custom;
+	select id into strict king_spear_id from gear where gear_name = 'King Spear' and not custom;
+	select id into strict lantern_sword_id from gear where gear_name = 'Lantern Sword' and not custom;
+	select id into strict gorment_mask_id from gear where gear_name = 'Gorment Mask' and not custom;
+
+	select id into strict leader_id from fighting_art where fighting_art_name = 'Leader' and not custom;
+	select id into strict mighty_strike_id from fighting_art where fighting_art_name = 'Mighty Strike' and not custom;
+	select id into strict strategist_id from fighting_art where fighting_art_name = 'Strategist' and not custom;
+	select id into strict acrobatics_id from fighting_art where fighting_art_name = 'Acrobatics' and not custom;
+	select id into strict tough_id from fighting_art where fighting_art_name = 'Tough' and not custom;
+
+	select id into strict red_fist_id from secret_fighting_art where secret_fighting_art_name = 'Red Fist' and not custom;
+	select id into strict kings_step_id from secret_fighting_art where secret_fighting_art_name = 'King''s Step' and not custom;
+	select id into strict synchronized_strike_id from secret_fighting_art where secret_fighting_art_name = 'Synchronized Strike' and not custom;
+
+	select id into strict fear_of_the_dark_id from disorder where disorder_name = 'Fear of the Dark' and not custom;
+	select id into strict cowardice_id from disorder where disorder_name = 'Cowardice' and not custom;
+	select id into strict brain_smog_id from disorder where disorder_name = 'Brain Smog' and not custom;
+
+	select id into strict veteran_id from ability_impairment where ability_impairment_name = 'Veteran' and not custom;
+	select id into strict servant_of_fate_id from ability_impairment where ability_impairment_name = 'Servant of Fate' and not custom;
+	select id into strict revenant_id from ability_impairment where ability_impairment_name = 'Revenant' and not custom;
+
+	insert into vignette_encounter_definition (
+		id,
+		name,
+		slug,
+		description,
+		source_monster_type,
+		source_nemesis_id,
+		source_quarry_id,
+		sort_order,
+		published
+	)
+	values
+		(
+			'33600000-0000-4000-8000-000000000101',
+			'[Fixture] Lantern-Raked Lion',
+			'fixture-lantern-raked-lion',
+			'Fixture-only single-monster quarry vignette for integration and UI development.',
+			'QUARRY',
+			null,
+			white_lion_id,
+			10,
+			true
+		),
+		(
+			'33600000-0000-4000-8000-000000000102',
+			'[Fixture] Three Witches at the Door',
+			'fixture-three-witches-at-the-door',
+			'Fixture-only multi-monster nemesis vignette for integration and UI development.',
+			'NEMESIS',
+			red_witches_id,
+			null,
+			20,
+			true
+		)
+	on conflict (id) do update set
+		name = excluded.name,
+		slug = excluded.slug,
+		description = excluded.description,
+		source_monster_type = excluded.source_monster_type,
+		source_nemesis_id = excluded.source_nemesis_id,
+		source_quarry_id = excluded.source_quarry_id,
+		sort_order = excluded.sort_order,
+		published = excluded.published;
+
+	insert into vignette_encounter_level (
+		id,
+		vignette_encounter_definition_id,
+		level_number,
+		movement,
+		speed,
+		accuracy,
+		evasion,
+		damage,
+		toughness,
+		wounds,
+		ai_deck_size,
+		hit_location_deck_size,
+		basic_action,
+		special_rules,
+		sort_order
+	)
+	values
+		(
+			'33600000-0000-4000-8000-000000000201',
+			'33600000-0000-4000-8000-000000000101',
+			1,
+			6,
+			2,
+			4,
+			0,
+			1,
+			6,
+			8,
+			7,
+			10,
+			'Claw and Lantern Snap',
+			'Fixture setup: a single White Lion prowls the edge of the lantern light.',
+			10
+		),
+		(
+			'33600000-0000-4000-8000-000000000202',
+			'33600000-0000-4000-8000-000000000101',
+			2,
+			6,
+			2,
+			4,
+			1,
+			2,
+			8,
+			10,
+			9,
+			10,
+			'Pounce Through the Dark',
+			'Fixture setup: the lion is still a single monster, just meaner about it.',
+			20
+		),
+		(
+			'33600000-0000-4000-8000-000000000203',
+			'33600000-0000-4000-8000-000000000102',
+			1,
+			5,
+			2,
+			4,
+			1,
+			1,
+			7,
+			12,
+			8,
+			12,
+			'Witch-Flame Advance',
+			'Fixture setup: Braal and Nico share the darkness as a multi-monster nemesis source.',
+			10
+		),
+		(
+			'33600000-0000-4000-8000-000000000204',
+			'33600000-0000-4000-8000-000000000102',
+			2,
+			6,
+			3,
+			3,
+			1,
+			2,
+			9,
+			16,
+			10,
+			12,
+			'Three-Fold Hex',
+			'Fixture setup: Braal, Nico, and the Seer test multi-monster copy flows.',
+			20
+		)
+	on conflict (id) do update set
+		vignette_encounter_definition_id = excluded.vignette_encounter_definition_id,
+		level_number = excluded.level_number,
+		movement = excluded.movement,
+		speed = excluded.speed,
+		accuracy = excluded.accuracy,
+		evasion = excluded.evasion,
+		damage = excluded.damage,
+		toughness = excluded.toughness,
+		wounds = excluded.wounds,
+		ai_deck_size = excluded.ai_deck_size,
+		hit_location_deck_size = excluded.hit_location_deck_size,
+		basic_action = excluded.basic_action,
+		special_rules = excluded.special_rules,
+		sort_order = excluded.sort_order;
+
+	insert into vignette_encounter_level_mood (id, vignette_encounter_level_id, mood_id, sort_order)
+	values
+		('33600000-0000-4000-8000-000000000301', '33600000-0000-4000-8000-000000000201', feeding_time_id, 10),
+		('33600000-0000-4000-8000-000000000302', '33600000-0000-4000-8000-000000000202', frantic_spinning_id, 10),
+		('33600000-0000-4000-8000-000000000303', '33600000-0000-4000-8000-000000000203', necrotoxins_id, 10),
+		('33600000-0000-4000-8000-000000000304', '33600000-0000-4000-8000-000000000204', aleatoric_melody_id, 10)
+	on conflict (vignette_encounter_level_id, mood_id) do update set
+		sort_order = excluded.sort_order;
+
+	insert into vignette_encounter_level_trait (id, vignette_encounter_level_id, trait_id, sort_order)
+	values
+		('33600000-0000-4000-8000-000000000401', '33600000-0000-4000-8000-000000000201', cunning_id, 10),
+		('33600000-0000-4000-8000-000000000402', '33600000-0000-4000-8000-000000000202', merciless_id, 10),
+		('33600000-0000-4000-8000-000000000403', '33600000-0000-4000-8000-000000000203', boiling_blood_id, 10),
+		('33600000-0000-4000-8000-000000000404', '33600000-0000-4000-8000-000000000203', discouraging_presence_id, 20),
+		('33600000-0000-4000-8000-000000000405', '33600000-0000-4000-8000-000000000204', red_initiate_id, 10),
+		('33600000-0000-4000-8000-000000000406', '33600000-0000-4000-8000-000000000204', witching_cloak_id, 20)
+	on conflict (vignette_encounter_level_id, trait_id) do update set
+		sort_order = excluded.sort_order;
+
+	insert into vignette_encounter_level_survivor_status (id, vignette_encounter_level_id, survivor_status_id, sort_order)
+	values
+		('33600000-0000-4000-8000-000000000501', '33600000-0000-4000-8000-000000000201', bloody_hands_id, 10),
+		('33600000-0000-4000-8000-000000000502', '33600000-0000-4000-8000-000000000202', battle_tempo_id, 10),
+		('33600000-0000-4000-8000-000000000503', '33600000-0000-4000-8000-000000000203', somatic_static_id, 10),
+		('33600000-0000-4000-8000-000000000504', '33600000-0000-4000-8000-000000000204', dreaded_decade_id, 10),
+		('33600000-0000-4000-8000-000000000505', '33600000-0000-4000-8000-000000000204', polarized_aura_id, 20)
+	on conflict (vignette_encounter_level_id, survivor_status_id) do update set
+		sort_order = excluded.sort_order;
+
+	insert into vignette_survivor_template (
+		id,
+		vignette_encounter_definition_id,
+		survivor_name,
+		survivor_type,
+		gender,
+		movement,
+		accuracy,
+		strength,
+		evasion,
+		luck,
+		speed,
+		survival,
+		insanity,
+		courage,
+		understanding,
+		weapon_proficiency,
+		weapon_type_id,
+		arm_armor,
+		body_armor,
+		head_armor,
+		leg_armor,
+		waist_armor,
+		notes,
+		sort_order
+	)
+	values
+		(
+			'33600000-0000-4000-8000-000000000601',
+			'33600000-0000-4000-8000-000000000101',
+			'[Fixture] Ashen Blade',
+			'CORE',
+			'FEMALE',
+			5,
+			1,
+			1,
+			1,
+			0,
+			0,
+			3,
+			4,
+			2,
+			1,
+			2,
+			sword_id,
+			1,
+			1,
+			1,
+			1,
+			1,
+			'Fixture-only survivor template for the single-monster quarry vignette.',
+			10
+		),
+		(
+			'33600000-0000-4000-8000-000000000602',
+			'33600000-0000-4000-8000-000000000101',
+			'[Fixture] Lantern Hook',
+			'CORE',
+			'MALE',
+			5,
+			0,
+			1,
+			2,
+			0,
+			1,
+			4,
+			2,
+			1,
+			2,
+			1,
+			dagger_id,
+			2,
+			1,
+			1,
+			0,
+			1,
+			'Fixture-only survivor template with an offset gear grid.',
+			20
+		),
+		(
+			'33600000-0000-4000-8000-000000000603',
+			'33600000-0000-4000-8000-000000000102',
+			'[Fixture] Braal Ward',
+			'CORE',
+			'FEMALE',
+			5,
+			0,
+			2,
+			0,
+			1,
+			0,
+			2,
+			5,
+			3,
+			1,
+			3,
+			shield_id,
+			2,
+			2,
+			1,
+			1,
+			1,
+			'Fixture-only survivor template for the multi-monster nemesis vignette.',
+			10
+		),
+		(
+			'33600000-0000-4000-8000-000000000604',
+			'33600000-0000-4000-8000-000000000102',
+			'[Fixture] Nico Spark',
+			'CORE',
+			'MALE',
+			5,
+			1,
+			1,
+			1,
+			0,
+			1,
+			3,
+			6,
+			2,
+			2,
+			2,
+			lantern_id,
+			1,
+			2,
+			1,
+			1,
+			1,
+			'Fixture-only survivor template carrying a lantern weapon type.',
+			20
+		),
+		(
+			'33600000-0000-4000-8000-000000000605',
+			'33600000-0000-4000-8000-000000000102',
+			'[Fixture] Seer Thread',
+			'CORE',
+			'FEMALE',
+			6,
+			1,
+			0,
+			2,
+			1,
+			0,
+			5,
+			8,
+			4,
+			4,
+			1,
+			spear_id,
+			1,
+			1,
+			2,
+			1,
+			2,
+			'Fixture-only survivor template for testing a fuller copied party.',
+			30
+		)
+	on conflict (id) do update set
+		vignette_encounter_definition_id = excluded.vignette_encounter_definition_id,
+		survivor_name = excluded.survivor_name,
+		survivor_type = excluded.survivor_type,
+		gender = excluded.gender,
+		movement = excluded.movement,
+		accuracy = excluded.accuracy,
+		strength = excluded.strength,
+		evasion = excluded.evasion,
+		luck = excluded.luck,
+		speed = excluded.speed,
+		survival = excluded.survival,
+		insanity = excluded.insanity,
+		courage = excluded.courage,
+		understanding = excluded.understanding,
+		weapon_proficiency = excluded.weapon_proficiency,
+		weapon_type_id = excluded.weapon_type_id,
+		arm_armor = excluded.arm_armor,
+		body_armor = excluded.body_armor,
+		head_armor = excluded.head_armor,
+		leg_armor = excluded.leg_armor,
+		waist_armor = excluded.waist_armor,
+		notes = excluded.notes,
+		sort_order = excluded.sort_order;
+
+	insert into vignette_survivor_template_fighting_art (id, vignette_survivor_template_id, fighting_art_id, sort_order)
+	values
+		('33600000-0000-4000-8000-000000000701', '33600000-0000-4000-8000-000000000601', leader_id, 10),
+		('33600000-0000-4000-8000-000000000702', '33600000-0000-4000-8000-000000000601', mighty_strike_id, 20),
+		('33600000-0000-4000-8000-000000000703', '33600000-0000-4000-8000-000000000602', strategist_id, 10),
+		('33600000-0000-4000-8000-000000000704', '33600000-0000-4000-8000-000000000603', tough_id, 10),
+		('33600000-0000-4000-8000-000000000705', '33600000-0000-4000-8000-000000000604', acrobatics_id, 10),
+		('33600000-0000-4000-8000-000000000706', '33600000-0000-4000-8000-000000000605', leader_id, 10)
+	on conflict (vignette_survivor_template_id, fighting_art_id) do update set
+		sort_order = excluded.sort_order;
+
+	insert into vignette_survivor_template_secret_fighting_art (id, vignette_survivor_template_id, secret_fighting_art_id, sort_order)
+	values
+		('33600000-0000-4000-8000-000000000801', '33600000-0000-4000-8000-000000000601', red_fist_id, 10),
+		('33600000-0000-4000-8000-000000000802', '33600000-0000-4000-8000-000000000603', kings_step_id, 10),
+		('33600000-0000-4000-8000-000000000803', '33600000-0000-4000-8000-000000000605', synchronized_strike_id, 10)
+	on conflict (vignette_survivor_template_id, secret_fighting_art_id) do update set
+		sort_order = excluded.sort_order;
+
+	insert into vignette_survivor_template_disorder (id, vignette_survivor_template_id, disorder_id, sort_order)
+	values
+		('33600000-0000-4000-8000-000000000901', '33600000-0000-4000-8000-000000000602', fear_of_the_dark_id, 10),
+		('33600000-0000-4000-8000-000000000902', '33600000-0000-4000-8000-000000000604', brain_smog_id, 10),
+		('33600000-0000-4000-8000-000000000903', '33600000-0000-4000-8000-000000000605', cowardice_id, 10)
+	on conflict (vignette_survivor_template_id, disorder_id) do update set
+		sort_order = excluded.sort_order;
+
+	insert into vignette_survivor_template_ability_impairment (id, vignette_survivor_template_id, ability_impairment_id, sort_order)
+	values
+		('33600000-0000-4000-8000-000000001001', '33600000-0000-4000-8000-000000000601', veteran_id, 10),
+		('33600000-0000-4000-8000-000000001002', '33600000-0000-4000-8000-000000000603', servant_of_fate_id, 10),
+		('33600000-0000-4000-8000-000000001003', '33600000-0000-4000-8000-000000000605', revenant_id, 10)
+	on conflict (vignette_survivor_template_id, ability_impairment_id) do update set
+		sort_order = excluded.sort_order;
+
+	insert into vignette_survivor_template_survivor_status (id, vignette_survivor_template_id, survivor_status_id, sort_order)
+	values
+		('33600000-0000-4000-8000-000000001101', '33600000-0000-4000-8000-000000000601', bloody_hands_id, 10),
+		('33600000-0000-4000-8000-000000001102', '33600000-0000-4000-8000-000000000603', battle_tempo_id, 10),
+		('33600000-0000-4000-8000-000000001103', '33600000-0000-4000-8000-000000000604', somatic_static_id, 10),
+		('33600000-0000-4000-8000-000000001104', '33600000-0000-4000-8000-000000000605', polarized_aura_id, 10)
+	on conflict (vignette_survivor_template_id, survivor_status_id) do update set
+		sort_order = excluded.sort_order;
+
+	insert into vignette_survivor_template_gear_grid (id, vignette_survivor_template_id, gear_id, row_number, column_number)
+	values
+		('33600000-0000-4000-8000-000000001201', '33600000-0000-4000-8000-000000000601', founding_stone_id, 0, 0),
+		('33600000-0000-4000-8000-000000001202', '33600000-0000-4000-8000-000000000601', cloth_id, 0, 1),
+		('33600000-0000-4000-8000-000000001203', '33600000-0000-4000-8000-000000000601', bone_dagger_id, 1, 0),
+		('33600000-0000-4000-8000-000000001204', '33600000-0000-4000-8000-000000000601', rawhide_headband_id, 1, 1),
+		('33600000-0000-4000-8000-000000001205', '33600000-0000-4000-8000-000000000602', white_lion_gauntlet_id, 0, 0),
+		('33600000-0000-4000-8000-000000001206', '33600000-0000-4000-8000-000000000602', bone_dagger_id, 0, 1),
+		('33600000-0000-4000-8000-000000001207', '33600000-0000-4000-8000-000000000602', skull_helm_id, 1, 0),
+		('33600000-0000-4000-8000-000000001208', '33600000-0000-4000-8000-000000000603', king_spear_id, 0, 0),
+		('33600000-0000-4000-8000-000000001209', '33600000-0000-4000-8000-000000000603', skull_helm_id, 1, 0),
+		('33600000-0000-4000-8000-000000001210', '33600000-0000-4000-8000-000000000603', cloth_id, 2, 0),
+		('33600000-0000-4000-8000-000000001211', '33600000-0000-4000-8000-000000000604', lantern_sword_id, 0, 0),
+		('33600000-0000-4000-8000-000000001212', '33600000-0000-4000-8000-000000000604', gorment_mask_id, 1, 0),
+		('33600000-0000-4000-8000-000000001213', '33600000-0000-4000-8000-000000000604', founding_stone_id, 1, 1),
+		('33600000-0000-4000-8000-000000001214', '33600000-0000-4000-8000-000000000605', rawhide_headband_id, 0, 0),
+		('33600000-0000-4000-8000-000000001215', '33600000-0000-4000-8000-000000000605', bone_dagger_id, 0, 1),
+		('33600000-0000-4000-8000-000000001216', '33600000-0000-4000-8000-000000000605', cloth_id, 1, 1)
+	on conflict (vignette_survivor_template_id, row_number, column_number) do update set
+		gear_id = excluded.gear_id;
+end $$;

--- a/supabase/seeds/026_vignette_encounter_fixtures.sql
+++ b/supabase/seeds/026_vignette_encounter_fixtures.sql
@@ -1,538 +1,1820 @@
 --------------------------------------------------------------------------------
--- Vignette Encounter Fixture Data
--- Clearly marked fixture-only one-shots for integration and UI development.
+-- Vignette Fixture Gear Data
 --------------------------------------------------------------------------------
-do $$
-declare
-	white_lion_id uuid;
-	red_witches_id uuid;
-	feeding_time_id uuid;
-	frantic_spinning_id uuid;
-	necrotoxins_id uuid;
-	aleatoric_melody_id uuid;
-	cunning_id uuid;
-	merciless_id uuid;
-	boiling_blood_id uuid;
-	discouraging_presence_id uuid;
-	red_initiate_id uuid;
-	witching_cloak_id uuid;
-	battle_tempo_id uuid;
-	bloody_hands_id uuid;
-	dreaded_decade_id uuid;
-	polarized_aura_id uuid;
-	somatic_static_id uuid;
-	sword_id uuid;
-	dagger_id uuid;
-	lantern_id uuid;
-	shield_id uuid;
-	spear_id uuid;
-	founding_stone_id uuid;
-	cloth_id uuid;
-	bone_dagger_id uuid;
-	skull_helm_id uuid;
-	rawhide_headband_id uuid;
-	white_lion_gauntlet_id uuid;
-	king_spear_id uuid;
-	lantern_sword_id uuid;
-	gorment_mask_id uuid;
-	leader_id uuid;
-	mighty_strike_id uuid;
-	strategist_id uuid;
-	acrobatics_id uuid;
-	tough_id uuid;
-	red_fist_id uuid;
-	kings_step_id uuid;
-	synchronized_strike_id uuid;
-	fear_of_the_dark_id uuid;
-	cowardice_id uuid;
-	brain_smog_id uuid;
-	veteran_id uuid;
-	servant_of_fate_id uuid;
-	revenant_id uuid;
-begin
-	select id into strict white_lion_id
-	from quarry
-	where monster_name = 'White Lion'
-		and not custom;
-
-	select id into strict red_witches_id
-	from nemesis
-	where monster_name = 'Red Witches'
-		and not custom
-		and multi_monster;
-
-	select id into strict feeding_time_id from mood where mood_name = 'Feeding Time' and not custom;
-	select id into strict frantic_spinning_id from mood where mood_name = 'Frantic Spinning' and not custom;
-	select id into strict necrotoxins_id from mood where mood_name = 'Necrotoxins' and not custom;
-	select id into strict aleatoric_melody_id from mood where mood_name = 'Aleatoric Melody' and not custom;
-
-	select id into strict cunning_id from trait where trait_name = 'Cunning' and not custom;
-	select id into strict merciless_id from trait where trait_name = 'Merciless' and not custom;
-	select id into strict boiling_blood_id from trait where trait_name = 'Boiling Blood' and not custom;
-	select id into strict discouraging_presence_id from trait where trait_name = 'Discouraging Presence' and not custom;
-	select id into strict red_initiate_id from trait where trait_name = 'Red Initiate' and not custom;
-	select id into strict witching_cloak_id from trait where trait_name = 'Witching Cloak' and not custom;
-
-	select id into strict battle_tempo_id from survivor_status where survivor_status_name = 'Battle Tempo' and not custom;
-	select id into strict bloody_hands_id from survivor_status where survivor_status_name = 'Bloody Hands' and not custom;
-	select id into strict dreaded_decade_id from survivor_status where survivor_status_name = 'Dreaded Decade' and not custom;
-	select id into strict polarized_aura_id from survivor_status where survivor_status_name = 'Polarized Aura' and not custom;
-	select id into strict somatic_static_id from survivor_status where survivor_status_name = 'Somatic Static' and not custom;
-
-	select id into strict sword_id from weapon_type where weapon_type_name = 'Sword' and not custom;
-	select id into strict dagger_id from weapon_type where weapon_type_name = 'Dagger' and not custom;
-	select id into strict lantern_id from weapon_type where weapon_type_name = 'Lantern' and not custom;
-	select id into strict shield_id from weapon_type where weapon_type_name = 'Shield' and not custom;
-	select id into strict spear_id from weapon_type where weapon_type_name = 'Spear' and not custom;
-
-	select id into strict founding_stone_id from gear where gear_name = 'Founding Stone' and not custom;
-	select id into strict cloth_id from gear where gear_name = 'Cloth' and not custom;
-	select id into strict bone_dagger_id from gear where gear_name = 'Bone Dagger' and not custom;
-	select id into strict skull_helm_id from gear where gear_name = 'Skull Helm' and not custom;
-	select id into strict rawhide_headband_id from gear where gear_name = 'Rawhide Headband' and not custom;
-	select id into strict white_lion_gauntlet_id from gear where gear_name = 'White Lion Gauntlet' and not custom;
-	select id into strict king_spear_id from gear where gear_name = 'King Spear' and not custom;
-	select id into strict lantern_sword_id from gear where gear_name = 'Lantern Sword' and not custom;
-	select id into strict gorment_mask_id from gear where gear_name = 'Gorment Mask' and not custom;
-
-	select id into strict leader_id from fighting_art where fighting_art_name = 'Leader' and not custom;
-	select id into strict mighty_strike_id from fighting_art where fighting_art_name = 'Mighty Strike' and not custom;
-	select id into strict strategist_id from fighting_art where fighting_art_name = 'Strategist' and not custom;
-	select id into strict acrobatics_id from fighting_art where fighting_art_name = 'Acrobatics' and not custom;
-	select id into strict tough_id from fighting_art where fighting_art_name = 'Tough' and not custom;
-
-	select id into strict red_fist_id from secret_fighting_art where secret_fighting_art_name = 'Red Fist' and not custom;
-	select id into strict kings_step_id from secret_fighting_art where secret_fighting_art_name = 'King''s Step' and not custom;
-	select id into strict synchronized_strike_id from secret_fighting_art where secret_fighting_art_name = 'Synchronized Strike' and not custom;
-
-	select id into strict fear_of_the_dark_id from disorder where disorder_name = 'Fear of the Dark' and not custom;
-	select id into strict cowardice_id from disorder where disorder_name = 'Cowardice' and not custom;
-	select id into strict brain_smog_id from disorder where disorder_name = 'Brain Smog' and not custom;
-
-	select id into strict veteran_id from ability_impairment where ability_impairment_name = 'Veteran' and not custom;
-	select id into strict servant_of_fate_id from ability_impairment where ability_impairment_name = 'Servant of Fate' and not custom;
-	select id into strict revenant_id from ability_impairment where ability_impairment_name = 'Revenant' and not custom;
-
-	insert into vignette_encounter_definition (
-		id,
-		name,
-		slug,
-		description,
-		source_monster_type,
-		source_nemesis_id,
-		source_quarry_id,
-		sort_order,
-		published
-	)
+insert into gear (gear_name)
+select fixture_gear.gear_name
+from (
 	values
-		(
-			'33600000-0000-4000-8000-000000000101',
-			'[Fixture] Lantern-Raked Lion',
-			'fixture-lantern-raked-lion',
-			'Fixture-only single-monster quarry vignette for integration and UI development.',
-			'QUARRY',
-			null,
-			white_lion_id,
-			10,
-			true
-		),
-		(
-			'33600000-0000-4000-8000-000000000102',
-			'[Fixture] Three Witches at the Door',
-			'fixture-three-witches-at-the-door',
-			'Fixture-only multi-monster nemesis vignette for integration and UI development.',
-			'NEMESIS',
-			red_witches_id,
-			null,
-			20,
-			true
+		('Ambush Falchion'),
+		('Braveshield'),
+		('Bravesword'),
+		('Cobbled Faulds'),
+		('Cobbled Greaves'),
+		('Cobbled Plackart'),
+		('Cobbled Vambraces'),
+		('Crusader Breastplate'),
+		('Crusader Cuisses'),
+		('Crusader Gauntlets'),
+		('Crusader Heirloom'),
+		('Crusader Sabatons'),
+		('Heart of a Hero'),
+		('Laurie''s Lenses'),
+		('Locking Tome'),
+		('Memento Blade'),
+		('Mush Diadema'),
+		('Protean Charm'),
+		('Ram Photophore'),
+		('Sacrificial Fang'),
+		('Sculptor Beads'),
+		('Shadowstalker Geta'),
+		('Shadowstalker Houmongi'),
+		('Shadowstalker Kasa'),
+		('Shadowstalker Obi'),
+		('Shadowstalker Sode'),
+		('Stoic Mask'),
+		('Stonescraper'),
+		('Survival Spear'),
+		('Tattered Archivist Robe'),
+		('Warding Guidon Lance'),
+		('Warding Tower Shield')
+) as fixture_gear(gear_name)
+where not exists (
+	select 1
+	from gear
+	where gear.gear_name = fixture_gear.gear_name
+		and gear.custom is false
+);
+--------------------------------------------------------------------------------
+-- Vignette Monster Data
+--------------------------------------------------------------------------------
+insert into vignette_monster
+(
+	monster_name,
+	multi_monster,
+	source_monster_type,
+	source_nemesis_id,
+	source_quarry_id
+)
+values
+(
+	'Killenium Butcher', -- Name
+	false, -- Multi Monster
+	'NEMESIS', -- Source Monster Type
+	(select id from nemesis where monster_name = 'Killenium Butcher'), -- Source Nemesis ID
+	null -- Source Quarry ID
+),
+(
+	'Screaming God', -- Name
+	false, -- Multi Monster
+	'QUARRY', -- Source Monster Type
+	null, -- Source Nemesis ID
+	(select id from quarry where monster_name = 'Screaming God') -- Source Quarry ID
+),
+(
+	'Screaming Nukalope', -- Name
+	false, -- Multi Monster
+	'QUARRY', -- Source Monster Type
+	null, -- Source Nemesis ID
+	(select id from quarry where monster_name = 'Screaming Nukalope') -- Source Quarry ID
+),
+(
+	'White Gigalion', -- Name
+	false, -- Multi Monster
+	'QUARRY', -- Source Monster Type
+	null, -- Source Nemesis ID
+	(select id from quarry where monster_name = 'White Gigalion') -- Source Quarry ID
+);
+--------------------------------------------------------------------------------
+-- Vignette Monster Level Data
+--------------------------------------------------------------------------------
+insert into vignette_monster_level
+(
+	ai_deck_remaining,
+	basic_cards,
+	advanced_cards,
+	legendary_cards,
+	overtone_cards,
+	accuracy,
+	accuracy_tokens,
+	damage,
+	damage_tokens,
+	evasion,
+	evasion_tokens,
+	level_number,
+	life,
+	luck,
+	luck_tokens,
+	movement,
+	movement_tokens,
+	sub_monster_name,
+	speed,
+	speed_tokens,
+	strength,
+	strength_tokens,
+	toughness,
+	toughness_tokens,
+	vignette_monster_id
+)
+values
+(
+	15, -- AI Deck Remaining
+	9, -- Basic Cards
+	6, -- Advanced Cards
+	0, -- Legendary Cards
+	0, -- Overtone Cards
+	0, -- Accuracy
+	1, -- Accuracy Tokens
+	1, -- Damage
+	0, -- Damage Tokens
+	0, -- Evasion
+	0, -- Evasion Tokens
+	2, -- Level Number
+	null, -- Life
+	0, -- Luck
+	0, -- Luck Tokens
+	5, -- Movement
+	0, -- Movement Tokens
+	null, -- Sub Monster Name
+	1, -- Speed
+	0, -- Speed Tokens
+	0, -- Strength
+	0, -- Strength Tokens
+	13, -- Toughness
+	0, -- Toughness Tokens
+	(select id from vignette_monster where monster_name = 'Killenium Butcher') -- Vignette Monster ID
+),
+(
+	16, -- AI Deck Remaining
+	11, -- Basic Cards
+	5, -- Advanced Cards
+	0, -- Legendary Cards
+	0, -- Overtone Cards
+	0, -- Accuracy
+	0, -- Accuracy Tokens
+	0, -- Damage
+	0, -- Damage Tokens
+	0, -- Evasion
+	0, -- Evasion Tokens
+	1, -- Level Number
+	null, -- Life
+	0, -- Luck
+	0, -- Luck Tokens
+	-1, -- Movement
+	0, -- Movement Tokens
+	null, -- Sub Monster Name
+	0, -- Speed
+	0, -- Speed Tokens
+	0, -- Strength
+	0, -- Strength Tokens
+	18, -- Toughness
+	0, -- Toughness Tokens
+	(select id from vignette_monster where monster_name = 'Screaming God') -- Vignette Monster ID
+),
+(
+	16, -- AI Deck Remaining
+	9, -- Basic Cards
+	7, -- Advanced Cards
+	0, -- Legendary Cards
+	0, -- Overtone Cards
+	0, -- Accuracy
+	1, -- Accuracy Tokens
+	0, -- Damage
+	0, -- Damage Tokens
+	0, -- Evasion
+	0, -- Evasion Tokens
+	2, -- Level Number
+	null, -- Life
+	0, -- Luck
+	0, -- Luck Tokens
+	9, -- Movement
+	0, -- Movement Tokens
+	null, -- Sub Monster Name
+	2, -- Speed
+	0, -- Speed Tokens
+	0, -- Strength
+	0, -- Strength Tokens
+	11, -- Toughness
+	0, -- Toughness Tokens
+	(select id from vignette_monster where monster_name = 'Screaming Nukalope') -- Vignette Monster ID
+),
+(
+	15, -- AI Deck Remaining
+	10, -- Basic Cards
+	5, -- Advanced Cards
+	0, -- Legendary Cards
+	0, -- Overtone Cards
+	0, -- Accuracy
+	0, -- Accuracy Tokens
+	1, -- Damage
+	0, -- Damage Tokens
+	0, -- Evasion
+	0, -- Evasion Tokens
+	2, -- Level Number
+	null, -- Life
+	0, -- Luck
+	0, -- Luck Tokens
+	8, -- Movement
+	0, -- Movement Tokens
+	null, -- Sub Monster Name
+	1, -- Speed
+	0, -- Speed Tokens
+	0, -- Strength
+	0, -- Strength Tokens
+	10, -- Toughness
+	0, -- Toughness Tokens
+	(select id from vignette_monster where monster_name = 'White Gigalion') -- Vignette Monster ID
+);
+--------------------------------------------------------------------------------
+-- Vignette Monster Level Survivor Status
+--------------------------------------------------------------------------------
+insert into vignette_monster_level_survivor_status
+(
+	vignette_monster_level_id,
+	survivor_status_id
+)
+values
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'Killenium Butcher'
 		)
-	on conflict (id) do update set
-		name = excluded.name,
-		slug = excluded.slug,
-		description = excluded.description,
-		source_monster_type = excluded.source_monster_type,
-		source_nemesis_id = excluded.source_nemesis_id,
-		source_quarry_id = excluded.source_quarry_id,
-		sort_order = excluded.sort_order,
-		published = excluded.published;
-
-	insert into vignette_encounter_level (
-		id,
-		vignette_encounter_definition_id,
-		level_number,
-		movement,
-		speed,
-		accuracy,
-		evasion,
-		damage,
-		toughness,
-		wounds,
-		ai_deck_size,
-		hit_location_deck_size,
-		basic_action,
-		special_rules,
-		sort_order
+		and level_number = 2
+	),
+	(
+		select id from survivor_status
+		where survivor_status_name = 'Infectious Lunacy'
+		and custom = false
 	)
-	values
-		(
-			'33600000-0000-4000-8000-000000000201',
-			'33600000-0000-4000-8000-000000000101',
-			1,
-			6,
-			2,
-			4,
-			0,
-			1,
-			6,
-			8,
-			7,
-			10,
-			'Claw and Lantern Snap',
-			'Fixture setup: a single White Lion prowls the edge of the lantern light.',
-			10
-		),
-		(
-			'33600000-0000-4000-8000-000000000202',
-			'33600000-0000-4000-8000-000000000101',
-			2,
-			6,
-			2,
-			4,
-			1,
-			2,
-			8,
-			10,
-			9,
-			10,
-			'Pounce Through the Dark',
-			'Fixture setup: the lion is still a single monster, just meaner about it.',
-			20
-		),
-		(
-			'33600000-0000-4000-8000-000000000203',
-			'33600000-0000-4000-8000-000000000102',
-			1,
-			5,
-			2,
-			4,
-			1,
-			1,
-			7,
-			12,
-			8,
-			12,
-			'Witch-Flame Advance',
-			'Fixture setup: Braal and Nico share the darkness as a multi-monster nemesis source.',
-			10
-		),
-		(
-			'33600000-0000-4000-8000-000000000204',
-			'33600000-0000-4000-8000-000000000102',
-			2,
-			6,
-			3,
-			3,
-			1,
-			2,
-			9,
-			16,
-			10,
-			12,
-			'Three-Fold Hex',
-			'Fixture setup: Braal, Nico, and the Seer test multi-monster copy flows.',
-			20
+);
+--------------------------------------------------------------------------------
+-- Vignette Monster Level Trait
+--------------------------------------------------------------------------------
+insert into vignette_monster_level_trait
+(
+	vignette_monster_level_id,
+	trait_id
+)
+values
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'Killenium Butcher'
 		)
-	on conflict (id) do update set
-		vignette_encounter_definition_id = excluded.vignette_encounter_definition_id,
-		level_number = excluded.level_number,
-		movement = excluded.movement,
-		speed = excluded.speed,
-		accuracy = excluded.accuracy,
-		evasion = excluded.evasion,
-		damage = excluded.damage,
-		toughness = excluded.toughness,
-		wounds = excluded.wounds,
-		ai_deck_size = excluded.ai_deck_size,
-		hit_location_deck_size = excluded.hit_location_deck_size,
-		basic_action = excluded.basic_action,
-		special_rules = excluded.special_rules,
-		sort_order = excluded.sort_order;
-
-	insert into vignette_encounter_level_mood (id, vignette_encounter_level_id, mood_id, sort_order)
-	values
-		('33600000-0000-4000-8000-000000000301', '33600000-0000-4000-8000-000000000201', feeding_time_id, 10),
-		('33600000-0000-4000-8000-000000000302', '33600000-0000-4000-8000-000000000202', frantic_spinning_id, 10),
-		('33600000-0000-4000-8000-000000000303', '33600000-0000-4000-8000-000000000203', necrotoxins_id, 10),
-		('33600000-0000-4000-8000-000000000304', '33600000-0000-4000-8000-000000000204', aleatoric_melody_id, 10)
-	on conflict (vignette_encounter_level_id, mood_id) do update set
-		sort_order = excluded.sort_order;
-
-	insert into vignette_encounter_level_trait (id, vignette_encounter_level_id, trait_id, sort_order)
-	values
-		('33600000-0000-4000-8000-000000000401', '33600000-0000-4000-8000-000000000201', cunning_id, 10),
-		('33600000-0000-4000-8000-000000000402', '33600000-0000-4000-8000-000000000202', merciless_id, 10),
-		('33600000-0000-4000-8000-000000000403', '33600000-0000-4000-8000-000000000203', boiling_blood_id, 10),
-		('33600000-0000-4000-8000-000000000404', '33600000-0000-4000-8000-000000000203', discouraging_presence_id, 20),
-		('33600000-0000-4000-8000-000000000405', '33600000-0000-4000-8000-000000000204', red_initiate_id, 10),
-		('33600000-0000-4000-8000-000000000406', '33600000-0000-4000-8000-000000000204', witching_cloak_id, 20)
-	on conflict (vignette_encounter_level_id, trait_id) do update set
-		sort_order = excluded.sort_order;
-
-	insert into vignette_encounter_level_survivor_status (id, vignette_encounter_level_id, survivor_status_id, sort_order)
-	values
-		('33600000-0000-4000-8000-000000000501', '33600000-0000-4000-8000-000000000201', bloody_hands_id, 10),
-		('33600000-0000-4000-8000-000000000502', '33600000-0000-4000-8000-000000000202', battle_tempo_id, 10),
-		('33600000-0000-4000-8000-000000000503', '33600000-0000-4000-8000-000000000203', somatic_static_id, 10),
-		('33600000-0000-4000-8000-000000000504', '33600000-0000-4000-8000-000000000204', dreaded_decade_id, 10),
-		('33600000-0000-4000-8000-000000000505', '33600000-0000-4000-8000-000000000204', polarized_aura_id, 20)
-	on conflict (vignette_encounter_level_id, survivor_status_id) do update set
-		sort_order = excluded.sort_order;
-
-	insert into vignette_survivor_template (
-		id,
-		vignette_encounter_definition_id,
-		survivor_name,
-		survivor_type,
-		gender,
-		movement,
-		accuracy,
-		strength,
-		evasion,
-		luck,
-		speed,
-		survival,
-		insanity,
-		courage,
-		understanding,
-		weapon_proficiency,
-		weapon_type_id,
-		arm_armor,
-		body_armor,
-		head_armor,
-		leg_armor,
-		waist_armor,
-		notes,
-		sort_order
+		and level_number = 2
+	),
+	(
+		select id from trait
+		where trait_name = 'Self-Aware'
+		and custom = false
 	)
-	values
-		(
-			'33600000-0000-4000-8000-000000000601',
-			'33600000-0000-4000-8000-000000000101',
-			'[Fixture] Ashen Blade',
-			'CORE',
-			'FEMALE',
-			5,
-			1,
-			1,
-			1,
-			0,
-			0,
-			3,
-			4,
-			2,
-			1,
-			2,
-			sword_id,
-			1,
-			1,
-			1,
-			1,
-			1,
-			'Fixture-only survivor template for the single-monster quarry vignette.',
-			10
-		),
-		(
-			'33600000-0000-4000-8000-000000000602',
-			'33600000-0000-4000-8000-000000000101',
-			'[Fixture] Lantern Hook',
-			'CORE',
-			'MALE',
-			5,
-			0,
-			1,
-			2,
-			0,
-			1,
-			4,
-			2,
-			1,
-			2,
-			1,
-			dagger_id,
-			2,
-			1,
-			1,
-			0,
-			1,
-			'Fixture-only survivor template with an offset gear grid.',
-			20
-		),
-		(
-			'33600000-0000-4000-8000-000000000603',
-			'33600000-0000-4000-8000-000000000102',
-			'[Fixture] Braal Ward',
-			'CORE',
-			'FEMALE',
-			5,
-			0,
-			2,
-			0,
-			1,
-			0,
-			2,
-			5,
-			3,
-			1,
-			3,
-			shield_id,
-			2,
-			2,
-			1,
-			1,
-			1,
-			'Fixture-only survivor template for the multi-monster nemesis vignette.',
-			10
-		),
-		(
-			'33600000-0000-4000-8000-000000000604',
-			'33600000-0000-4000-8000-000000000102',
-			'[Fixture] Nico Spark',
-			'CORE',
-			'MALE',
-			5,
-			1,
-			1,
-			1,
-			0,
-			1,
-			3,
-			6,
-			2,
-			2,
-			2,
-			lantern_id,
-			1,
-			2,
-			1,
-			1,
-			1,
-			'Fixture-only survivor template carrying a lantern weapon type.',
-			20
-		),
-		(
-			'33600000-0000-4000-8000-000000000605',
-			'33600000-0000-4000-8000-000000000102',
-			'[Fixture] Seer Thread',
-			'CORE',
-			'FEMALE',
-			6,
-			1,
-			0,
-			2,
-			1,
-			0,
-			5,
-			8,
-			4,
-			4,
-			1,
-			spear_id,
-			1,
-			1,
-			2,
-			1,
-			2,
-			'Fixture-only survivor template for testing a fuller copied party.',
-			30
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'Killenium Butcher'
 		)
-	on conflict (id) do update set
-		vignette_encounter_definition_id = excluded.vignette_encounter_definition_id,
-		survivor_name = excluded.survivor_name,
-		survivor_type = excluded.survivor_type,
-		gender = excluded.gender,
-		movement = excluded.movement,
-		accuracy = excluded.accuracy,
-		strength = excluded.strength,
-		evasion = excluded.evasion,
-		luck = excluded.luck,
-		speed = excluded.speed,
-		survival = excluded.survival,
-		insanity = excluded.insanity,
-		courage = excluded.courage,
-		understanding = excluded.understanding,
-		weapon_proficiency = excluded.weapon_proficiency,
-		weapon_type_id = excluded.weapon_type_id,
-		arm_armor = excluded.arm_armor,
-		body_armor = excluded.body_armor,
-		head_armor = excluded.head_armor,
-		leg_armor = excluded.leg_armor,
-		waist_armor = excluded.waist_armor,
-		notes = excluded.notes,
-		sort_order = excluded.sort_order;
-
-	insert into vignette_survivor_template_fighting_art (id, vignette_survivor_template_id, fighting_art_id, sort_order)
-	values
-		('33600000-0000-4000-8000-000000000701', '33600000-0000-4000-8000-000000000601', leader_id, 10),
-		('33600000-0000-4000-8000-000000000702', '33600000-0000-4000-8000-000000000601', mighty_strike_id, 20),
-		('33600000-0000-4000-8000-000000000703', '33600000-0000-4000-8000-000000000602', strategist_id, 10),
-		('33600000-0000-4000-8000-000000000704', '33600000-0000-4000-8000-000000000603', tough_id, 10),
-		('33600000-0000-4000-8000-000000000705', '33600000-0000-4000-8000-000000000604', acrobatics_id, 10),
-		('33600000-0000-4000-8000-000000000706', '33600000-0000-4000-8000-000000000605', leader_id, 10)
-	on conflict (vignette_survivor_template_id, fighting_art_id) do update set
-		sort_order = excluded.sort_order;
-
-	insert into vignette_survivor_template_secret_fighting_art (id, vignette_survivor_template_id, secret_fighting_art_id, sort_order)
-	values
-		('33600000-0000-4000-8000-000000000801', '33600000-0000-4000-8000-000000000601', red_fist_id, 10),
-		('33600000-0000-4000-8000-000000000802', '33600000-0000-4000-8000-000000000603', kings_step_id, 10),
-		('33600000-0000-4000-8000-000000000803', '33600000-0000-4000-8000-000000000605', synchronized_strike_id, 10)
-	on conflict (vignette_survivor_template_id, secret_fighting_art_id) do update set
-		sort_order = excluded.sort_order;
-
-	insert into vignette_survivor_template_disorder (id, vignette_survivor_template_id, disorder_id, sort_order)
-	values
-		('33600000-0000-4000-8000-000000000901', '33600000-0000-4000-8000-000000000602', fear_of_the_dark_id, 10),
-		('33600000-0000-4000-8000-000000000902', '33600000-0000-4000-8000-000000000604', brain_smog_id, 10),
-		('33600000-0000-4000-8000-000000000903', '33600000-0000-4000-8000-000000000605', cowardice_id, 10)
-	on conflict (vignette_survivor_template_id, disorder_id) do update set
-		sort_order = excluded.sort_order;
-
-	insert into vignette_survivor_template_ability_impairment (id, vignette_survivor_template_id, ability_impairment_id, sort_order)
-	values
-		('33600000-0000-4000-8000-000000001001', '33600000-0000-4000-8000-000000000601', veteran_id, 10),
-		('33600000-0000-4000-8000-000000001002', '33600000-0000-4000-8000-000000000603', servant_of_fate_id, 10),
-		('33600000-0000-4000-8000-000000001003', '33600000-0000-4000-8000-000000000605', revenant_id, 10)
-	on conflict (vignette_survivor_template_id, ability_impairment_id) do update set
-		sort_order = excluded.sort_order;
-
-	insert into vignette_survivor_template_survivor_status (id, vignette_survivor_template_id, survivor_status_id, sort_order)
-	values
-		('33600000-0000-4000-8000-000000001101', '33600000-0000-4000-8000-000000000601', bloody_hands_id, 10),
-		('33600000-0000-4000-8000-000000001102', '33600000-0000-4000-8000-000000000603', battle_tempo_id, 10),
-		('33600000-0000-4000-8000-000000001103', '33600000-0000-4000-8000-000000000604', somatic_static_id, 10),
-		('33600000-0000-4000-8000-000000001104', '33600000-0000-4000-8000-000000000605', polarized_aura_id, 10)
-	on conflict (vignette_survivor_template_id, survivor_status_id) do update set
-		sort_order = excluded.sort_order;
-
-	insert into vignette_survivor_template_gear_grid (id, vignette_survivor_template_id, gear_id, row_number, column_number)
-	values
-		('33600000-0000-4000-8000-000000001201', '33600000-0000-4000-8000-000000000601', founding_stone_id, 0, 0),
-		('33600000-0000-4000-8000-000000001202', '33600000-0000-4000-8000-000000000601', cloth_id, 0, 1),
-		('33600000-0000-4000-8000-000000001203', '33600000-0000-4000-8000-000000000601', bone_dagger_id, 1, 0),
-		('33600000-0000-4000-8000-000000001204', '33600000-0000-4000-8000-000000000601', rawhide_headband_id, 1, 1),
-		('33600000-0000-4000-8000-000000001205', '33600000-0000-4000-8000-000000000602', white_lion_gauntlet_id, 0, 0),
-		('33600000-0000-4000-8000-000000001206', '33600000-0000-4000-8000-000000000602', bone_dagger_id, 0, 1),
-		('33600000-0000-4000-8000-000000001207', '33600000-0000-4000-8000-000000000602', skull_helm_id, 1, 0),
-		('33600000-0000-4000-8000-000000001208', '33600000-0000-4000-8000-000000000603', king_spear_id, 0, 0),
-		('33600000-0000-4000-8000-000000001209', '33600000-0000-4000-8000-000000000603', skull_helm_id, 1, 0),
-		('33600000-0000-4000-8000-000000001210', '33600000-0000-4000-8000-000000000603', cloth_id, 2, 0),
-		('33600000-0000-4000-8000-000000001211', '33600000-0000-4000-8000-000000000604', lantern_sword_id, 0, 0),
-		('33600000-0000-4000-8000-000000001212', '33600000-0000-4000-8000-000000000604', gorment_mask_id, 1, 0),
-		('33600000-0000-4000-8000-000000001213', '33600000-0000-4000-8000-000000000604', founding_stone_id, 1, 1),
-		('33600000-0000-4000-8000-000000001214', '33600000-0000-4000-8000-000000000605', rawhide_headband_id, 0, 0),
-		('33600000-0000-4000-8000-000000001215', '33600000-0000-4000-8000-000000000605', bone_dagger_id, 0, 1),
-		('33600000-0000-4000-8000-000000001216', '33600000-0000-4000-8000-000000000605', cloth_id, 1, 1)
-	on conflict (vignette_survivor_template_id, row_number, column_number) do update set
-		gear_id = excluded.gear_id;
-end $$;
+		and level_number = 2
+	),
+	(
+		select id from trait
+		where trait_name = 'Scorn'
+		and custom = false
+	)
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'Screaming Nukalope'
+		)
+		and level_number = 2
+	),
+	(
+		select id from trait
+		where trait_name = 'Atomic Vigor - Inert'
+		and custom = false
+	)
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'Screaming Nukalope'
+		)
+		and level_number = 2
+	),
+	(
+		select id from trait
+		where trait_name = 'Critical Mass - Inert'
+		and custom = false
+	)
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'Screaming Nukalope'
+		)
+		and level_number = 2
+	),
+	(
+		select id from trait
+		where trait_name = 'Prehensile Tail - Inert'
+		and custom = false
+	)
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'White Gigalion'
+		)
+		and level_number = 2
+	),
+	(
+		select id from trait
+		where trait_name = 'Vicious'
+		and custom = false
+	)
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'White Gigalion'
+		)
+		and level_number = 2
+	),
+	(
+		select id from trait
+		where trait_name = 'Giga Claws'
+		and custom = false
+	)
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'White Gigalion'
+		)
+		and level_number = 2
+	),
+	(
+		select id from trait
+		where trait_name = 'Smart Cat'
+		and custom = false
+	)
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'Screaming God'
+		)
+		and level_number = 1
+	),
+	(
+		select id from trait
+		where trait_name = 'Endless Horizon'
+		and custom = false
+	)
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'Screaming God'
+		)
+		and level_number = 1
+	),
+	(
+		select id from trait
+		where trait_name = 'Stampede'
+		and custom = false
+	)
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'Screaming God'
+		)
+		and level_number = 1
+	),
+	(
+		select id from trait
+		where trait_name = 'Withering Blast'
+		and custom = false
+	)
+),
+(
+	(
+		select id from vignette_monster_level
+		where vignette_monster_id = (
+			select id from vignette_monster
+			where monster_name = 'Screaming God'
+		)
+		and level_number = 1
+	),
+	(
+		select id from trait
+		where trait_name = 'Grasping Undermaw'
+		and custom = false
+	)
+);
+--------------------------------------------------------------------------------
+-- Vignette Survivor Data
+--------------------------------------------------------------------------------
+insert into vignette_survivor
+(
+	vignette_monster_id,
+	survivor_name,
+	survivor_type,
+	gender,
+	movement,
+	accuracy,
+	strength,
+	evasion,
+	luck,
+	speed,
+	survival,
+	insanity,
+	courage,
+	understanding,
+	weapon_proficiency,
+	weapon_type_id,
+	arm_armor,
+	body_armor,
+	head_armor,
+	leg_armor,
+	waist_armor,
+	notes
+)
+values
+-- Killenium Butcher
+(
+	(select id from vignette_monster where monster_name = 'Killenium Butcher'),
+	'Brave', -- Survivor Name
+	'CORE', -- Survivor Type
+	'MALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	0, -- Strength
+	0, -- Evasion
+	3, -- Luck
+	0, -- Speed
+	4, -- Survival
+	4, -- Insanity
+	7, -- Courage
+	0, -- Understanding
+	0, -- Weapon Proficiency
+	null, -- Weapon Type ID
+	4, -- Arm Armor
+	4, -- Body Armor
+	0, -- Head Armor
+	4, -- Leg Armor
+	4, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'Killenium Butcher'),
+	'Hollow', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	0, -- Strength
+	-1, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	3, -- Survival
+	1, -- Insanity
+	0, -- Courage
+	0, -- Understanding
+	0, -- Weapon Proficiency
+	null, -- Weapon Type ID
+	7, -- Arm Armor
+	5, -- Body Armor
+	6, -- Head Armor
+	5, -- Leg Armor
+	5, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'Killenium Butcher'),
+	'Forgot', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	0, -- Strength
+	0, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	5, -- Survival
+	3, -- Insanity
+	1, -- Courage
+	5, -- Understanding
+	0, -- Weapon Proficiency
+	null, -- Weapon Type ID
+	6, -- Arm Armor
+	3, -- Body Armor
+	3, -- Head Armor
+	5, -- Leg Armor
+	5, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'Killenium Butcher'),
+	'Red', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	0, -- Strength
+	0, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	5, -- Survival
+	2, -- Insanity
+	5, -- Courage
+	2, -- Understanding
+	3, -- Weapon Proficiency
+	(select id from weapon_type where weapon_type_name = 'Spear' and custom is false), -- Weapon Type ID
+	12, -- Arm Armor
+	4, -- Body Armor
+	3, -- Head Armor
+	4, -- Leg Armor
+	3, -- Waist Armor
+	'' -- Notes
+),
+-- Screaming Nukalope
+(
+	(select id from vignette_monster where monster_name = 'Screaming Nukalope'),
+	'Ashbloom', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	6, -- Movement
+	0, -- Accuracy
+	2, -- Strength
+	0, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	6, -- Survival
+	5, -- Insanity
+	6, -- Courage
+	2, -- Understanding
+	0, -- Weapon Proficiency
+	null, -- Weapon Type ID
+	4, -- Arm Armor
+	4, -- Body Armor
+	4, -- Head Armor
+	4, -- Leg Armor
+	0, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'Screaming Nukalope'),
+	'Gnostin', -- Survivor Name
+	'CORE', -- Survivor Type
+	'MALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	0, -- Strength
+	0, -- Evasion
+	1, -- Luck
+	0, -- Speed
+	6, -- Survival
+	5, -- Insanity
+	2, -- Courage
+	7, -- Understanding
+	0, -- Weapon Proficiency
+	null, -- Weapon Type ID
+	4, -- Arm Armor
+	4, -- Body Armor
+	3, -- Head Armor
+	2, -- Leg Armor
+	2, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'Screaming Nukalope'),
+	'Monday', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	0, -- Strength
+	0, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	6, -- Survival
+	3, -- Insanity
+	4, -- Courage
+	2, -- Understanding
+	0, -- Weapon Proficiency
+	null, -- Weapon Type ID
+	2, -- Arm Armor
+	2, -- Body Armor
+	2, -- Head Armor
+	2, -- Leg Armor
+	2, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'Screaming Nukalope'),
+	'Ashroot', -- Survivor Name
+	'CORE', -- Survivor Type
+	'MALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	0, -- Strength
+	0, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	6, -- Survival
+	3, -- Insanity
+	1, -- Courage
+	0, -- Understanding
+	4, -- Weapon Proficiency
+	(select id from weapon_type where weapon_type_name = 'Shield' and custom is false), -- Weapon Type ID
+	6, -- Arm Armor
+	6, -- Body Armor
+	6, -- Head Armor
+	6, -- Leg Armor
+	6, -- Waist Armor
+	'' -- Notes
+),
+-- White Gigalion
+(
+	(select id from vignette_monster where monster_name = 'White Gigalion'),
+	'Rock Knight', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	1, -- Strength
+	0, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	3, -- Survival
+	6, -- Insanity
+	0, -- Courage
+	2, -- Understanding
+	4, -- Weapon Proficiency
+	(select id from weapon_type where weapon_type_name = 'Club' and custom is false), -- Weapon Type ID
+	0, -- Arm Armor
+	4, -- Body Armor
+	3, -- Head Armor
+	4, -- Leg Armor
+	4, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'White Gigalion'),
+	'Hungry Basalt', -- Survivor Name
+	'CORE', -- Survivor Type
+	'MALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	0, -- Strength
+	0, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	3, -- Survival
+	3, -- Insanity
+	0, -- Courage
+	0, -- Understanding
+	0, -- Weapon Proficiency
+	null, -- Weapon Type ID
+	4, -- Arm Armor
+	4, -- Body Armor
+	4, -- Head Armor
+	4, -- Leg Armor
+	4, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'White Gigalion'),
+	'Gadrock', -- Survivor Name
+	'CORE', -- Survivor Type
+	'MALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	0, -- Strength
+	0, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	3, -- Survival
+	4, -- Insanity
+	6, -- Courage
+	2, -- Understanding
+	2, -- Weapon Proficiency
+	(select id from weapon_type where weapon_type_name = 'Katar' and custom is false), -- Weapon Type ID
+	3, -- Arm Armor
+	3, -- Body Armor
+	3, -- Head Armor
+	3, -- Leg Armor
+	3, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'White Gigalion'),
+	'Breccia', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	0, -- Strength
+	0, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	4, -- Survival
+	2, -- Insanity
+	1, -- Courage
+	5, -- Understanding
+	3, -- Weapon Proficiency
+	(select id from weapon_type where weapon_type_name = 'Whip' and custom is false), -- Weapon Type ID
+	4, -- Arm Armor
+	4, -- Body Armor
+	4, -- Head Armor
+	4, -- Leg Armor
+	4, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'Screaming God'),
+	'Sage', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	2, -- Strength
+	1, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	8, -- Survival
+	0, -- Insanity
+	7, -- Courage
+	0, -- Understanding
+	0, -- Weapon Proficiency
+	null, -- Weapon Type ID
+	10, -- Arm Armor
+	10, -- Body Armor
+	10, -- Head Armor
+	10, -- Leg Armor
+	10, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'Screaming God'),
+	'Lyra', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	5, -- Movement
+	1, -- Accuracy
+	7, -- Strength
+	1, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	8, -- Survival
+	3, -- Insanity
+	0, -- Courage
+	0, -- Understanding
+	0, -- Weapon Proficiency
+	null, -- Weapon Type ID
+	3, -- Arm Armor
+	3, -- Body Armor
+	3, -- Head Armor
+	3, -- Leg Armor
+	3, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'Screaming God'),
+	'Melody', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	3, -- Strength
+	1, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	8, -- Survival
+	9, -- Insanity
+	5, -- Courage
+	2, -- Understanding
+	0, -- Weapon Proficiency
+	null, -- Weapon Type ID
+	4, -- Arm Armor
+	4, -- Body Armor
+	4, -- Head Armor
+	4, -- Leg Armor
+	4, -- Waist Armor
+	'' -- Notes
+),
+(
+	(select id from vignette_monster where monster_name = 'Screaming God'),
+	'Harmony', -- Survivor Name
+	'CORE', -- Survivor Type
+	'FEMALE', -- Gender
+	5, -- Movement
+	0, -- Accuracy
+	4, -- Strength
+	1, -- Evasion
+	0, -- Luck
+	0, -- Speed
+	8, -- Survival
+	5, -- Insanity
+	2, -- Courage
+	5, -- Understanding
+	5, -- Weapon Proficiency
+	(select id from weapon_type where weapon_type_name = 'Axe' and custom is false), -- Weapon Type ID
+	4, -- Arm Armor
+	4, -- Body Armor
+	4, -- Head Armor
+	4, -- Leg Armor
+	4, -- Waist Armor
+	'' -- Notes
+);
+--------------------------------------------------------------------------------
+-- Vignette Survivor Disorder Data
+--------------------------------------------------------------------------------
+insert into vignette_survivor_disorder (vignette_survivor_id, disorder_id) values
+(
+	(select id from vignette_survivor where survivor_name = 'Brave'),
+	(select id from disorder where disorder_name = 'Quixotic')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashroot'),
+	(select id from disorder where disorder_name = 'Anxiety')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from disorder where disorder_name = 'Hoarder')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hungry Basalt'),
+	(select id from disorder where disorder_name = 'Binge Eating')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from disorder where disorder_name = 'Squeamish')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from disorder where disorder_name = 'Post-Traumatic Stress')
+);
+--------------------------------------------------------------------------------
+-- Vignette Survivor Fighting Art Data
+--------------------------------------------------------------------------------
+insert into vignette_survivor_fighting_art (vignette_survivor_id, fighting_art_id) values
+(
+	(select id from vignette_survivor where survivor_name = 'Monday'),
+	(select id from fighting_art where fighting_art_name = 'Trick Attack')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gnostin'),
+	(select id from fighting_art where fighting_art_name = 'Strategist')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashbloom'),
+	(select id from fighting_art where fighting_art_name = 'Wardrobe Expert')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from fighting_art where fighting_art_name = 'Orator of Death')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from fighting_art where fighting_art_name = 'Clutch Fighter')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Breccia'),
+	(select id from fighting_art where fighting_art_name = 'Mighty Strike')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from fighting_art where fighting_art_name = 'Leader')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from fighting_art where fighting_art_name = 'Combo Master')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from fighting_art where fighting_art_name = 'Clutch Fighter')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from fighting_art where fighting_art_name = 'Extra Sense')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Harmony'),
+	(select id from fighting_art where fighting_art_name = 'Double Dash')
+);
+--------------------------------------------------------------------------------
+-- Vignette Survivor Secret Fighting Art Data
+--------------------------------------------------------------------------------
+insert into vignette_survivor_secret_fighting_art (vignette_survivor_id, secret_fighting_art_id) values
+(
+	(select id from vignette_survivor where survivor_name = 'Gnostin'),
+	(select id from secret_fighting_art where secret_fighting_art_name = 'Beetle Strength')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashbloom'),
+	(select id from secret_fighting_art where secret_fighting_art_name = 'Unshackled')
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from secret_fighting_art where secret_fighting_art_name = 'King''s Step')
+);
+--------------------------------------------------------------------------------
+-- Vignette Survivor Gear Grid Data
+--------------------------------------------------------------------------------
+insert into vignette_survivor_gear_grid (
+	vignette_survivor_id,
+	gear_id,
+	row_number,
+	column_number
+) values
+-- Ashbloom
+(
+	(select id from vignette_survivor where survivor_name = 'Ashbloom'),
+	(select id from gear where gear_name = 'Musk Bomb'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashbloom'),
+	(select id from gear where gear_name = 'Warding Guidon Lance'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashbloom'),
+	(select id from gear where gear_name = 'Warding Tower Shield'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashbloom'),
+	(select id from gear where gear_name = 'Crusader Breastplate'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashbloom'),
+	(select id from gear where gear_name = 'Crusader Heirloom'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashbloom'),
+	(select id from gear where gear_name = 'Dried Acanthus'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashbloom'),
+	(select id from gear where gear_name = 'Crusader Gauntlets'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashbloom'),
+	(select id from gear where gear_name = 'Crusader Sabatons'),
+	2,
+	2
+),
+-- Ashroot
+(
+	(select id from vignette_survivor where survivor_name = 'Ashroot'),
+	(select id from gear where gear_name = 'First Aid Kit'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashroot'),
+	(select id from gear where gear_name = 'Crusader Cuisses'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashroot'),
+	(select id from gear where gear_name = 'Warding Guidon Lance'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashroot'),
+	(select id from gear where gear_name = 'Warding Tower Shield'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashroot'),
+	(select id from gear where gear_name = 'Crusader Breastplate'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashroot'),
+	(select id from gear where gear_name = 'Crusader Heirloom'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashroot'),
+	(select id from gear where gear_name = 'Sunspot Dart'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashroot'),
+	(select id from gear where gear_name = 'Crusader Gauntlets'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Ashroot'),
+	(select id from gear where gear_name = 'Crusader Sabatons'),
+	2,
+	2
+),
+-- Gnostin
+(
+	(select id from vignette_survivor where survivor_name = 'Gnostin'),
+	(select id from gear where gear_name = 'Phoenix Gauntlet'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gnostin'),
+	(select id from gear where gear_name = 'Stonesmasher'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gnostin'),
+	(select id from gear where gear_name = 'Lucky Charm'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gnostin'),
+	(select id from gear where gear_name = 'Sculptor Beads'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gnostin'),
+	(select id from gear where gear_name = 'Cycloid Scale Shoes'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gnostin'),
+	(select id from gear where gear_name = 'Stonescraper'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gnostin'),
+	(select id from gear where gear_name = 'Phoenix Plackart'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gnostin'),
+	(select id from gear where gear_name = 'White Lion Skirt'),
+	2,
+	2
+),
+-- Monday
+(
+	(select id from vignette_survivor where survivor_name = 'Monday'),
+	(select id from gear where gear_name = 'Fecal Salve'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Monday'),
+	(select id from gear where gear_name = 'Shadowstalker Houmongi'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Monday'),
+	(select id from gear where gear_name = 'Ambush Falchion'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Monday'),
+	(select id from gear where gear_name = 'Shadowstalker Kasa'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Monday'),
+	(select id from gear where gear_name = 'Shadowstalker Sode'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Monday'),
+	(select id from gear where gear_name = 'Shadowstalker Obi'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Monday'),
+	(select id from gear where gear_name = 'Shadowstalker Geta'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Monday'),
+	(select id from gear where gear_name = 'Scarab Circlet'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Monday'),
+	(select id from gear where gear_name = 'Stone Noses'),
+	2,
+	2
+),
+-- Red
+(
+	(select id from vignette_survivor where survivor_name = 'Red'),
+	(select id from gear where gear_name = 'Ram Photophore'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Red'),
+	(select id from gear where gear_name = 'Tabard'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Red'),
+	(select id from gear where gear_name = 'Hard Breastplate'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Red'),
+	(select id from gear where gear_name = 'Leather Skirt'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Red'),
+	(select id from gear where gear_name = 'Cloth Leggings'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Red'),
+	(select id from gear where gear_name = 'Protean Charm'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Red'),
+	(select id from gear where gear_name = 'Seasoned Monster Meat'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Red'),
+	(select id from gear where gear_name = 'Survival Spear'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Red'),
+	(select id from gear where gear_name = 'White Dragon Gauntlets'),
+	2,
+	2
+),
+-- Brave
+(
+	(select id from vignette_survivor where survivor_name = 'Brave'),
+	(select id from gear where gear_name = 'Bravesword'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Brave'),
+	(select id from gear where gear_name = 'Cobbled Vambraces'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Brave'),
+	(select id from gear where gear_name = 'Braveshield'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Brave'),
+	(select id from gear where gear_name = 'Cobbled Plackart'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Brave'),
+	(select id from gear where gear_name = 'Heart of a Hero'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Brave'),
+	(select id from gear where gear_name = 'Cobbled Faulds'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Brave'),
+	(select id from gear where gear_name = 'Life Elixir'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Brave'),
+	(select id from gear where gear_name = 'Cobbled Greaves'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Brave'),
+	(select id from gear where gear_name = 'Bandages'),
+	2,
+	2
+),
+-- Forgot
+(
+	(select id from vignette_survivor where survivor_name = 'Forgot'),
+	(select id from gear where gear_name = 'Tattered Archivist Robe'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Forgot'),
+	(select id from gear where gear_name = 'Leather Cuirass'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Forgot'),
+	(select id from gear where gear_name = 'Laurie''s Lenses'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Forgot'),
+	(select id from gear where gear_name = 'Gloom Bracelets'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Forgot'),
+	(select id from gear where gear_name = 'Gloom Cream'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Forgot'),
+	(select id from gear where gear_name = 'Lantern Greaves'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Forgot'),
+	(select id from gear where gear_name = 'Lantern Mail'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Forgot'),
+	(select id from gear where gear_name = 'Locking Tome'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Forgot'),
+	(select id from gear where gear_name = 'Memento Blade'),
+	2,
+	2
+),
+-- Hollow
+(
+	(select id from vignette_survivor where survivor_name = 'Hollow'),
+	(select id from gear where gear_name = 'Sacrificial Fang'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hollow'),
+	(select id from gear where gear_name = 'Dragonskull Helm'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hollow'),
+	(select id from gear where gear_name = 'Dragon Belt'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hollow'),
+	(select id from gear where gear_name = 'Green Ring'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hollow'),
+	(select id from gear where gear_name = 'Dragon Mantle'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hollow'),
+	(select id from gear where gear_name = 'Stoic Mask'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hollow'),
+	(select id from gear where gear_name = 'Dragon Boots'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hollow'),
+	(select id from gear where gear_name = 'Bird Bread'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hollow'),
+	(select id from gear where gear_name = 'Dragon Gloves'),
+	2,
+	2
+),
+-- Rock Knight
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from gear where gear_name = 'Lovelorn Rock'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from gear where gear_name = 'Bone Darts'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from gear where gear_name = 'Armor Spikes'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from gear where gear_name = 'Skull Helm'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from gear where gear_name = 'Regal Plackart'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from gear where gear_name = 'Skullcap Hammer'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from gear where gear_name = 'Bone Earrings'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from gear where gear_name = 'Regal Faulds'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Rock Knight'),
+	(select id from gear where gear_name = 'Regal Greaves'),
+	2,
+	2
+),
+-- Hungry Basalt
+(
+	(select id from vignette_survivor where survivor_name = 'Hungry Basalt'),
+	(select id from gear where gear_name = 'Gorment Boots'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hungry Basalt'),
+	(select id from gear where gear_name = 'Monster Tooth Necklace'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hungry Basalt'),
+	(select id from gear where gear_name = 'Elder Earrings'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hungry Basalt'),
+	(select id from gear where gear_name = 'Gorment Sleeves'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hungry Basalt'),
+	(select id from gear where gear_name = 'Gorment Suit'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hungry Basalt'),
+	(select id from gear where gear_name = 'Gorment Mask'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hungry Basalt'),
+	(select id from gear where gear_name = 'Boss Mehndi'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hungry Basalt'),
+	(select id from gear where gear_name = 'Greater Gaxe'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Hungry Basalt'),
+	(select id from gear where gear_name = 'Round Leather Shield'),
+	2,
+	2
+),
+-- Gadrock
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from gear where gear_name = 'Gorn'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from gear where gear_name = 'White Lion Boots'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from gear where gear_name = 'White Lion Skirt'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from gear where gear_name = 'White Lion Coat'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from gear where gear_name = 'Frenzy Drink'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from gear where gear_name = 'Lion Headdress'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from gear where gear_name = 'White Lion Helm'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from gear where gear_name = 'White Lion Gauntlet'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Gadrock'),
+	(select id from gear where gear_name = 'Beast Knuckle'),
+	2,
+	2
+),
+-- Breccia
+(
+	(select id from vignette_survivor where survivor_name = 'Breccia'),
+	(select id from gear where gear_name = 'Leather Cuirass'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Breccia'),
+	(select id from gear where gear_name = 'Leather Mask'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Breccia'),
+	(select id from gear where gear_name = 'Leather Skirt'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Breccia'),
+	(select id from gear where gear_name = 'Hunter Whip'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Breccia'),
+	(select id from gear where gear_name = 'Lucky Charm'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Breccia'),
+	(select id from gear where gear_name = 'Brain Mint'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Breccia'),
+	(select id from gear where gear_name = 'Leather Bracers'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Breccia'),
+	(select id from gear where gear_name = 'Leather Boots'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Breccia'),
+	(select id from gear where gear_name = 'Monster Grease'),
+	2,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Melody'),
+	(select id from gear where gear_name = 'Dark Water Vial'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Melody'),
+	(select id from gear where gear_name = 'Gorn'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Melody'),
+	(select id from gear where gear_name = 'Vandal Sledge'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Melody'),
+	(select id from gear where gear_name = 'Count Tabard'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Melody'),
+	(select id from gear where gear_name = 'Count Vest'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Melody'),
+	(select id from gear where gear_name = 'Count Wrappings'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Melody'),
+	(select id from gear where gear_name = 'Count Sandals'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Melody'),
+	(select id from gear where gear_name = 'Count Treukh'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Melody'),
+	(select id from gear where gear_name = 'Bone Dagger'),
+	2,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from gear where gear_name = 'White Lion Gauntlet'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from gear where gear_name = 'White Lion Helm'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from gear where gear_name = 'White Lion Skirt'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from gear where gear_name = 'White Lion Boots'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from gear where gear_name = 'Pipa'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from gear where gear_name = 'Vespertine Cello'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from gear where gear_name = 'Zanbato'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from gear where gear_name = 'Monster Grease'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Lyra'),
+	(select id from gear where gear_name = 'White Lion Coat'),
+	2,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from gear where gear_name = 'Beacon Shield'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from gear where gear_name = 'Oxidized Lantern Helm'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from gear where gear_name = 'Meteor Unguis'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from gear where gear_name = 'Lantern Mail'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from gear where gear_name = 'Lantern Cuirass'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from gear where gear_name = 'Lantern Gauntlets'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from gear where gear_name = 'Mush Diadema'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from gear where gear_name = 'Lantern Greaves'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Sage'),
+	(select id from gear where gear_name = 'Elder Earrings'),
+	2,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Harmony'),
+	(select id from gear where gear_name = 'Singing Pantaloons'),
+	0,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Harmony'),
+	(select id from gear where gear_name = 'Singing Gloves'),
+	0,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Harmony'),
+	(select id from gear where gear_name = 'Energy Drum'),
+	0,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Harmony'),
+	(select id from gear where gear_name = 'Singing Cap'),
+	1,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Harmony'),
+	(select id from gear where gear_name = 'Lucky Charm'),
+	1,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Harmony'),
+	(select id from gear where gear_name = 'Bandages'),
+	1,
+	2
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Harmony'),
+	(select id from gear where gear_name = 'Singing Breastplate'),
+	2,
+	0
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Harmony'),
+	(select id from gear where gear_name = 'Saxe'),
+	2,
+	1
+),
+(
+	(select id from vignette_survivor where survivor_name = 'Harmony'),
+	(select id from gear where gear_name = 'Singing Boots'),
+	2,
+	2
+);


### PR DESCRIPTION
## Summary
- Seed fixture-only vignette encounter definitions for a single-monster White Lion quarry source and a multi-monster Red Witches nemesis source.
- Add level moods, traits, survivor statuses, survivor templates, survivor template links, and gear-grid templates for integration and UI development.
- Add focused integration coverage for the fixture contract and bump the app version to 0.91.3.

## Dependencies
- None.

## Tests
- `npx prettier --check __tests__/integration/vignette-seed-fixtures.test.ts supabase/seeds/026_vignette_encounter_fixtures.sql package.json package-lock.json`
- `npx supabase db reset --local --yes`
- `npm run integration-test -- __tests__/integration/vignette-seed-fixtures.test.ts`

Closes #336