### PR TITLE
[VIG-02.02] Add vignette Zod schemas

### DIFF
--- a/__tests__/schemas/vignette-encounter.test.ts
+++ b/__tests__/schemas/vignette-encounter.test.ts
@@ -103,7 +103,7 @@ describe('VignetteEncounterDeleteInputSchema', () => {
 
     expect(result.success).toBe(false)
     if (!result.success)
-      expect(result.error.issues[0].message).toMatch(/valid vignette id/i)
+      expect(result.error.issues[0].message).toMatch(/valid uuid/i)
   })
 })
 

--- a/__tests__/schemas/vignette-encounter.test.ts
+++ b/__tests__/schemas/vignette-encounter.test.ts
@@ -1,0 +1,303 @@
+import {
+  VignetteActiveLimitSchema,
+  VignetteCreateInputSchema,
+  VignetteEncounterAIDeckUpdateInputSchema,
+  VignetteEncounterDeleteInputSchema,
+  VignetteEncounterMonsterMoodInputSchema,
+  VignetteEncounterMonsterStateDeleteInputSchema,
+  VignetteEncounterMonsterSurvivorStatusInputSchema,
+  VignetteEncounterMonsterTraitInputSchema,
+  VignetteEncounterMonsterUpdateInputSchema,
+  VignetteEncounterSurvivorGearGridUpdateInputSchema,
+  VignetteEncounterSurvivorLiveStateUpdateInputSchema,
+  VignetteEncounterUpdateInputSchema,
+  VignetteShareInputSchema,
+  VignetteShareRemovalInputSchema
+} from '@/schemas/vignette-encounter'
+import { describe, expect, it } from 'vitest'
+
+const uuid = '12345678-1234-4234-8234-123456789abc'
+const alternateUuid = '12345678-1234-4234-8234-123456789abd'
+
+describe('VignetteCreateInputSchema', () => {
+  it('accepts a valid catalog create payload', () => {
+    const result = VignetteCreateInputSchema.parse({
+      vignette_monster_id: uuid,
+      level_number: 2
+    })
+
+    expect(result).toEqual({ vignette_monster_id: uuid, level_number: 2 })
+  })
+
+  it('rejects invalid id and level values', () => {
+    const result = VignetteCreateInputSchema.safeParse({
+      vignette_monster_id: 'not-a-uuid',
+      level_number: 5
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.path[0])).toEqual([
+        'vignette_monster_id',
+        'level_number'
+      ])
+    }
+  })
+})
+
+describe('VignetteActiveLimitSchema', () => {
+  it('accepts a user with no active owned vignette', () => {
+    expect(VignetteActiveLimitSchema.parse({})).toEqual({
+      active_vignette_encounter_id: null
+    })
+  })
+
+  it('rejects a second active owned vignette with themed copy', () => {
+    const result = VignetteActiveLimitSchema.safeParse({
+      active_vignette_encounter_id: uuid
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success)
+      expect(result.error.issues[0].message).toMatch(/one active vignette/i)
+  })
+})
+
+describe('VignetteEncounterUpdateInputSchema', () => {
+  it('accepts turn and notes updates', () => {
+    const result = VignetteEncounterUpdateInputSchema.parse({
+      vignette_encounter_id: uuid,
+      turn: 'SURVIVOR',
+      notes: 'The lantern still burns.'
+    })
+
+    expect(result).toEqual({
+      vignette_encounter_id: uuid,
+      turn: 'SURVIVOR',
+      notes: 'The lantern still burns.'
+    })
+  })
+
+  it('rejects an empty update payload', () => {
+    const result = VignetteEncounterUpdateInputSchema.safeParse({
+      vignette_encounter_id: uuid
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success)
+      expect(result.error.issues[0].message).toMatch(/one change/i)
+  })
+})
+
+describe('VignetteEncounterDeleteInputSchema', () => {
+  it('accepts a valid delete payload', () => {
+    expect(
+      VignetteEncounterDeleteInputSchema.parse({ vignette_encounter_id: uuid })
+    ).toEqual({ vignette_encounter_id: uuid })
+  })
+
+  it('rejects invalid delete payloads', () => {
+    const result = VignetteEncounterDeleteInputSchema.safeParse({
+      vignette_encounter_id: 'not-a-uuid'
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success)
+      expect(result.error.issues[0].message).toMatch(/valid vignette id/i)
+  })
+})
+
+describe('VignetteEncounterAIDeckUpdateInputSchema', () => {
+  it('accepts AI deck card count updates', () => {
+    const result = VignetteEncounterAIDeckUpdateInputSchema.parse({
+      vignette_encounter_ai_deck_id: uuid,
+      basic_cards: 7,
+      advanced_cards: 3
+    })
+
+    expect(result.basic_cards).toBe(7)
+    expect(result.advanced_cards).toBe(3)
+  })
+
+  it('rejects negative AI deck counts', () => {
+    const result = VignetteEncounterAIDeckUpdateInputSchema.safeParse({
+      vignette_encounter_ai_deck_id: uuid,
+      basic_cards: -1
+    })
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('VignetteEncounterMonsterUpdateInputSchema', () => {
+  it('accepts mutable monster state updates', () => {
+    const result = VignetteEncounterMonsterUpdateInputSchema.parse({
+      vignette_encounter_monster_id: uuid,
+      ai_card_drawn: true,
+      knocked_down: true,
+      monster_name: '  Lantern Horror  ',
+      wounds: 3
+    })
+
+    expect(result).toMatchObject({
+      ai_card_drawn: true,
+      knocked_down: true,
+      monster_name: 'Lantern Horror',
+      wounds: 3
+    })
+  })
+
+  it('rejects negative wounds', () => {
+    const result = VignetteEncounterMonsterUpdateInputSchema.safeParse({
+      vignette_encounter_monster_id: uuid,
+      wounds: -1
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an empty monster update payload', () => {
+    const result = VignetteEncounterMonsterUpdateInputSchema.safeParse({
+      vignette_encounter_monster_id: uuid
+    })
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('Vignette active monster state card schemas', () => {
+  it('accepts mood, trait, and survivor status inserts with nullable source links', () => {
+    expect(
+      VignetteEncounterMonsterMoodInputSchema.parse({
+        vignette_encounter_monster_id: uuid,
+        mood_id: alternateUuid
+      })
+    ).toMatchObject({ source_vignette_monster_level_mood_id: null })
+
+    expect(
+      VignetteEncounterMonsterTraitInputSchema.parse({
+        vignette_encounter_monster_id: uuid,
+        trait_id: alternateUuid,
+        source_vignette_monster_level_trait_id: uuid
+      })
+    ).toMatchObject({ source_vignette_monster_level_trait_id: uuid })
+
+    expect(
+      VignetteEncounterMonsterSurvivorStatusInputSchema.parse({
+        vignette_encounter_monster_id: uuid,
+        survivor_status_id: alternateUuid
+      })
+    ).toMatchObject({ source_vignette_monster_level_survivor_status_id: null })
+  })
+
+  it('accepts monster state delete payloads', () => {
+    expect(
+      VignetteEncounterMonsterStateDeleteInputSchema.parse({ id: uuid })
+    ).toEqual({
+      id: uuid
+    })
+  })
+})
+
+describe('VignetteEncounterSurvivorLiveStateUpdateInputSchema', () => {
+  it('accepts live survivor state updates including survival and notes', () => {
+    const result = VignetteEncounterSurvivorLiveStateUpdateInputSchema.parse({
+      vignette_encounter_survivor_id: uuid,
+      activation_used: true,
+      bleeding_tokens: 1,
+      knocked_down: true,
+      movement_used: true,
+      notes: 'The survivor refuses the dark',
+      survival: 2,
+      survival_tokens: -1
+    })
+
+    expect(result).toMatchObject({
+      activation_used: true,
+      bleeding_tokens: 1,
+      knocked_down: true,
+      movement_used: true,
+      notes: 'The survivor refuses the dark',
+      survival: 2,
+      survival_tokens: -1
+    })
+  })
+
+  it('rejects negative survival and bleeding token counts', () => {
+    const result =
+      VignetteEncounterSurvivorLiveStateUpdateInputSchema.safeParse({
+        vignette_encounter_survivor_id: uuid,
+        bleeding_tokens: -1,
+        survival: -1
+      })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an empty live-state update payload', () => {
+    const result =
+      VignetteEncounterSurvivorLiveStateUpdateInputSchema.safeParse({
+        vignette_encounter_survivor_id: uuid
+      })
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('VignetteEncounterSurvivorGearGridUpdateInputSchema', () => {
+  it('accepts active gear-grid position updates', () => {
+    const result = VignetteEncounterSurvivorGearGridUpdateInputSchema.parse({
+      vignette_encounter_survivor_gear_grid_id: uuid,
+      row_number: 1,
+      column_number: 2
+    })
+
+    expect(result.row_number).toBe(1)
+    expect(result.column_number).toBe(2)
+  })
+
+  it('rejects out-of-bounds grid coordinates', () => {
+    const result = VignetteEncounterSurvivorGearGridUpdateInputSchema.safeParse(
+      {
+        vignette_encounter_survivor_gear_grid_id: uuid,
+        row_number: 3
+      }
+    )
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('Vignette sharing schemas', () => {
+  it('trims exact-username share input', () => {
+    const result = VignetteShareInputSchema.parse({
+      vignette_encounter_id: uuid,
+      username: '  lanternkeeper  '
+    })
+
+    expect(result.username).toBe('lanternkeeper')
+  })
+
+  it('rejects empty usernames', () => {
+    const result = VignetteShareInputSchema.safeParse({
+      vignette_encounter_id: uuid,
+      username: ''
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success)
+      expect(result.error.issues[0].message).toMatch(/nameless collaborator/i)
+  })
+
+  it('accepts share removal payloads', () => {
+    const result = VignetteShareRemovalInputSchema.parse({
+      vignette_encounter_id: uuid,
+      shared_user_id: alternateUuid
+    })
+
+    expect(result).toEqual({
+      vignette_encounter_id: uuid,
+      shared_user_id: alternateUuid
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.91.4",
+  "version": "0.92.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.91.4",
+      "version": "0.92.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.91.4",
+  "version": "0.92.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/schemas/vignette-encounter.ts
+++ b/schemas/vignette-encounter.ts
@@ -1,0 +1,463 @@
+import { Constants } from '@/lib/database.types'
+import { z } from 'zod'
+
+/** Vignette UUID Schema */
+const VignetteUuidSchema = z.uuid('A valid vignette id is required.')
+
+/** Vignette Level Number Schema */
+const VignetteLevelNumberSchema = z
+  .number()
+  .int('Vignette level must be a whole number.')
+  .min(1, 'Vignette level must be at least 1.')
+  .max(4, 'Vignette level cannot exceed 4.')
+
+/** Vignette Non-Negative Count Schema */
+const VignetteNonNegativeCountSchema = z
+  .number()
+  .int('Count must be a whole number.')
+  .min(0, 'Count cannot be negative.')
+
+/** Vignette Token Count Schema */
+const VignetteTokenCountSchema = z.number().int('Token count must be whole.')
+
+/** Vignette Grid Coordinate Schema */
+const VignetteGridCoordinateSchema = z
+  .number()
+  .int('Gear grid coordinates must be whole numbers.')
+  .min(0, 'Gear grid coordinates cannot be negative.')
+  .max(2, 'Gear grid coordinates cannot exceed 2.')
+
+/** Vignette Showdown Turn Schema */
+export const VignetteShowdownTurnSchema = z.enum(
+  Constants.public.Enums.showdown_turn
+)
+
+/**
+ * At Least One Defined
+ *
+ * Checks whether at least one field exists on a payload.
+ *
+ * @param data Payload Data
+ * @param fields Field Names
+ * @returns Whether At Least One Field Is Defined
+ */
+function hasAtLeastOneDefined(
+  data: Record<string, unknown>,
+  fields: readonly string[]
+): boolean {
+  return fields.some((field) => data[field] !== undefined)
+}
+
+/**
+ * Require At Least One Update
+ *
+ * Adds a validation issue when an update payload has no mutable fields.
+ *
+ * @param data Payload Data
+ * @param ctx Refinement Context
+ * @param fields Mutable Field Names
+ */
+function requireAtLeastOneUpdate(
+  data: Record<string, unknown>,
+  ctx: z.RefinementCtx,
+  fields: readonly string[]
+): void {
+  if (hasAtLeastOneDefined(data, fields)) return
+
+  ctx.addIssue({
+    code: 'custom',
+    message: 'At least one change must be included in the update record.'
+  })
+}
+
+/** Vignette Create Input Schema */
+export const VignetteCreateInputSchema = z.object({
+  /** Vignette Monster ID */
+  vignette_monster_id: VignetteUuidSchema,
+  /** Level Number */
+  level_number: VignetteLevelNumberSchema
+})
+
+/** Vignette Create Input */
+export type VignetteCreateInput = z.infer<typeof VignetteCreateInputSchema>
+
+/** Vignette Active Limit Schema */
+export const VignetteActiveLimitSchema = z
+  .object({
+    /** Active Owned Vignette Encounter ID */
+    active_vignette_encounter_id: VignetteUuidSchema.nullable().default(null)
+  })
+  .refine((data) => data.active_vignette_encounter_id === null, {
+    message: 'Only one active vignette can run at a time.',
+    path: ['active_vignette_encounter_id']
+  })
+
+/** Vignette Active Limit */
+export type VignetteActiveLimit = z.infer<typeof VignetteActiveLimitSchema>
+
+/** Vignette Encounter Update Input Schema */
+export const VignetteEncounterUpdateInputSchema = z
+  .object({
+    /** Vignette Encounter ID */
+    vignette_encounter_id: VignetteUuidSchema,
+    /** Turn */
+    turn: VignetteShowdownTurnSchema.optional(),
+    /** Notes */
+    notes: z.string().optional()
+  })
+  .superRefine((data, ctx) =>
+    requireAtLeastOneUpdate(data, ctx, ['turn', 'notes'])
+  )
+
+/** Vignette Encounter Update Input */
+export type VignetteEncounterUpdateInput = z.infer<
+  typeof VignetteEncounterUpdateInputSchema
+>
+
+/** Vignette Encounter Delete Input Schema */
+export const VignetteEncounterDeleteInputSchema = z.object({
+  /** Vignette Encounter ID */
+  vignette_encounter_id: VignetteUuidSchema
+})
+
+/** Vignette Encounter Delete Input */
+export type VignetteEncounterDeleteInput = z.infer<
+  typeof VignetteEncounterDeleteInputSchema
+>
+
+/** Vignette Encounter AI Deck Update Input Schema */
+export const VignetteEncounterAIDeckUpdateInputSchema = z
+  .object({
+    /** Vignette Encounter AI Deck ID */
+    vignette_encounter_ai_deck_id: VignetteUuidSchema,
+    /** Basic Cards */
+    basic_cards: VignetteNonNegativeCountSchema.optional(),
+    /** Advanced Cards */
+    advanced_cards: VignetteNonNegativeCountSchema.optional(),
+    /** Legendary Cards */
+    legendary_cards: VignetteNonNegativeCountSchema.optional(),
+    /** Overtone Cards */
+    overtone_cards: VignetteNonNegativeCountSchema.optional()
+  })
+  .superRefine((data, ctx) =>
+    requireAtLeastOneUpdate(data, ctx, [
+      'basic_cards',
+      'advanced_cards',
+      'legendary_cards',
+      'overtone_cards'
+    ])
+  )
+
+/** Vignette Encounter AI Deck Update Input */
+export type VignetteEncounterAIDeckUpdateInput = z.infer<
+  typeof VignetteEncounterAIDeckUpdateInputSchema
+>
+
+/** Vignette Encounter Monster Update Fields */
+const VignetteEncounterMonsterUpdateFields = [
+  'accuracy',
+  'accuracy_tokens',
+  'ai_card_drawn',
+  'ai_deck_remaining',
+  'damage',
+  'damage_tokens',
+  'evasion',
+  'evasion_tokens',
+  'knocked_down',
+  'luck',
+  'luck_tokens',
+  'monster_name',
+  'movement',
+  'movement_tokens',
+  'notes',
+  'speed',
+  'speed_tokens',
+  'strength',
+  'strength_tokens',
+  'toughness',
+  'toughness_tokens',
+  'wounds'
+]
+
+/** Vignette Encounter Monster Update Input Schema */
+export const VignetteEncounterMonsterUpdateInputSchema = z
+  .object({
+    /** Vignette Encounter Monster ID */
+    vignette_encounter_monster_id: VignetteUuidSchema,
+    /** Accuracy */
+    accuracy: z.number().int('Accuracy must be a whole number.').optional(),
+    /** Accuracy Tokens */
+    accuracy_tokens: VignetteTokenCountSchema.optional(),
+    /** AI Card Drawn */
+    ai_card_drawn: z.boolean().optional(),
+    /** AI Deck Remaining */
+    ai_deck_remaining: VignetteNonNegativeCountSchema.optional(),
+    /** Damage */
+    damage: z.number().int('Damage must be a whole number.').optional(),
+    /** Damage Tokens */
+    damage_tokens: VignetteTokenCountSchema.optional(),
+    /** Evasion */
+    evasion: z.number().int('Evasion must be a whole number.').optional(),
+    /** Evasion Tokens */
+    evasion_tokens: VignetteTokenCountSchema.optional(),
+    /** Knocked Down */
+    knocked_down: z.boolean().optional(),
+    /** Luck */
+    luck: z.number().int('Luck must be a whole number.').optional(),
+    /** Luck Tokens */
+    luck_tokens: VignetteTokenCountSchema.optional(),
+    /** Monster Name */
+    monster_name: z
+      .string()
+      .trim()
+      .min(1, 'A nameless monster cannot be recorded.')
+      .optional(),
+    /** Movement */
+    movement: z.number().int('Movement must be a whole number.').optional(),
+    /** Movement Tokens */
+    movement_tokens: VignetteTokenCountSchema.optional(),
+    /** Notes */
+    notes: z.string().optional(),
+    /** Speed */
+    speed: z.number().int('Speed must be a whole number.').optional(),
+    /** Speed Tokens */
+    speed_tokens: VignetteTokenCountSchema.optional(),
+    /** Strength */
+    strength: z.number().int('Strength must be a whole number.').optional(),
+    /** Strength Tokens */
+    strength_tokens: VignetteTokenCountSchema.optional(),
+    /** Toughness */
+    toughness: z.number().int('Toughness must be a whole number.').optional(),
+    /** Toughness Tokens */
+    toughness_tokens: VignetteTokenCountSchema.optional(),
+    /** Wounds */
+    wounds: VignetteNonNegativeCountSchema.optional()
+  })
+  .superRefine((data, ctx) =>
+    requireAtLeastOneUpdate(data, ctx, VignetteEncounterMonsterUpdateFields)
+  )
+
+/** Vignette Encounter Monster Update Input */
+export type VignetteEncounterMonsterUpdateInput = z.infer<
+  typeof VignetteEncounterMonsterUpdateInputSchema
+>
+
+/** Vignette Encounter Monster Mood Input Schema */
+export const VignetteEncounterMonsterMoodInputSchema = z.object({
+  /** Vignette Encounter Monster ID */
+  vignette_encounter_monster_id: VignetteUuidSchema,
+  /** Mood ID */
+  mood_id: VignetteUuidSchema,
+  /** Source Vignette Monster Level Mood ID */
+  source_vignette_monster_level_mood_id:
+    VignetteUuidSchema.nullable().default(null)
+})
+
+/** Vignette Encounter Monster Mood Input */
+export type VignetteEncounterMonsterMoodInput = z.infer<
+  typeof VignetteEncounterMonsterMoodInputSchema
+>
+
+/** Vignette Encounter Monster Trait Input Schema */
+export const VignetteEncounterMonsterTraitInputSchema = z.object({
+  /** Vignette Encounter Monster ID */
+  vignette_encounter_monster_id: VignetteUuidSchema,
+  /** Trait ID */
+  trait_id: VignetteUuidSchema,
+  /** Source Vignette Monster Level Trait ID */
+  source_vignette_monster_level_trait_id:
+    VignetteUuidSchema.nullable().default(null)
+})
+
+/** Vignette Encounter Monster Trait Input */
+export type VignetteEncounterMonsterTraitInput = z.infer<
+  typeof VignetteEncounterMonsterTraitInputSchema
+>
+
+/** Vignette Encounter Monster Survivor Status Input Schema */
+export const VignetteEncounterMonsterSurvivorStatusInputSchema = z.object({
+  /** Vignette Encounter Monster ID */
+  vignette_encounter_monster_id: VignetteUuidSchema,
+  /** Survivor Status ID */
+  survivor_status_id: VignetteUuidSchema,
+  /** Source Vignette Monster Level Survivor Status ID */
+  source_vignette_monster_level_survivor_status_id:
+    VignetteUuidSchema.nullable().default(null)
+})
+
+/** Vignette Encounter Monster Survivor Status Input */
+export type VignetteEncounterMonsterSurvivorStatusInput = z.infer<
+  typeof VignetteEncounterMonsterSurvivorStatusInputSchema
+>
+
+/** Vignette Encounter Monster State Delete Input Schema */
+export const VignetteEncounterMonsterStateDeleteInputSchema = z.object({
+  /** Active Monster State Row ID */
+  id: VignetteUuidSchema
+})
+
+/** Vignette Encounter Monster State Delete Input */
+export type VignetteEncounterMonsterStateDeleteInput = z.infer<
+  typeof VignetteEncounterMonsterStateDeleteInputSchema
+>
+
+/** Vignette Encounter Survivor Live State Fields */
+const VignetteEncounterSurvivorLiveStateFields = [
+  'accuracy_tokens',
+  'activation_used',
+  'arm_heavy_damage',
+  'arm_light_damage',
+  'bleeding_tokens',
+  'block_tokens',
+  'body_heavy_damage',
+  'body_light_damage',
+  'brain_light_damage',
+  'dead',
+  'deflect_tokens',
+  'evasion_tokens',
+  'head_heavy_damage',
+  'insanity_tokens',
+  'knocked_down',
+  'leg_heavy_damage',
+  'leg_light_damage',
+  'luck_tokens',
+  'movement_tokens',
+  'movement_used',
+  'notes',
+  'priority_target',
+  'retired',
+  'scout',
+  'speed_tokens',
+  'strength_tokens',
+  'survival',
+  'survival_tokens',
+  'waist_heavy_damage',
+  'waist_light_damage'
+]
+
+/** Vignette Encounter Survivor Live State Update Input Schema */
+export const VignetteEncounterSurvivorLiveStateUpdateInputSchema = z
+  .object({
+    /** Vignette Encounter Survivor ID */
+    vignette_encounter_survivor_id: VignetteUuidSchema,
+    /** Accuracy Tokens */
+    accuracy_tokens: VignetteTokenCountSchema.optional(),
+    /** Activation Used */
+    activation_used: z.boolean().optional(),
+    /** Arm Heavy Damage */
+    arm_heavy_damage: z.boolean().optional(),
+    /** Arm Light Damage */
+    arm_light_damage: z.boolean().optional(),
+    /** Bleeding Tokens */
+    bleeding_tokens: VignetteNonNegativeCountSchema.optional(),
+    /** Block Tokens */
+    block_tokens: VignetteTokenCountSchema.optional(),
+    /** Body Heavy Damage */
+    body_heavy_damage: z.boolean().optional(),
+    /** Body Light Damage */
+    body_light_damage: z.boolean().optional(),
+    /** Brain Light Damage */
+    brain_light_damage: z.boolean().optional(),
+    /** Dead */
+    dead: z.boolean().optional(),
+    /** Deflect Tokens */
+    deflect_tokens: VignetteTokenCountSchema.optional(),
+    /** Evasion Tokens */
+    evasion_tokens: VignetteTokenCountSchema.optional(),
+    /** Head Heavy Damage */
+    head_heavy_damage: z.boolean().optional(),
+    /** Insanity Tokens */
+    insanity_tokens: VignetteTokenCountSchema.optional(),
+    /** Knocked Down */
+    knocked_down: z.boolean().optional(),
+    /** Leg Heavy Damage */
+    leg_heavy_damage: z.boolean().optional(),
+    /** Leg Light Damage */
+    leg_light_damage: z.boolean().optional(),
+    /** Luck Tokens */
+    luck_tokens: VignetteTokenCountSchema.optional(),
+    /** Movement Tokens */
+    movement_tokens: VignetteTokenCountSchema.optional(),
+    /** Movement Used */
+    movement_used: z.boolean().optional(),
+    /** Notes */
+    notes: z.string().optional(),
+    /** Priority Target */
+    priority_target: z.boolean().optional(),
+    /** Retired */
+    retired: z.boolean().optional(),
+    /** Scout */
+    scout: z.boolean().optional(),
+    /** Speed Tokens */
+    speed_tokens: VignetteTokenCountSchema.optional(),
+    /** Strength Tokens */
+    strength_tokens: VignetteTokenCountSchema.optional(),
+    /** Survival */
+    survival: VignetteNonNegativeCountSchema.optional(),
+    /** Survival Tokens */
+    survival_tokens: VignetteTokenCountSchema.optional(),
+    /** Waist Heavy Damage */
+    waist_heavy_damage: z.boolean().optional(),
+    /** Waist Light Damage */
+    waist_light_damage: z.boolean().optional()
+  })
+  .superRefine((data, ctx) => {
+    requireAtLeastOneUpdate(data, ctx, VignetteEncounterSurvivorLiveStateFields)
+  })
+
+/** Vignette Encounter Survivor Live State Update Input */
+export type VignetteEncounterSurvivorLiveStateUpdateInput = z.infer<
+  typeof VignetteEncounterSurvivorLiveStateUpdateInputSchema
+>
+
+/** Vignette Encounter Survivor Gear Grid Update Input Schema */
+export const VignetteEncounterSurvivorGearGridUpdateInputSchema = z
+  .object({
+    /** Vignette Encounter Survivor Gear Grid ID */
+    vignette_encounter_survivor_gear_grid_id: VignetteUuidSchema,
+    /** Gear ID */
+    gear_id: VignetteUuidSchema.optional(),
+    /** Row Number */
+    row_number: VignetteGridCoordinateSchema.optional(),
+    /** Column Number */
+    column_number: VignetteGridCoordinateSchema.optional()
+  })
+  .superRefine((data, ctx) =>
+    requireAtLeastOneUpdate(data, ctx, [
+      'gear_id',
+      'row_number',
+      'column_number'
+    ])
+  )
+
+/** Vignette Encounter Survivor Gear Grid Update Input */
+export type VignetteEncounterSurvivorGearGridUpdateInput = z.infer<
+  typeof VignetteEncounterSurvivorGearGridUpdateInputSchema
+>
+
+/** Vignette Share Input Schema */
+export const VignetteShareInputSchema = z.object({
+  /** Vignette Encounter ID */
+  vignette_encounter_id: VignetteUuidSchema,
+  /** Username */
+  username: z
+    .string()
+    .trim()
+    .min(1, 'A nameless collaborator cannot be invited.')
+})
+
+/** Vignette Share Input */
+export type VignetteShareInput = z.infer<typeof VignetteShareInputSchema>
+
+/** Vignette Share Removal Input Schema */
+export const VignetteShareRemovalInputSchema = z.object({
+  /** Vignette Encounter ID */
+  vignette_encounter_id: VignetteUuidSchema,
+  /** Shared User ID */
+  shared_user_id: VignetteUuidSchema
+})
+
+/** Vignette Share Removal Input */
+export type VignetteShareRemovalInput = z.infer<
+  typeof VignetteShareRemovalInputSchema
+>

--- a/schemas/vignette-encounter.ts
+++ b/schemas/vignette-encounter.ts
@@ -1,8 +1,8 @@
 import { Constants } from '@/lib/database.types'
 import { z } from 'zod'
 
-/** Vignette UUID Schema */
-const VignetteUuidSchema = z.uuid('A valid vignette id is required.')
+/** UUID Schema */
+const UuidSchema = z.uuid('A valid UUID is required.')
 
 /** Vignette Level Number Schema */
 const VignetteLevelNumberSchema = z
@@ -18,7 +18,9 @@ const VignetteNonNegativeCountSchema = z
   .min(0, 'Count cannot be negative.')
 
 /** Vignette Token Count Schema */
-const VignetteTokenCountSchema = z.number().int('Token count must be whole.')
+const VignetteTokenCountSchema = z
+  .number()
+  .int('Token count must be a whole number.')
 
 /** Vignette Grid Coordinate Schema */
 const VignetteGridCoordinateSchema = z
@@ -73,7 +75,7 @@ function requireAtLeastOneUpdate(
 /** Vignette Create Input Schema */
 export const VignetteCreateInputSchema = z.object({
   /** Vignette Monster ID */
-  vignette_monster_id: VignetteUuidSchema,
+  vignette_monster_id: UuidSchema,
   /** Level Number */
   level_number: VignetteLevelNumberSchema
 })
@@ -85,7 +87,7 @@ export type VignetteCreateInput = z.infer<typeof VignetteCreateInputSchema>
 export const VignetteActiveLimitSchema = z
   .object({
     /** Active Owned Vignette Encounter ID */
-    active_vignette_encounter_id: VignetteUuidSchema.nullable().default(null)
+    active_vignette_encounter_id: UuidSchema.nullable().default(null)
   })
   .refine((data) => data.active_vignette_encounter_id === null, {
     message: 'Only one active vignette can run at a time.',
@@ -99,7 +101,7 @@ export type VignetteActiveLimit = z.infer<typeof VignetteActiveLimitSchema>
 export const VignetteEncounterUpdateInputSchema = z
   .object({
     /** Vignette Encounter ID */
-    vignette_encounter_id: VignetteUuidSchema,
+    vignette_encounter_id: UuidSchema,
     /** Turn */
     turn: VignetteShowdownTurnSchema.optional(),
     /** Notes */
@@ -117,7 +119,7 @@ export type VignetteEncounterUpdateInput = z.infer<
 /** Vignette Encounter Delete Input Schema */
 export const VignetteEncounterDeleteInputSchema = z.object({
   /** Vignette Encounter ID */
-  vignette_encounter_id: VignetteUuidSchema
+  vignette_encounter_id: UuidSchema
 })
 
 /** Vignette Encounter Delete Input */
@@ -129,7 +131,7 @@ export type VignetteEncounterDeleteInput = z.infer<
 export const VignetteEncounterAIDeckUpdateInputSchema = z
   .object({
     /** Vignette Encounter AI Deck ID */
-    vignette_encounter_ai_deck_id: VignetteUuidSchema,
+    vignette_encounter_ai_deck_id: UuidSchema,
     /** Basic Cards */
     basic_cards: VignetteNonNegativeCountSchema.optional(),
     /** Advanced Cards */
@@ -183,7 +185,7 @@ const VignetteEncounterMonsterUpdateFields = [
 export const VignetteEncounterMonsterUpdateInputSchema = z
   .object({
     /** Vignette Encounter Monster ID */
-    vignette_encounter_monster_id: VignetteUuidSchema,
+    vignette_encounter_monster_id: UuidSchema,
     /** Accuracy */
     accuracy: z.number().int('Accuracy must be a whole number.').optional(),
     /** Accuracy Tokens */
@@ -245,12 +247,12 @@ export type VignetteEncounterMonsterUpdateInput = z.infer<
 /** Vignette Encounter Monster Mood Input Schema */
 export const VignetteEncounterMonsterMoodInputSchema = z.object({
   /** Vignette Encounter Monster ID */
-  vignette_encounter_monster_id: VignetteUuidSchema,
+  vignette_encounter_monster_id: UuidSchema,
   /** Mood ID */
-  mood_id: VignetteUuidSchema,
+  mood_id: UuidSchema,
   /** Source Vignette Monster Level Mood ID */
   source_vignette_monster_level_mood_id:
-    VignetteUuidSchema.nullable().default(null)
+    UuidSchema.nullable().default(null)
 })
 
 /** Vignette Encounter Monster Mood Input */
@@ -261,12 +263,12 @@ export type VignetteEncounterMonsterMoodInput = z.infer<
 /** Vignette Encounter Monster Trait Input Schema */
 export const VignetteEncounterMonsterTraitInputSchema = z.object({
   /** Vignette Encounter Monster ID */
-  vignette_encounter_monster_id: VignetteUuidSchema,
+  vignette_encounter_monster_id: UuidSchema,
   /** Trait ID */
-  trait_id: VignetteUuidSchema,
+  trait_id: UuidSchema,
   /** Source Vignette Monster Level Trait ID */
   source_vignette_monster_level_trait_id:
-    VignetteUuidSchema.nullable().default(null)
+    UuidSchema.nullable().default(null)
 })
 
 /** Vignette Encounter Monster Trait Input */
@@ -277,12 +279,12 @@ export type VignetteEncounterMonsterTraitInput = z.infer<
 /** Vignette Encounter Monster Survivor Status Input Schema */
 export const VignetteEncounterMonsterSurvivorStatusInputSchema = z.object({
   /** Vignette Encounter Monster ID */
-  vignette_encounter_monster_id: VignetteUuidSchema,
+  vignette_encounter_monster_id: UuidSchema,
   /** Survivor Status ID */
-  survivor_status_id: VignetteUuidSchema,
+  survivor_status_id: UuidSchema,
   /** Source Vignette Monster Level Survivor Status ID */
   source_vignette_monster_level_survivor_status_id:
-    VignetteUuidSchema.nullable().default(null)
+    UuidSchema.nullable().default(null)
 })
 
 /** Vignette Encounter Monster Survivor Status Input */
@@ -293,7 +295,7 @@ export type VignetteEncounterMonsterSurvivorStatusInput = z.infer<
 /** Vignette Encounter Monster State Delete Input Schema */
 export const VignetteEncounterMonsterStateDeleteInputSchema = z.object({
   /** Active Monster State Row ID */
-  id: VignetteUuidSchema
+  id: UuidSchema
 })
 
 /** Vignette Encounter Monster State Delete Input */
@@ -339,7 +341,7 @@ const VignetteEncounterSurvivorLiveStateFields = [
 export const VignetteEncounterSurvivorLiveStateUpdateInputSchema = z
   .object({
     /** Vignette Encounter Survivor ID */
-    vignette_encounter_survivor_id: VignetteUuidSchema,
+    vignette_encounter_survivor_id: UuidSchema,
     /** Accuracy Tokens */
     accuracy_tokens: VignetteTokenCountSchema.optional(),
     /** Activation Used */
@@ -414,9 +416,9 @@ export type VignetteEncounterSurvivorLiveStateUpdateInput = z.infer<
 export const VignetteEncounterSurvivorGearGridUpdateInputSchema = z
   .object({
     /** Vignette Encounter Survivor Gear Grid ID */
-    vignette_encounter_survivor_gear_grid_id: VignetteUuidSchema,
+    vignette_encounter_survivor_gear_grid_id: UuidSchema,
     /** Gear ID */
-    gear_id: VignetteUuidSchema.optional(),
+    gear_id: UuidSchema.optional(),
     /** Row Number */
     row_number: VignetteGridCoordinateSchema.optional(),
     /** Column Number */
@@ -438,7 +440,7 @@ export type VignetteEncounterSurvivorGearGridUpdateInput = z.infer<
 /** Vignette Share Input Schema */
 export const VignetteShareInputSchema = z.object({
   /** Vignette Encounter ID */
-  vignette_encounter_id: VignetteUuidSchema,
+  vignette_encounter_id: UuidSchema,
   /** Username */
   username: z
     .string()
@@ -452,9 +454,9 @@ export type VignetteShareInput = z.infer<typeof VignetteShareInputSchema>
 /** Vignette Share Removal Input Schema */
 export const VignetteShareRemovalInputSchema = z.object({
   /** Vignette Encounter ID */
-  vignette_encounter_id: VignetteUuidSchema,
+  vignette_encounter_id: UuidSchema,
   /** Shared User ID */
-  shared_user_id: VignetteUuidSchema
+  shared_user_id: UuidSchema
 })
 
 /** Vignette Share Removal Input */

--- a/schemas/vignette-encounter.ts
+++ b/schemas/vignette-encounter.ts
@@ -251,8 +251,7 @@ export const VignetteEncounterMonsterMoodInputSchema = z.object({
   /** Mood ID */
   mood_id: UuidSchema,
   /** Source Vignette Monster Level Mood ID */
-  source_vignette_monster_level_mood_id:
-    UuidSchema.nullable().default(null)
+  source_vignette_monster_level_mood_id: UuidSchema.nullable().default(null)
 })
 
 /** Vignette Encounter Monster Mood Input */
@@ -267,8 +266,7 @@ export const VignetteEncounterMonsterTraitInputSchema = z.object({
   /** Trait ID */
   trait_id: UuidSchema,
   /** Source Vignette Monster Level Trait ID */
-  source_vignette_monster_level_trait_id:
-    UuidSchema.nullable().default(null)
+  source_vignette_monster_level_trait_id: UuidSchema.nullable().default(null)
 })
 
 /** Vignette Encounter Monster Trait Input */


### PR DESCRIPTION
## Summary
- Adds vignette encounter Zod schemas for catalog creation, active gameplay updates, sharing, deletion, and active-limit validation.
- Covers valid and invalid schema payloads for create, update, monster state, survivor live state, gear grid, and sharing inputs.
- Bumps the app version to 0.92.0 for this PR.

## Dependencies
- No dependency changes.

## Related Issues
Closes #342

## Testing
- `npx vitest run __tests__/schemas/vignette-encounter.test.ts --coverage.enabled=false`

## Additional Context
- The focused schema tests pass without coverage thresholds; running only this file through the full npm test script also executes the tests but triggers repository-wide coverage thresholds.