### PR TITLE
[VIG-02.03] Add vignette DAL read helpers

### DIFF
--- a/__tests__/lib/dal/vignette-encounter.test.ts
+++ b/__tests__/lib/dal/vignette-encounter.test.ts
@@ -1,0 +1,554 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSupabase = {
+  from: vi.fn()
+}
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabase
+}))
+
+vi.mock('@/lib/dal/user', () => ({
+  getUserId: vi.fn()
+}))
+
+const {
+  getAccessibleVignetteEncountersForUser,
+  getActiveVignetteEncounterForUser,
+  getSharedVignetteEncountersForUser,
+  getVignetteEncounter,
+  getVignetteEncounterAIDecks,
+  getVignetteEncounterMonsters,
+  getVignetteEncounterSharedUsers,
+  getVignetteEncounterSurvivors,
+  getVignetteMonster,
+  getVignetteMonsters
+} = await import('@/lib/dal/vignette-encounter')
+const { getUserId } = await import('@/lib/dal/user')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(getUserId).mockResolvedValue('owner-1')
+})
+
+function queryResult(data: unknown, error: unknown = null) {
+  return { data, error }
+}
+
+function makeQuery(result: unknown, error: unknown = null) {
+  const resolved = queryResult(result, error)
+  const query = {
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(resolved),
+    select: vi.fn().mockReturnThis(),
+    then: (resolve: (value: unknown) => unknown) =>
+      Promise.resolve(resolve(resolved))
+  }
+
+  return query
+}
+
+function mockFromSequence(...queries: ReturnType<typeof makeQuery>[]) {
+  mockSupabase.from.mockImplementation(() => {
+    const query = queries.shift()
+    if (!query) throw new Error('Unexpected query')
+    return query
+  })
+}
+
+const rawCatalogMonster = {
+  id: 'vm-1',
+  monster_name: 'Killenium Butcher',
+  multi_monster: false,
+  source_monster_type: 'NEMESIS',
+  source_nemesis_id: 'nemesis-1',
+  source_quarry_id: null,
+  vignette_monster_level: [
+    {
+      id: 'level-1',
+      vignette_monster_id: 'vm-1',
+      level_number: 1,
+      movement: 6,
+      speed: 2,
+      accuracy: 4,
+      evasion: 1,
+      damage: 2,
+      toughness: 8,
+      life: 12,
+      ai_deck_remaining: 7,
+      basic_cards: 3,
+      advanced_cards: 2,
+      legendary_cards: 1,
+      overtone_cards: 0,
+      accuracy_tokens: 0,
+      damage_tokens: 0,
+      evasion_tokens: 0,
+      luck: 0,
+      luck_tokens: 0,
+      movement_tokens: 0,
+      speed_tokens: 0,
+      strength: 0,
+      strength_tokens: 0,
+      sub_monster_name: null,
+      toughness_tokens: 0,
+      vignette_monster_level_mood: [
+        {
+          id: 'level-mood-1',
+          mood_id: 'mood-1',
+          vignette_monster_level_id: 'level-1',
+          mood: {
+            id: 'mood-1',
+            custom: true,
+            user_id: 'author-1',
+            mood_name: 'Guttering Dread',
+            rules: null
+          }
+        }
+      ],
+      vignette_monster_level_trait: [
+        {
+          id: 'level-trait-1',
+          trait_id: 'trait-1',
+          vignette_monster_level_id: 'level-1',
+          trait: {
+            id: 'trait-1',
+            custom: false,
+            user_id: null,
+            trait_name: 'Built In Terror',
+            rules: 'Boo.'
+          }
+        }
+      ],
+      vignette_monster_level_survivor_status: []
+    }
+  ],
+  vignette_survivor: [
+    {
+      id: 'survivor-1',
+      vignette_monster_id: 'vm-1',
+      survivor_name: 'Lantern Bearer',
+      survivor_type: 'CORE',
+      gender: 'FEMALE',
+      movement: 5,
+      accuracy: 0,
+      strength: 1,
+      evasion: 0,
+      luck: 0,
+      speed: 0,
+      survival: 2,
+      insanity: 1,
+      courage: 0,
+      understanding: 0,
+      weapon_proficiency: 0,
+      weapon_type_id: null,
+      arm_armor: 0,
+      body_armor: 0,
+      head_armor: 0,
+      leg_armor: 0,
+      waist_armor: 0,
+      notes: '',
+      vignette_survivor_ability_impairment: [],
+      vignette_survivor_disorder: [],
+      vignette_survivor_fighting_art: [],
+      vignette_survivor_secret_fighting_art: [],
+      vignette_survivor_gear_grid: [
+        {
+          id: 'gear-grid-1',
+          vignette_survivor_id: 'survivor-1',
+          gear_id: 'gear-1',
+          row_number: 0,
+          column_number: 1,
+          gear: {
+            id: 'gear-1',
+            custom: true,
+            user_id: 'author-2',
+            gear_name: 'Bone Blade',
+            location_id: null,
+            accessory: null,
+            accuracy: null,
+            affinity_top: null,
+            affinity_left: null,
+            affinity_right: null,
+            affinity_bottom: null,
+            affinity_bonus: null,
+            affinity_bonus_requirements: [{ affinity: 'RED', puzzle: false }],
+            armor_points: null,
+            armor_location: null,
+            keywords: null,
+            rules: null,
+            speed: null,
+            strength: null,
+            weapon_type_id: null,
+            gear_gear_cost: [{ cost_gear_id: 'gear-2', quantity: 1 }],
+            gear_resource_cost: [],
+            gear_resource_type_cost: []
+          }
+        }
+      ]
+    }
+  ]
+}
+
+describe('getVignetteMonsters', () => {
+  it('returns vignette catalog monsters keyed by id with nested setup data', async () => {
+    mockSupabase.from.mockReturnValue(makeQuery([rawCatalogMonster]))
+
+    const result = await getVignetteMonsters()
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('vignette_monster')
+    expect(result['vm-1'].levels[0].moods[0].mood).toMatchObject({
+      id: 'mood-1',
+      mood_name: 'Guttering Dread',
+      author_user_id: 'author-1',
+      author_username: null,
+      author_avatar_url: null
+    })
+    expect(result['vm-1'].levels[0].traits[0].trait).toMatchObject({
+      id: 'trait-1',
+      author_user_id: null
+    })
+    expect(result['vm-1'].survivors[0].gear_grid[0].gear).toMatchObject({
+      id: 'gear-1',
+      gear_name: 'Bone Blade',
+      author_user_id: 'author-2',
+      affinity_bonus_requirements: [{ affinity: 'RED', puzzle: false }],
+      gear_costs: [{ cost_gear_id: 'gear-2', quantity: 1 }]
+    })
+  })
+
+  it('throws when the catalog query fails', async () => {
+    mockSupabase.from.mockReturnValue(makeQuery(null, { message: 'DB error' }))
+
+    await expect(getVignetteMonsters()).rejects.toThrow(
+      'Error Fetching Vignette Monsters: DB error'
+    )
+  })
+})
+
+describe('getVignetteMonster', () => {
+  it('returns null when the id is null', async () => {
+    const result = await getVignetteMonster(null)
+
+    expect(result).toBeNull()
+    expect(mockSupabase.from).not.toHaveBeenCalled()
+  })
+
+  it('filters by vignette monster id', async () => {
+    const query = makeQuery([rawCatalogMonster])
+    mockSupabase.from.mockReturnValue(query)
+
+    const result = await getVignetteMonster('vm-1')
+
+    expect(result?.id).toBe('vm-1')
+    expect(query.eq).toHaveBeenCalledWith('id', 'vm-1')
+  })
+})
+
+describe('vignette encounter summaries', () => {
+  const ownedEncounter = {
+    id: 'encounter-1',
+    level_number: 2,
+    turn: 'MONSTER',
+    user_id: 'owner-1',
+    vignette_monster_id: 'vm-1',
+    vignette_monster: { monster_name: 'Killenium Butcher' }
+  }
+
+  const sharedEncounter = {
+    id: 'encounter-2',
+    level_number: 1,
+    turn: 'SURVIVOR',
+    user_id: 'other-owner',
+    vignette_monster_id: 'vm-2',
+    vignette_monster: { monster_name: 'Screaming Nukalope' }
+  }
+
+  it('fetches only the current user owned active vignette', async () => {
+    const query = makeQuery(ownedEncounter)
+    mockSupabase.from.mockReturnValue(query)
+
+    const result = await getActiveVignetteEncounterForUser()
+
+    expect(query.eq).toHaveBeenCalledWith('user_id', 'owner-1')
+    expect(result).toEqual({
+      id: 'encounter-1',
+      level_number: 2,
+      monster_name: 'Killenium Butcher',
+      owner_avatar_url: null,
+      owner_user_id: 'owner-1',
+      owner_username: null,
+      role: 'owner',
+      turn: 'MONSTER',
+      vignette_monster_id: 'vm-1'
+    })
+  })
+
+  it('fetches shared active vignettes as collaborator summaries', async () => {
+    const query = makeQuery([{ vignette_encounter: sharedEncounter }])
+    mockSupabase.from.mockReturnValue(query)
+
+    const result = await getSharedVignetteEncountersForUser()
+
+    expect(query.eq).toHaveBeenCalledWith('shared_user_id', 'owner-1')
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'encounter-2',
+        role: 'collaborator',
+        monster_name: 'Screaming Nukalope',
+        owner_user_id: 'other-owner'
+      })
+    ])
+  })
+
+  it('combines owned and shared summaries for accessible switching', async () => {
+    mockFromSequence(
+      makeQuery(ownedEncounter),
+      makeQuery([{ vignette_encounter: sharedEncounter }])
+    )
+
+    const result = await getAccessibleVignetteEncountersForUser()
+
+    expect(result.map((summary) => summary.id)).toEqual([
+      'encounter-1',
+      'encounter-2'
+    ])
+    expect(result.map((summary) => summary.role)).toEqual([
+      'owner',
+      'collaborator'
+    ])
+  })
+})
+
+describe('getVignetteEncounter', () => {
+  const encounter = {
+    id: 'encounter-1',
+    level_number: 1,
+    notes: 'A narrow pool of light.',
+    turn: 'MONSTER',
+    user_id: 'owner-1',
+    vignette_monster_id: 'vm-1'
+  }
+
+  const aiDeck = {
+    id: 'deck-1',
+    vignette_encounter_id: 'encounter-1',
+    basic_cards: 4,
+    advanced_cards: 2,
+    legendary_cards: 1,
+    overtone_cards: 0
+  }
+
+  it('returns null when the id is undefined', async () => {
+    const result = await getVignetteEncounter(undefined)
+
+    expect(result).toBeNull()
+    expect(mockSupabase.from).not.toHaveBeenCalled()
+  })
+
+  it('assembles full active detail state with role data', async () => {
+    mockFromSequence(
+      makeQuery(encounter),
+      makeQuery([rawCatalogMonster]),
+      makeQuery([aiDeck]),
+      makeQuery([
+        {
+          id: 'share-1',
+          vignette_encounter_id: 'encounter-1',
+          shared_user_id: 'collab-1',
+          user_settings: { username: 'lantern.friend', avatar_url: null }
+        }
+      ]),
+      makeQuery([
+        {
+          id: 'active-monster-1',
+          vignette_encounter_id: 'encounter-1',
+          ai_deck_id: 'deck-1',
+          monster_name: 'Butcher',
+          wounds: 2,
+          vignette_encounter_monster_mood: [
+            {
+              id: 'active-mood-1',
+              vignette_encounter_monster_id: 'active-monster-1',
+              mood_id: 'mood-1',
+              source_vignette_monster_level_mood_id: 'level-mood-1',
+              mood: {
+                id: 'mood-1',
+                custom: true,
+                user_id: 'author-1',
+                mood_name: 'Guttering Dread',
+                rules: null
+              }
+            }
+          ],
+          vignette_encounter_monster_trait: [],
+          vignette_encounter_monster_survivor_status: []
+        }
+      ]),
+      makeQuery([
+        {
+          id: 'active-survivor-1',
+          vignette_encounter_id: 'encounter-1',
+          vignette_monster_id: 'vm-1',
+          source_vignette_survivor_id: 'survivor-1',
+          survivor_name: 'Lantern Bearer',
+          survivor_type: 'CORE',
+          movement: 5,
+          accuracy: 0,
+          strength: 1,
+          evasion: 0,
+          luck: 0,
+          speed: 0,
+          survival: 2,
+          insanity: 1,
+          courage: 0,
+          understanding: 0,
+          weapon_proficiency: 0,
+          weapon_type_id: null,
+          arm_armor: 0,
+          body_armor: 0,
+          head_armor: 0,
+          leg_armor: 0,
+          waist_armor: 0,
+          gender: 'FEMALE',
+          notes: 'Still standing.',
+          activation_used: true,
+          accuracy_tokens: 0,
+          arm_heavy_damage: false,
+          arm_light_damage: false,
+          bleeding_tokens: 1,
+          block_tokens: 0,
+          body_heavy_damage: false,
+          body_light_damage: false,
+          brain_light_damage: false,
+          dead: false,
+          deflect_tokens: 0,
+          evasion_tokens: 0,
+          head_heavy_damage: false,
+          insanity_tokens: 0,
+          knocked_down: false,
+          leg_heavy_damage: false,
+          leg_light_damage: false,
+          luck_tokens: 0,
+          movement_tokens: 0,
+          movement_used: true,
+          priority_target: false,
+          retired: false,
+          scout: false,
+          speed_tokens: 0,
+          strength_tokens: 0,
+          survival_tokens: -1,
+          waist_heavy_damage: false,
+          waist_light_damage: false,
+          vignette_encounter_survivor_ability_impairment: [],
+          vignette_encounter_survivor_disorder: [],
+          vignette_encounter_survivor_fighting_art: [],
+          vignette_encounter_survivor_secret_fighting_art: [],
+          vignette_encounter_survivor_gear_grid: []
+        }
+      ])
+    )
+
+    const result = await getVignetteEncounter('encounter-1')
+
+    expect(result).toMatchObject({
+      id: 'encounter-1',
+      role: 'owner',
+      vignette_monster: { id: 'vm-1' },
+      ai_decks: { 'deck-1': aiDeck },
+      shared_users: [
+        {
+          id: 'share-1',
+          shared_user_id: 'collab-1',
+          username: 'lantern.friend',
+          avatar_url: null
+        }
+      ]
+    })
+    expect(result!.monsters['active-monster-1'].ai_deck).toEqual(aiDeck)
+    expect(result!.monsters['active-monster-1'].moods[0].mood).toMatchObject({
+      mood_name: 'Guttering Dread',
+      author_user_id: 'author-1'
+    })
+    expect(result!.survivors['active-survivor-1'].live_state).toMatchObject({
+      activation_used: true,
+      bleeding_tokens: 1,
+      movement_used: true,
+      survival_tokens: -1,
+      notes: 'Still standing.'
+    })
+    expect(result!.survivors['active-survivor-1']).not.toHaveProperty(
+      'activation_used'
+    )
+  })
+
+  it('uses collaborator role when the current user is not the owner', async () => {
+    vi.mocked(getUserId).mockResolvedValue('collab-1')
+    mockFromSequence(
+      makeQuery(encounter),
+      makeQuery([rawCatalogMonster]),
+      makeQuery([]),
+      makeQuery([]),
+      makeQuery([]),
+      makeQuery([])
+    )
+
+    const result = await getVignetteEncounter('encounter-1')
+
+    expect(result?.role).toBe('collaborator')
+  })
+
+  it('throws when the base encounter query fails', async () => {
+    mockSupabase.from.mockReturnValue(makeQuery(null, { message: 'DB error' }))
+
+    await expect(getVignetteEncounter('encounter-1')).rejects.toThrow(
+      'Error Fetching Vignette Encounter: DB error'
+    )
+  })
+})
+
+describe('active vignette child readers', () => {
+  it('returns null for empty ids', async () => {
+    await expect(getVignetteEncounterAIDecks(null)).resolves.toBeNull()
+    await expect(getVignetteEncounterMonsters(undefined)).resolves.toBeNull()
+    await expect(getVignetteEncounterSurvivors(null)).resolves.toBeNull()
+    await expect(getVignetteEncounterSharedUsers(undefined)).resolves.toBeNull()
+    expect(mockSupabase.from).not.toHaveBeenCalled()
+  })
+
+  it('fetches AI decks when active monsters are read without prefetched decks', async () => {
+    const aiDeck = {
+      id: 'deck-1',
+      vignette_encounter_id: 'encounter-1',
+      basic_cards: 4,
+      advanced_cards: 2,
+      legendary_cards: 1,
+      overtone_cards: 0
+    }
+    mockFromSequence(
+      makeQuery([
+        {
+          id: 'active-monster-1',
+          vignette_encounter_id: 'encounter-1',
+          ai_deck_id: 'deck-1',
+          monster_name: 'Butcher',
+          vignette_encounter_monster_mood: [],
+          vignette_encounter_monster_trait: [],
+          vignette_encounter_monster_survivor_status: []
+        }
+      ]),
+      makeQuery([aiDeck])
+    )
+
+    const result = await getVignetteEncounterMonsters('encounter-1')
+
+    expect(result!['active-monster-1'].ai_deck).toEqual(aiDeck)
+    expect(mockSupabase.from).toHaveBeenNthCalledWith(
+      1,
+      'vignette_encounter_monster'
+    )
+    expect(mockSupabase.from).toHaveBeenNthCalledWith(
+      2,
+      'vignette_encounter_ai_deck'
+    )
+  })
+})

--- a/__tests__/lib/dal/vignette-encounter.test.ts
+++ b/__tests__/lib/dal/vignette-encounter.test.ts
@@ -504,6 +504,19 @@ describe('getVignetteEncounter', () => {
       'Error Fetching Vignette Encounter: DB error'
     )
   })
+
+  it('throws with the missing vignette monster id when catalog data is absent', async () => {
+    mockFromSequence(
+      makeQuery(encounter),
+      makeQuery([]),
+      makeQuery([]),
+      makeQuery([])
+    )
+
+    await expect(getVignetteEncounter('encounter-1')).rejects.toThrow(
+      'Error Fetching Vignette Encounter: Vignette Monster Not Found for vignette_monster_id vm-1'
+    )
+  })
 })
 
 describe('active vignette child readers', () => {
@@ -549,6 +562,36 @@ describe('active vignette child readers', () => {
     expect(mockSupabase.from).toHaveBeenNthCalledWith(
       2,
       'vignette_encounter_ai_deck'
+    )
+  })
+
+  it('throws when an active monster references an unknown AI deck', async () => {
+    mockFromSequence(
+      makeQuery([
+        {
+          id: 'active-monster-1',
+          vignette_encounter_id: 'encounter-1',
+          ai_deck_id: 'missing-deck',
+          monster_name: 'Butcher',
+          vignette_encounter_monster_mood: [],
+          vignette_encounter_monster_trait: [],
+          vignette_encounter_monster_survivor_status: []
+        }
+      ]),
+      makeQuery([
+        {
+          id: 'deck-1',
+          vignette_encounter_id: 'encounter-1',
+          basic_cards: 4,
+          advanced_cards: 2,
+          legendary_cards: 1,
+          overtone_cards: 0
+        }
+      ])
+    )
+
+    await expect(getVignetteEncounterMonsters('encounter-1')).rejects.toThrow(
+      'Error Fetching Vignette Encounter Monsters: AI deck missing-deck not found for monster active-monster-1'
     )
   })
 })

--- a/lib/dal/gear.ts
+++ b/lib/dal/gear.ts
@@ -38,10 +38,10 @@ export function toGearDetail(
     gear_gear_cost,
     gear_resource_cost,
     gear_resource_type_cost,
-    ...restWithUserId
+    user_id,
+    ...rest
   } = row
-  const rest = { ...restWithUserId }
-  delete (rest as { user_id?: string | null }).user_id
+  void user_id
 
   return {
     ...rest,

--- a/lib/dal/gear.ts
+++ b/lib/dal/gear.ts
@@ -18,7 +18,7 @@ import {
  * @param row Raw gear row including the junction relations.
  * @returns Normalized GearDetail.
  */
-function toGearDetail(
+export function toGearDetail(
   row: Omit<
     GearDetail,
     | 'gear_costs'
@@ -30,6 +30,7 @@ function toGearDetail(
     gear_gear_cost?: GearGearCostDetail[] | null
     gear_resource_cost?: GearResourceCostDetail[] | null
     gear_resource_type_cost?: GearResourceTypeCostDetail[] | null
+    user_id?: string | null
   }
 ): GearDetail {
   const {
@@ -37,8 +38,10 @@ function toGearDetail(
     gear_gear_cost,
     gear_resource_cost,
     gear_resource_type_cost,
-    ...rest
+    ...restWithUserId
   } = row
+  const rest = { ...restWithUserId }
+  delete (rest as { user_id?: string | null }).user_id
 
   return {
     ...rest,

--- a/lib/dal/vignette-encounter.ts
+++ b/lib/dal/vignette-encounter.ts
@@ -1,0 +1,976 @@
+import { toGearDetail } from '@/lib/dal/gear'
+import {
+  resolveSettlementAuthorship,
+  type SettlementMemberProfile
+} from '@/lib/dal/settlement-shared-user'
+import { getUserId } from '@/lib/dal/user'
+import { createClient } from '@/lib/supabase/client'
+import type {
+  CatalogAuthorshipDetail,
+  GearDetail,
+  VignetteEncounterAIDeckDetail,
+  VignetteEncounterDetail,
+  VignetteEncounterMonsterDetail,
+  VignetteEncounterSharedUserDetail,
+  VignetteEncounterSummary,
+  VignetteEncounterSurvivorDetail,
+  VignetteEncounterSurvivorLiveState,
+  VignetteMonsterDetail
+} from '@/lib/types'
+
+type DataRow = Record<string, unknown>
+
+const EMPTY_MEMBER_PROFILES = new Map<string, SettlementMemberProfile>()
+
+/** Catalog Authorship Select Statement */
+const CATALOG_AUTHORSHIP_SELECT = 'custom, id, rules, user_id'
+
+/** Gear Select Statement */
+const GEAR_SELECT = [
+  'accessory',
+  'accuracy',
+  'affinity_bonus',
+  'affinity_bonus_requirements',
+  'affinity_bottom',
+  'affinity_left',
+  'affinity_right',
+  'affinity_top',
+  'armor_location',
+  'armor_points',
+  'custom',
+  'gear_name',
+  'id',
+  'keywords',
+  'location_id',
+  'rules',
+  'speed',
+  'strength',
+  'user_id',
+  'weapon_type_id',
+  'gear_gear_cost!gear_gear_cost_gear_id_fkey(cost_gear_id, quantity)',
+  'gear_resource_cost(resource_id, quantity)',
+  'gear_resource_type_cost(resource_type, quantity)'
+].join(', ')
+
+/**
+ * Vignette Monster Select Statement
+ *
+ * Includes the survivors that are associated with the monster.
+ */
+const VIGNETTE_MONSTER_SELECT = [
+  'id',
+  'monster_name',
+  'multi_monster',
+  'source_monster_type',
+  'source_nemesis_id',
+  'source_quarry_id',
+  [
+    'vignette_monster_level(',
+    [
+      'accuracy',
+      'accuracy_tokens',
+      'advanced_cards',
+      'ai_deck_remaining',
+      'basic_cards',
+      'damage',
+      'damage_tokens',
+      'evasion',
+      'evasion_tokens',
+      'id',
+      'legendary_cards',
+      'level_number',
+      'life',
+      'luck',
+      'luck_tokens',
+      'movement',
+      'movement_tokens',
+      'overtone_cards',
+      'speed',
+      'speed_tokens',
+      'strength',
+      'strength_tokens',
+      'sub_monster_name',
+      'toughness',
+      'toughness_tokens',
+      'vignette_monster_id',
+      `vignette_monster_level_mood(id, mood_id, vignette_monster_level_id, mood(${CATALOG_AUTHORSHIP_SELECT}, mood_name))`,
+      `vignette_monster_level_trait(id, trait_id, vignette_monster_level_id, trait(${CATALOG_AUTHORSHIP_SELECT}, trait_name))`,
+      `vignette_monster_level_survivor_status(id, survivor_status_id, vignette_monster_level_id, survivor_status(${CATALOG_AUTHORSHIP_SELECT}, survivor_status_name))`
+    ].join(', '),
+    ')'
+  ].join(''),
+  [
+    'vignette_survivor(',
+    [
+      'accuracy',
+      'arm_armor',
+      'body_armor',
+      'courage',
+      'evasion',
+      'gender',
+      'head_armor',
+      'id',
+      'insanity',
+      'leg_armor',
+      'luck',
+      'movement',
+      'notes',
+      'speed',
+      'strength',
+      'survival',
+      'survivor_name',
+      'survivor_type',
+      'understanding',
+      'vignette_monster_id',
+      'waist_armor',
+      'weapon_proficiency',
+      'weapon_type_id',
+      `vignette_survivor_ability_impairment(id, ability_impairment_id, vignette_survivor_id, ability_impairment(${CATALOG_AUTHORSHIP_SELECT}, ability_impairment_name))`,
+      `vignette_survivor_disorder(id, disorder_id, vignette_survivor_id, disorder(${CATALOG_AUTHORSHIP_SELECT}, disorder_name))`,
+      `vignette_survivor_fighting_art(id, fighting_art_id, vignette_survivor_id, fighting_art(${CATALOG_AUTHORSHIP_SELECT}, fighting_art_name))`,
+      `vignette_survivor_secret_fighting_art(id, secret_fighting_art_id, vignette_survivor_id, secret_fighting_art(${CATALOG_AUTHORSHIP_SELECT}, secret_fighting_art_name))`,
+      `vignette_survivor_gear_grid(id, column_number, gear_id, row_number, vignette_survivor_id, gear(${GEAR_SELECT}))`
+    ].join(', '),
+    ')'
+  ].join('')
+].join(', ')
+
+/**
+ * Vignette Encounter Survivor Select Statement
+ *
+ * Includes the survivors that are part of this specific encounter.
+ */
+const VIGNETTE_ENCOUNTER_SURVIVOR_SELECT = [
+  'accuracy',
+  'accuracy_tokens',
+  'activation_used',
+  'arm_armor',
+  'arm_heavy_damage',
+  'arm_light_damage',
+  'bleeding_tokens',
+  'block_tokens',
+  'body_armor',
+  'body_heavy_damage',
+  'body_light_damage',
+  'brain_light_damage',
+  'courage',
+  'dead',
+  'deflect_tokens',
+  'evasion',
+  'evasion_tokens',
+  'gender',
+  'head_armor',
+  'head_heavy_damage',
+  'id',
+  'insanity',
+  'insanity_tokens',
+  'knocked_down',
+  'leg_armor',
+  'leg_heavy_damage',
+  'leg_light_damage',
+  'luck',
+  'luck_tokens',
+  'movement',
+  'movement_tokens',
+  'movement_used',
+  'notes',
+  'priority_target',
+  'retired',
+  'scout',
+  'source_vignette_survivor_id',
+  'speed',
+  'speed_tokens',
+  'strength',
+  'strength_tokens',
+  'survival',
+  'survival_tokens',
+  'survivor_name',
+  'survivor_type',
+  'understanding',
+  'vignette_encounter_id',
+  'vignette_monster_id',
+  'waist_armor',
+  'waist_heavy_damage',
+  'waist_light_damage',
+  'weapon_proficiency',
+  'weapon_type_id',
+  `vignette_encounter_survivor_ability_impairment(id, ability_impairment_id, source_vignette_survivor_ability_impairment_id, vignette_encounter_survivor_id, ability_impairment(${CATALOG_AUTHORSHIP_SELECT}, ability_impairment_name))`,
+  `vignette_encounter_survivor_disorder(id, disorder_id, source_vignette_survivor_disorder_id, vignette_encounter_survivor_id, disorder(${CATALOG_AUTHORSHIP_SELECT}, disorder_name))`,
+  `vignette_encounter_survivor_fighting_art(id, fighting_art_id, source_vignette_survivor_fighting_art_id, vignette_encounter_survivor_id, fighting_art(${CATALOG_AUTHORSHIP_SELECT}, fighting_art_name))`,
+  `vignette_encounter_survivor_secret_fighting_art(id, secret_fighting_art_id, source_vignette_survivor_secret_fighting_art_id, vignette_encounter_survivor_id, secret_fighting_art(${CATALOG_AUTHORSHIP_SELECT}, secret_fighting_art_name))`,
+  `vignette_encounter_survivor_gear_grid(id, column_number, gear_id, row_number, source_vignette_survivor_gear_grid_id, vignette_encounter_survivor_id, gear(${GEAR_SELECT}))`
+].join(', ')
+
+/**
+ * Vignette Encounter Summary Select Statement
+ *
+ * Includes the summary information for a specific vignette encounter.
+ */
+const VIGNETTE_ENCOUNTER_SUMMARY_SELECT =
+  'id, level_number, turn, user_id, vignette_monster_id, vignette_monster(monster_name)'
+
+/**
+ * Live State Keys
+ *
+ * The keys that are used to represent the live state of a vignette encounter.
+ */
+const LIVE_STATE_KEYS = [
+  'accuracy_tokens',
+  'activation_used',
+  'arm_heavy_damage',
+  'arm_light_damage',
+  'bleeding_tokens',
+  'block_tokens',
+  'body_heavy_damage',
+  'body_light_damage',
+  'brain_light_damage',
+  'dead',
+  'deflect_tokens',
+  'evasion_tokens',
+  'head_heavy_damage',
+  'insanity_tokens',
+  'knocked_down',
+  'leg_heavy_damage',
+  'leg_light_damage',
+  'luck_tokens',
+  'movement_tokens',
+  'movement_used',
+  'notes',
+  'priority_target',
+  'retired',
+  'scout',
+  'speed_tokens',
+  'strength_tokens',
+  'survival',
+  'survival_tokens',
+  'waist_heavy_damage',
+  'waist_light_damage'
+] as const
+
+/**
+ * Rows
+ *
+ * @param value Value to Convert
+ * @returns Array of DataRow Objects
+ */
+function rows(value: unknown): DataRow[] {
+  return Array.isArray(value) ? (value as DataRow[]) : []
+}
+
+/**
+ * First Row
+ *
+ * @param value Value to Extract First Row From
+ * @returns First DataRow Object (or null)
+ */
+function firstRow(value: unknown): DataRow | null {
+  if (Array.isArray(value)) return (value[0] as DataRow | undefined) ?? null
+  return value && typeof value === 'object' ? (value as DataRow) : null
+}
+
+/**
+ * Omit
+ *
+ * @param row DataRow to Omit Properties From
+ * @param keys Keys to Omit
+ * @returns Updated DataRow with Properties Omitted
+ */
+function omit(row: DataRow, keys: readonly string[]): DataRow {
+  const result = { ...row }
+  for (const key of keys) delete result[key]
+  return result
+}
+
+/**
+ * Resolve Vignette Authorship
+ *
+ * @param row DataRow to Resolve Authorship For
+ * @returns Resolved CatalogAuthorshipDetail
+ */
+function resolveVignetteAuthorship(
+  row: DataRow | null | undefined
+): CatalogAuthorshipDetail {
+  return resolveSettlementAuthorship(
+    {
+      custom: row?.custom === true,
+      user_id: typeof row?.user_id === 'string' ? row.user_id : null
+    },
+    EMPTY_MEMBER_PROFILES
+  )
+}
+
+/**
+ * Catalog Detail
+ *
+ * @param row DataRow to Create a Catalog Detail For
+ * @returns Catalog Detail (or null)
+ */
+function catalogDetail<T>(
+  row: DataRow | null
+): (T & CatalogAuthorshipDetail) | null {
+  if (!row) return null
+
+  return {
+    ...omit(row, ['user_id']),
+    ...resolveVignetteAuthorship(row)
+  } as T & CatalogAuthorshipDetail
+}
+
+/**
+ * Relation Detail
+ *
+ * Maps a junction row with one embedded catalog relation into its public detail
+ * shape with catalog authorship data.
+ *
+ * @param row Junction Row
+ * @param relationKey Embedded Relation Key
+ * @returns Relation Detail or Null
+ */
+function relationDetail<T>(row: DataRow, relationKey: string): T | null {
+  const relation = catalogDetail(firstRow(row[relationKey]))
+  if (!relation) return null
+
+  return {
+    ...omit(row, [relationKey]),
+    [relationKey]: relation
+  } as T
+}
+
+/**
+ * Gear Detail
+ *
+ * Maps an embedded gear row into gear detail, normalizing nested cost and
+ * affinity arrays.
+ *
+ * @param row Gear Row
+ * @returns Gear Detail or Null
+ */
+function gearDetail(
+  row: DataRow | null
+): (GearDetail & CatalogAuthorshipDetail) | null {
+  if (!row) return null
+
+  return {
+    ...toGearDetail(row as Parameters<typeof toGearDetail>[0]),
+    ...resolveVignetteAuthorship(row)
+  } as GearDetail & CatalogAuthorshipDetail
+}
+
+/**
+ * Gear Grid Detail
+ *
+ * Maps a gear-grid row and its embedded gear into the expected detail shape.
+ *
+ * @param row Gear Grid Row
+ * @returns Gear Grid Detail or Null
+ */
+function gearGridDetail<T>(row: DataRow): T | null {
+  const gear = gearDetail(firstRow(row.gear))
+  if (!gear) return null
+
+  return {
+    ...omit(row, ['gear']),
+    gear
+  } as T
+}
+
+/**
+ * Map Present
+ *
+ * Maps rows through a nullable mapper and removes null results.
+ *
+ * @param values Rows to Map
+ * @param mapper Nullable Mapper
+ * @returns Present Mapped Values
+ */
+function mapPresent<T>(
+  values: DataRow[],
+  mapper: (row: DataRow) => T | null
+): T[] {
+  return values.map(mapper).filter((value): value is T => value !== null)
+}
+
+/**
+ * Vignette Monster Level
+ *
+ * Maps a catalog monster level with mood, trait, and survivor-status setup
+ * rows.
+ *
+ * @param row Vignette Monster Level Row
+ * @returns Vignette Monster Level Detail
+ */
+function vignetteMonsterLevel(
+  row: DataRow
+): VignetteMonsterDetail['levels'][number] {
+  return {
+    ...omit(row, [
+      'vignette_monster_level_mood',
+      'vignette_monster_level_trait',
+      'vignette_monster_level_survivor_status'
+    ]),
+    moods: mapPresent(rows(row.vignette_monster_level_mood), (moodRow) =>
+      relationDetail(moodRow, 'mood')
+    ),
+    traits: mapPresent(rows(row.vignette_monster_level_trait), (traitRow) =>
+      relationDetail(traitRow, 'trait')
+    ),
+    survivor_statuses: mapPresent(
+      rows(row.vignette_monster_level_survivor_status),
+      (statusRow) => relationDetail(statusRow, 'survivor_status')
+    )
+  } as VignetteMonsterDetail['levels'][number]
+}
+
+/**
+ * Vignette Survivor
+ *
+ * Maps a catalog survivor preset with abilities, disorders, fighting arts, and
+ * gear-grid rows.
+ *
+ * @param row Vignette Survivor Row
+ * @returns Vignette Survivor Detail
+ */
+function vignetteSurvivor(
+  row: DataRow
+): VignetteMonsterDetail['survivors'][number] {
+  return {
+    ...omit(row, [
+      'vignette_survivor_ability_impairment',
+      'vignette_survivor_disorder',
+      'vignette_survivor_fighting_art',
+      'vignette_survivor_secret_fighting_art',
+      'vignette_survivor_gear_grid'
+    ]),
+    abilities_impairments: mapPresent(
+      rows(row.vignette_survivor_ability_impairment),
+      (abilityRow) => relationDetail(abilityRow, 'ability_impairment')
+    ),
+    disorders: mapPresent(rows(row.vignette_survivor_disorder), (disorderRow) =>
+      relationDetail(disorderRow, 'disorder')
+    ),
+    fighting_arts: mapPresent(
+      rows(row.vignette_survivor_fighting_art),
+      (fightingArtRow) => relationDetail(fightingArtRow, 'fighting_art')
+    ),
+    secret_fighting_arts: mapPresent(
+      rows(row.vignette_survivor_secret_fighting_art),
+      (secretFightingArtRow) =>
+        relationDetail(secretFightingArtRow, 'secret_fighting_art')
+    ),
+    gear_grid: mapPresent(rows(row.vignette_survivor_gear_grid), gearGridDetail)
+  } as VignetteMonsterDetail['survivors'][number]
+}
+
+/**
+ * Vignette Monster
+ *
+ * Maps a catalog vignette monster with level and survivor preset collections.
+ *
+ * @param row Vignette Monster Row
+ * @returns Vignette Monster Detail
+ */
+function vignetteMonster(row: DataRow): VignetteMonsterDetail {
+  return {
+    ...omit(row, ['vignette_monster_level', 'vignette_survivor']),
+    levels: rows(row.vignette_monster_level).map(vignetteMonsterLevel),
+    survivors: rows(row.vignette_survivor).map(vignetteSurvivor)
+  } as VignetteMonsterDetail
+}
+
+/**
+ * Active Monster
+ *
+ * Maps an active vignette monster row with its mutable mood, trait, and
+ * survivor-status rows.
+ *
+ * @param row Active Monster Row
+ * @param aiDecks AI Deck Map
+ * @returns Vignette Encounter Monster Detail
+ */
+function activeMonster(
+  row: DataRow,
+  aiDecks: { [key: string]: VignetteEncounterAIDeckDetail }
+): VignetteEncounterMonsterDetail {
+  return {
+    ...omit(row, [
+      'vignette_encounter_monster_mood',
+      'vignette_encounter_monster_trait',
+      'vignette_encounter_monster_survivor_status'
+    ]),
+    ai_deck: aiDecks[row.ai_deck_id as string],
+    moods: mapPresent(rows(row.vignette_encounter_monster_mood), (moodRow) =>
+      relationDetail(moodRow, 'mood')
+    ),
+    traits: mapPresent(rows(row.vignette_encounter_monster_trait), (traitRow) =>
+      relationDetail(traitRow, 'trait')
+    ),
+    survivor_statuses: mapPresent(
+      rows(row.vignette_encounter_monster_survivor_status),
+      (statusRow) => relationDetail(statusRow, 'survivor_status')
+    )
+  } as VignetteEncounterMonsterDetail
+}
+
+/**
+ * Live State
+ *
+ * Extracts active survivor live-state fields from a survivor row.
+ *
+ * @param row Active Survivor Row
+ * @returns Vignette Encounter Survivor Live State
+ */
+function liveState(row: DataRow): VignetteEncounterSurvivorLiveState {
+  return Object.fromEntries(
+    LIVE_STATE_KEYS.map((key) => [key, row[key]])
+  ) as VignetteEncounterSurvivorLiveState
+}
+
+/**
+ * Active Survivor
+ *
+ * Maps an active vignette survivor row into static survivor data, live state,
+ * child catalog rows, and gear-grid rows.
+ *
+ * @param row Active Survivor Row
+ * @returns Vignette Encounter Survivor Detail
+ */
+function activeSurvivor(row: DataRow): VignetteEncounterSurvivorDetail {
+  return {
+    ...omit(row, [
+      ...LIVE_STATE_KEYS,
+      'vignette_encounter_survivor_ability_impairment',
+      'vignette_encounter_survivor_disorder',
+      'vignette_encounter_survivor_fighting_art',
+      'vignette_encounter_survivor_secret_fighting_art',
+      'vignette_encounter_survivor_gear_grid'
+    ]),
+    live_state: liveState(row),
+    abilities_impairments: mapPresent(
+      rows(row.vignette_encounter_survivor_ability_impairment),
+      (abilityRow) => relationDetail(abilityRow, 'ability_impairment')
+    ),
+    disorders: mapPresent(
+      rows(row.vignette_encounter_survivor_disorder),
+      (disorderRow) => relationDetail(disorderRow, 'disorder')
+    ),
+    fighting_arts: mapPresent(
+      rows(row.vignette_encounter_survivor_fighting_art),
+      (fightingArtRow) => relationDetail(fightingArtRow, 'fighting_art')
+    ),
+    secret_fighting_arts: mapPresent(
+      rows(row.vignette_encounter_survivor_secret_fighting_art),
+      (secretFightingArtRow) =>
+        relationDetail(secretFightingArtRow, 'secret_fighting_art')
+    ),
+    gear_grid: mapPresent(
+      rows(row.vignette_encounter_survivor_gear_grid),
+      gearGridDetail
+    )
+  } as VignetteEncounterSurvivorDetail
+}
+
+/**
+ * Shared User
+ *
+ * Maps a vignette shared-user row with optional embedded user settings.
+ *
+ * @param row Shared User Row
+ * @returns Vignette Encounter Shared User Detail
+ */
+function sharedUser(row: DataRow): VignetteEncounterSharedUserDetail {
+  const profile = firstRow(row.user_settings)
+
+  return {
+    ...omit(row, ['user_settings']),
+    username: typeof profile?.username === 'string' ? profile.username : '',
+    avatar_url:
+      typeof profile?.avatar_url === 'string' ? profile.avatar_url : null
+  } as VignetteEncounterSharedUserDetail
+}
+
+/**
+ * Summary
+ *
+ * Maps an active vignette encounter row into summary data for switcher UI.
+ *
+ * @param row Vignette Encounter Row
+ * @param role Caller Role
+ * @returns Vignette Encounter Summary
+ */
+function summary(
+  row: DataRow,
+  role: VignetteEncounterSummary['role']
+): VignetteEncounterSummary {
+  const monster = firstRow(row.vignette_monster)
+
+  return {
+    id: row.id as string,
+    vignette_monster_id: row.vignette_monster_id as string,
+    monster_name:
+      typeof monster?.monster_name === 'string' ? monster.monster_name : '',
+    level_number: row.level_number as number,
+    turn: row.turn as VignetteEncounterSummary['turn'],
+    owner_user_id: row.user_id as string,
+    owner_username: null,
+    owner_avatar_url: null,
+    role
+  }
+}
+
+/**
+ * Fetch Vignette Monster Rows
+ *
+ * Fetches raw vignette monster catalog rows, optionally filtered by ID.
+ *
+ * @param vignetteMonsterId Optional Vignette Monster ID
+ * @returns Raw Vignette Monster Rows
+ */
+async function fetchVignetteMonsterRows(
+  vignetteMonsterId?: string
+): Promise<DataRow[]> {
+  const supabase = createClient()
+  const query = supabase
+    .from('vignette_monster')
+    .select(VIGNETTE_MONSTER_SELECT)
+
+  const { data, error } = vignetteMonsterId
+    ? await query.eq('id', vignetteMonsterId)
+    : await query
+
+  if (error)
+    throw new Error(`Error Fetching Vignette Monsters: ${error.message}`)
+
+  return (data ?? []) as unknown as DataRow[]
+}
+
+/**
+ * Get Vignette Encounter AI Decks
+ *
+ * Retrieves active AI decks for a vignette encounter.
+ *
+ * @param vignetteEncounterId Vignette Encounter ID
+ * @returns Vignette Encounter AI Deck Map or Null
+ */
+export async function getVignetteEncounterAIDecks(
+  vignetteEncounterId: string | null | undefined
+): Promise<{ [key: string]: VignetteEncounterAIDeckDetail } | null> {
+  if (!vignetteEncounterId) return null
+
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_ai_deck')
+    .select(
+      'advanced_cards, basic_cards, id, legendary_cards, overtone_cards, vignette_encounter_id'
+    )
+    .eq('vignette_encounter_id', vignetteEncounterId)
+
+  if (error)
+    throw new Error(
+      `Error Fetching Vignette Encounter AI Decks: ${error.message}`
+    )
+
+  const aiDecks: { [key: string]: VignetteEncounterAIDeckDetail } = {}
+  for (const aiDeck of data ?? []) aiDecks[aiDeck.id] = aiDeck
+
+  return aiDecks
+}
+
+/**
+ * Get Vignette Encounter Monsters
+ *
+ * Retrieves active monster rows for a vignette encounter.
+ *
+ * @param vignetteEncounterId Vignette Encounter ID
+ * @param prefetchedAIDecks Optional Prefetched AI Deck Map
+ * @returns Vignette Encounter Monster Map or Null
+ */
+export async function getVignetteEncounterMonsters(
+  vignetteEncounterId: string | null | undefined,
+  prefetchedAIDecks?: { [key: string]: VignetteEncounterAIDeckDetail }
+): Promise<{ [key: string]: VignetteEncounterMonsterDetail } | null> {
+  if (!vignetteEncounterId) return null
+
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_monster')
+    .select(
+      [
+        'accuracy',
+        'accuracy_tokens',
+        'ai_card_drawn',
+        'ai_deck_id',
+        'ai_deck_remaining',
+        'damage',
+        'damage_tokens',
+        'evasion',
+        'evasion_tokens',
+        'id',
+        'knocked_down',
+        'luck',
+        'luck_tokens',
+        'monster_name',
+        'movement',
+        'movement_tokens',
+        'notes',
+        'source_vignette_monster_level_id',
+        'speed',
+        'speed_tokens',
+        'strength',
+        'strength_tokens',
+        'toughness',
+        'toughness_tokens',
+        'vignette_encounter_id',
+        'wounds',
+        `vignette_encounter_monster_mood(id, mood_id, source_vignette_monster_level_mood_id, vignette_encounter_monster_id, mood(${CATALOG_AUTHORSHIP_SELECT}, mood_name))`,
+        `vignette_encounter_monster_trait(id, trait_id, source_vignette_monster_level_trait_id, vignette_encounter_monster_id, trait(${CATALOG_AUTHORSHIP_SELECT}, trait_name))`,
+        `vignette_encounter_monster_survivor_status(id, survivor_status_id, source_vignette_monster_level_survivor_status_id, vignette_encounter_monster_id, survivor_status(${CATALOG_AUTHORSHIP_SELECT}, survivor_status_name))`
+      ].join(', ')
+    )
+    .eq('vignette_encounter_id', vignetteEncounterId)
+
+  if (error)
+    throw new Error(
+      `Error Fetching Vignette Encounter Monsters: ${error.message}`
+    )
+
+  const aiDecks =
+    prefetchedAIDecks ??
+    (await getVignetteEncounterAIDecks(vignetteEncounterId)) ??
+    {}
+  const monsters: { [key: string]: VignetteEncounterMonsterDetail } = {}
+  for (const monster of (data ?? []) as unknown as DataRow[])
+    monsters[monster.id as string] = activeMonster(monster, aiDecks)
+
+  return monsters
+}
+
+/**
+ * Get Vignette Encounter Survivors
+ *
+ * Retrieves active survivor rows for a vignette encounter.
+ *
+ * @param vignetteEncounterId Vignette Encounter ID
+ * @returns Vignette Encounter Survivor Map or Null
+ */
+export async function getVignetteEncounterSurvivors(
+  vignetteEncounterId: string | null | undefined
+): Promise<{ [key: string]: VignetteEncounterSurvivorDetail } | null> {
+  if (!vignetteEncounterId) return null
+
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_survivor')
+    .select(VIGNETTE_ENCOUNTER_SURVIVOR_SELECT)
+    .eq('vignette_encounter_id', vignetteEncounterId)
+
+  if (error)
+    throw new Error(
+      `Error Fetching Vignette Encounter Survivors: ${error.message}`
+    )
+
+  const survivors: { [key: string]: VignetteEncounterSurvivorDetail } = {}
+  for (const survivor of (data ?? []) as unknown as DataRow[])
+    survivors[survivor.id as string] = activeSurvivor(survivor)
+
+  return survivors
+}
+
+/**
+ * Get Vignette Encounter Shared Users
+ *
+ * Retrieves share rows for a vignette encounter.
+ *
+ * @param vignetteEncounterId Vignette Encounter ID
+ * @returns Shared User Details or Null
+ */
+export async function getVignetteEncounterSharedUsers(
+  vignetteEncounterId: string | null | undefined
+): Promise<VignetteEncounterSharedUserDetail[] | null> {
+  if (!vignetteEncounterId) return null
+
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_shared_user')
+    .select(
+      'id, shared_user_id, vignette_encounter_id, user_settings(username, avatar_url)'
+    )
+    .eq('vignette_encounter_id', vignetteEncounterId)
+
+  if (error)
+    throw new Error(
+      `Error Fetching Vignette Encounter Shared Users: ${error.message}`
+    )
+
+  return ((data ?? []) as unknown as DataRow[]).map(sharedUser)
+}
+
+/**
+ * Get Vignette Monsters
+ *
+ * Retrieves vignette catalog monsters with levels, survivor presets, and nested
+ * catalog rows needed for setup UI.
+ *
+ * @returns Vignette Monsters Map
+ */
+export async function getVignetteMonsters(): Promise<{
+  [key: string]: VignetteMonsterDetail
+}> {
+  await getUserId()
+
+  const rawRows = await fetchVignetteMonsterRows()
+  const monsters: { [key: string]: VignetteMonsterDetail } = {}
+  for (const row of rawRows) monsters[row.id as string] = vignetteMonster(row)
+
+  return monsters
+}
+
+/**
+ * Get Vignette Monster
+ *
+ * Retrieves a single vignette catalog monster by ID.
+ *
+ * @param vignetteMonsterId Vignette Monster ID
+ * @returns Vignette Monster Detail or Null
+ */
+export async function getVignetteMonster(
+  vignetteMonsterId: string | null | undefined
+): Promise<VignetteMonsterDetail | null> {
+  if (!vignetteMonsterId) return null
+
+  await getUserId()
+
+  const [row] = await fetchVignetteMonsterRows(vignetteMonsterId)
+  return row ? vignetteMonster(row) : null
+}
+
+/**
+ * Get Active Vignette Encounter For User
+ *
+ * Retrieves the current user's owned active vignette summary. Shared vignettes
+ * are intentionally excluded and do not count as owned active vignettes.
+ *
+ * @returns Owned Active Vignette Summary or Null
+ */
+export async function getActiveVignetteEncounterForUser(): Promise<VignetteEncounterSummary | null> {
+  const userId = await getUserId()
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter')
+    .select(VIGNETTE_ENCOUNTER_SUMMARY_SELECT)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error)
+    throw new Error(
+      `Error Fetching Active Vignette Encounter: ${error.message}`
+    )
+  if (!data) return null
+
+  return summary(data as unknown as DataRow, 'owner')
+}
+
+/**
+ * Get Shared Vignette Encounters For User
+ *
+ * Retrieves active vignette summaries shared with the current user.
+ *
+ * @returns Shared Vignette Summaries
+ */
+export async function getSharedVignetteEncountersForUser(): Promise<
+  VignetteEncounterSummary[]
+> {
+  const userId = await getUserId()
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_shared_user')
+    .select(`vignette_encounter(${VIGNETTE_ENCOUNTER_SUMMARY_SELECT})`)
+    .eq('shared_user_id', userId)
+
+  if (error)
+    throw new Error(
+      `Error Fetching Shared Vignette Encounters: ${error.message}`
+    )
+
+  return ((data ?? []) as unknown as DataRow[])
+    .map((row) => firstRow(row.vignette_encounter))
+    .filter((row): row is DataRow => row !== null)
+    .map((row) => summary(row, 'collaborator'))
+}
+
+/**
+ * Get Accessible Vignette Encounters For User
+ *
+ * Retrieves owned and shared active vignette summaries for switcher UI.
+ *
+ * @returns Accessible Vignette Summaries
+ */
+export async function getAccessibleVignetteEncountersForUser(): Promise<
+  VignetteEncounterSummary[]
+> {
+  const [ownedEncounter, sharedEncounters] = await Promise.all([
+    getActiveVignetteEncounterForUser(),
+    getSharedVignetteEncountersForUser()
+  ])
+
+  return [...(ownedEncounter ? [ownedEncounter] : []), ...sharedEncounters]
+}
+
+/**
+ * Get Vignette Encounter
+ *
+ * Retrieves full active vignette detail state for tracker UI.
+ *
+ * @param vignetteEncounterId Vignette Encounter ID
+ * @returns Vignette Encounter Detail or Null
+ */
+export async function getVignetteEncounter(
+  vignetteEncounterId: string | null | undefined
+): Promise<VignetteEncounterDetail | null> {
+  if (!vignetteEncounterId) return null
+
+  const userId = await getUserId()
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter')
+    .select('id, level_number, notes, turn, user_id, vignette_monster_id')
+    .eq('id', vignetteEncounterId)
+    .maybeSingle()
+
+  if (error)
+    throw new Error(`Error Fetching Vignette Encounter: ${error.message}`)
+  if (!data) return null
+
+  const encounter = data as unknown as DataRow
+  const [catalogMonsterRows, aiDecks, sharedUsers] = await Promise.all([
+    fetchVignetteMonsterRows(encounter.vignette_monster_id as string),
+    getVignetteEncounterAIDecks(encounter.id as string),
+    getVignetteEncounterSharedUsers(encounter.id as string)
+  ])
+  const catalogMonster = catalogMonsterRows[0]
+    ? vignetteMonster(catalogMonsterRows[0])
+    : null
+
+  if (!catalogMonster) throw new Error('Vignette Monster Not Found')
+
+  const [monsters, survivors] = await Promise.all([
+    getVignetteEncounterMonsters(encounter.id as string, aiDecks ?? {}),
+    getVignetteEncounterSurvivors(encounter.id as string)
+  ])
+
+  return {
+    ...encounter,
+    role: encounter.user_id === userId ? 'owner' : 'collaborator',
+    vignette_monster: catalogMonster,
+    ai_decks: aiDecks ?? {},
+    monsters: monsters ?? {},
+    survivors: survivors ?? {},
+    shared_users: sharedUsers ?? []
+  } as VignetteEncounterDetail
+}

--- a/lib/dal/vignette-encounter.ts
+++ b/lib/dal/vignette-encounter.ts
@@ -491,13 +491,28 @@ function activeMonster(
   row: DataRow,
   aiDecks: { [key: string]: VignetteEncounterAIDeckDetail }
 ): VignetteEncounterMonsterDetail {
+  const monsterId = typeof row.id === 'string' && row.id ? row.id : 'unknown'
+  const aiDeckId = row.ai_deck_id
+
+  if (typeof aiDeckId !== 'string' || !aiDeckId)
+    throw new Error(
+      `Error Fetching Vignette Encounter Monsters: Monster ${monsterId} is missing ai_deck_id`
+    )
+
+  const aiDeck = aiDecks[aiDeckId]
+
+  if (!aiDeck)
+    throw new Error(
+      `Error Fetching Vignette Encounter Monsters: AI deck ${aiDeckId} not found for monster ${monsterId}`
+    )
+
   return {
     ...omit(row, [
       'vignette_encounter_monster_mood',
       'vignette_encounter_monster_trait',
       'vignette_encounter_monster_survivor_status'
     ]),
-    ai_deck: aiDecks[row.ai_deck_id as string],
+    ai_deck: aiDeck,
     moods: mapPresent(rows(row.vignette_encounter_monster_mood), (moodRow) =>
       relationDetail(moodRow, 'mood')
     ),
@@ -948,8 +963,9 @@ export async function getVignetteEncounter(
   if (!data) return null
 
   const encounter = data as unknown as DataRow
+  const vignetteMonsterId = encounter.vignette_monster_id as string
   const [catalogMonsterRows, aiDecks, sharedUsers] = await Promise.all([
-    fetchVignetteMonsterRows(encounter.vignette_monster_id as string),
+    fetchVignetteMonsterRows(vignetteMonsterId),
     getVignetteEncounterAIDecks(encounter.id as string),
     getVignetteEncounterSharedUsers(encounter.id as string)
   ])
@@ -957,7 +973,10 @@ export async function getVignetteEncounter(
     ? vignetteMonster(catalogMonsterRows[0])
     : null
 
-  if (!catalogMonster) throw new Error('Vignette Monster Not Found')
+  if (!catalogMonster)
+    throw new Error(
+      `Error Fetching Vignette Encounter: Vignette Monster Not Found for vignette_monster_id ${vignetteMonsterId}`
+    )
 
   const [monsters, survivors] = await Promise.all([
     getVignetteEncounterMonsters(encounter.id as string, aiDecks ?? {}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.92.0",
+      "version": "0.93.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary
- Adds vignette DAL read helpers for catalog monsters, owned/shared active summaries, accessible summaries, and full active encounter detail state.
- Includes active child readers for AI decks, monsters, survivors, and shared users, with role data for owner/collaborator UI decisions.
- Reuses the shared gear normalizer and bumps the app version to 0.93.0.

## Dependencies
- No dependency changes.

## Related Issues
Closes #338

## Testing
- `npx vitest run __tests__/lib/dal/vignette-encounter.test.ts __tests__/lib/dal/gear.test.ts --coverage.enabled=false`
- `npx prettier --check lib/dal/vignette-encounter.ts __tests__/lib/dal/vignette-encounter.test.ts lib/dal/gear.ts package.json package-lock.json`

## Additional Context
- The read helpers follow the existing hunt/showdown DAL pattern: null-safe IDs, prefixed query errors, keyed maps for active detail collections, and focused mapper helpers for nested PostgREST rows.