### PR TITLE
[VIG-02.04] Add vignette DAL mutation helpers

### DIFF
--- a/__tests__/lib/dal/vignette-encounter.test.ts
+++ b/__tests__/lib/dal/vignette-encounter.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockSupabase = {
-  from: vi.fn()
+  from: vi.fn(),
+  rpc: vi.fn()
 }
 
 vi.mock('@/lib/supabase/client', () => ({
@@ -9,10 +10,20 @@ vi.mock('@/lib/supabase/client', () => ({
 }))
 
 vi.mock('@/lib/dal/user', () => ({
-  getUserId: vi.fn()
+  getUserId: vi.fn(),
+  lookupUserByUsername: vi.fn()
 }))
 
 const {
+  addVignetteEncounterMonsterMood,
+  addVignetteEncounterMonsterSurvivorStatus,
+  addVignetteEncounterMonsterTrait,
+  addVignetteEncounterSharedUser,
+  addVignetteEncounterSurvivorAbilityImpairment,
+  addVignetteEncounterSurvivorDisorder,
+  addVignetteEncounterSurvivorFightingArt,
+  addVignetteEncounterSurvivorSecretFightingArt,
+  createVignetteEncounter,
   getAccessibleVignetteEncountersForUser,
   getActiveVignetteEncounterForUser,
   getSharedVignetteEncountersForUser,
@@ -22,9 +33,24 @@ const {
   getVignetteEncounterSharedUsers,
   getVignetteEncounterSurvivors,
   getVignetteMonster,
-  getVignetteMonsters
+  getVignetteMonsters,
+  removeVignetteEncounter,
+  removeVignetteEncounterMonsterMood,
+  removeVignetteEncounterMonsterSurvivorStatus,
+  removeVignetteEncounterMonsterTrait,
+  removeVignetteEncounterSharedUser,
+  removeVignetteEncounterSharedUserByUsername,
+  removeVignetteEncounterSurvivorAbilityImpairment,
+  removeVignetteEncounterSurvivorDisorder,
+  removeVignetteEncounterSurvivorFightingArt,
+  removeVignetteEncounterSurvivorSecretFightingArt,
+  updateVignetteEncounter,
+  updateVignetteEncounterAIDeck,
+  updateVignetteEncounterMonster,
+  updateVignetteEncounterSurvivorGearGrid,
+  updateVignetteEncounterSurvivorLiveState
 } = await import('@/lib/dal/vignette-encounter')
-const { getUserId } = await import('@/lib/dal/user')
+const { getUserId, lookupUserByUsername } = await import('@/lib/dal/user')
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -54,6 +80,45 @@ function mockFromSequence(...queries: ReturnType<typeof makeQuery>[]) {
     if (!query) throw new Error('Unexpected query')
     return query
   })
+}
+
+function makeMutationQuery(error: unknown = null) {
+  const resolved = { error }
+  const query = {
+    eq: vi.fn().mockReturnThis(),
+    then: (resolve: (value: typeof resolved) => unknown) =>
+      Promise.resolve(resolve(resolved))
+  }
+
+  return query
+}
+
+function mockUpdate(error: unknown = null) {
+  const query = makeMutationQuery(error)
+  const update = vi.fn().mockReturnValue(query)
+  mockSupabase.from.mockReturnValue({ update })
+
+  return { query, update }
+}
+
+function mockDelete(error: unknown = null) {
+  const query = makeMutationQuery(error)
+  const remove = vi.fn().mockReturnValue(query)
+  mockSupabase.from.mockReturnValue({ delete: remove })
+
+  return { query, remove }
+}
+
+function mockInsertWithId(id: string, error: unknown = null) {
+  const single = vi.fn().mockResolvedValue({
+    data: error ? null : { id },
+    error
+  })
+  const select = vi.fn().mockReturnValue({ single })
+  const insert = vi.fn().mockReturnValue({ select })
+  mockSupabase.from.mockReturnValue({ insert })
+
+  return { insert, select, single }
 }
 
 const rawCatalogMonster = {
@@ -593,5 +658,350 @@ describe('active vignette child readers', () => {
     await expect(getVignetteEncounterMonsters('encounter-1')).rejects.toThrow(
       'Error Fetching Vignette Encounter Monsters: AI deck missing-deck not found for monster active-monster-1'
     )
+  })
+})
+
+describe('vignette encounter mutation helpers', () => {
+  it('creates an active vignette encounter from catalog data', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: 'encounter-1', error: null })
+
+    const result = await createVignetteEncounter({
+      vignette_monster_id: 'vm-1',
+      level_number: 2
+    })
+
+    expect(result).toBe('encounter-1')
+    expect(mockSupabase.rpc).toHaveBeenCalledWith(
+      'create_vignette_encounter_from_catalog',
+      {
+        target_level_number: 2,
+        target_vignette_monster_id: 'vm-1'
+      }
+    )
+  })
+
+  it('throws when active vignette creation fails', async () => {
+    mockSupabase.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'active limit reached' }
+    })
+
+    await expect(
+      createVignetteEncounter({
+        vignette_monster_id: 'vm-1',
+        level_number: 1
+      })
+    ).rejects.toThrow('Error Creating Vignette Encounter: active limit reached')
+  })
+
+  it('updates encounter-level state', async () => {
+    const { query, update } = mockUpdate()
+
+    await updateVignetteEncounter({
+      vignette_encounter_id: 'encounter-1',
+      notes: 'The lantern guttered.',
+      turn: 'SURVIVOR'
+    })
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('vignette_encounter')
+    expect(update).toHaveBeenCalledWith({
+      notes: 'The lantern guttered.',
+      turn: 'SURVIVOR'
+    })
+    expect(query.eq).toHaveBeenCalledWith('id', 'encounter-1')
+  })
+
+  it('removes an active vignette encounter by id', async () => {
+    const { query } = mockDelete()
+
+    await removeVignetteEncounter({ vignette_encounter_id: 'encounter-1' })
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('vignette_encounter')
+    expect(query.eq).toHaveBeenCalledWith('id', 'encounter-1')
+  })
+
+  it('updates active AI deck, monster, survivor, and gear-grid state', async () => {
+    let mutation = mockUpdate()
+    await updateVignetteEncounterAIDeck({
+      vignette_encounter_ai_deck_id: 'deck-1',
+      basic_cards: 2
+    })
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_ai_deck'
+    )
+    expect(mutation.update).toHaveBeenCalledWith({ basic_cards: 2 })
+    expect(mutation.query.eq).toHaveBeenCalledWith('id', 'deck-1')
+
+    mutation = mockUpdate()
+    await updateVignetteEncounterMonster({
+      vignette_encounter_monster_id: 'monster-1',
+      wounds: 3
+    })
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_monster'
+    )
+    expect(mutation.update).toHaveBeenCalledWith({ wounds: 3 })
+    expect(mutation.query.eq).toHaveBeenCalledWith('id', 'monster-1')
+
+    mutation = mockUpdate()
+    await updateVignetteEncounterSurvivorLiveState({
+      vignette_encounter_survivor_id: 'survivor-1',
+      knocked_down: true,
+      survival_tokens: -1
+    })
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_survivor'
+    )
+    expect(mutation.update).toHaveBeenCalledWith({
+      knocked_down: true,
+      survival_tokens: -1
+    })
+    expect(mutation.query.eq).toHaveBeenCalledWith('id', 'survivor-1')
+
+    mutation = mockUpdate()
+    await updateVignetteEncounterSurvivorGearGrid({
+      vignette_encounter_survivor_gear_grid_id: 'gear-grid-1',
+      column_number: 2,
+      row_number: 1
+    })
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_survivor_gear_grid'
+    )
+    expect(mutation.update).toHaveBeenCalledWith({
+      column_number: 2,
+      row_number: 1
+    })
+    expect(mutation.query.eq).toHaveBeenCalledWith('id', 'gear-grid-1')
+  })
+
+  it('adds and removes active monster state rows', async () => {
+    let insertion = mockInsertWithId('mood-row-1')
+    await expect(
+      addVignetteEncounterMonsterMood({
+        mood_id: 'mood-1',
+        source_vignette_monster_level_mood_id: null,
+        vignette_encounter_monster_id: 'monster-1'
+      })
+    ).resolves.toBe('mood-row-1')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_monster_mood'
+    )
+    expect(insertion.insert).toHaveBeenCalledWith({
+      mood_id: 'mood-1',
+      source_vignette_monster_level_mood_id: null,
+      vignette_encounter_monster_id: 'monster-1'
+    })
+
+    insertion = mockInsertWithId('trait-row-1')
+    await expect(
+      addVignetteEncounterMonsterTrait({
+        source_vignette_monster_level_trait_id: null,
+        trait_id: 'trait-1',
+        vignette_encounter_monster_id: 'monster-1'
+      })
+    ).resolves.toBe('trait-row-1')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_monster_trait'
+    )
+    expect(insertion.insert).toHaveBeenCalledWith({
+      source_vignette_monster_level_trait_id: null,
+      trait_id: 'trait-1',
+      vignette_encounter_monster_id: 'monster-1'
+    })
+
+    insertion = mockInsertWithId('status-row-1')
+    await expect(
+      addVignetteEncounterMonsterSurvivorStatus({
+        source_vignette_monster_level_survivor_status_id: null,
+        survivor_status_id: 'status-1',
+        vignette_encounter_monster_id: 'monster-1'
+      })
+    ).resolves.toBe('status-row-1')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_monster_survivor_status'
+    )
+    expect(insertion.insert).toHaveBeenCalledWith({
+      source_vignette_monster_level_survivor_status_id: null,
+      survivor_status_id: 'status-1',
+      vignette_encounter_monster_id: 'monster-1'
+    })
+
+    let deletion = mockDelete()
+    await removeVignetteEncounterMonsterMood({ id: 'mood-row-1' })
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_monster_mood'
+    )
+    expect(deletion.query.eq).toHaveBeenCalledWith('id', 'mood-row-1')
+
+    deletion = mockDelete()
+    await removeVignetteEncounterMonsterTrait({ id: 'trait-row-1' })
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_monster_trait'
+    )
+    expect(deletion.query.eq).toHaveBeenCalledWith('id', 'trait-row-1')
+
+    deletion = mockDelete()
+    await removeVignetteEncounterMonsterSurvivorStatus({ id: 'status-row-1' })
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_monster_survivor_status'
+    )
+    expect(deletion.query.eq).toHaveBeenCalledWith('id', 'status-row-1')
+  })
+
+  it('adds and removes active survivor child rows', async () => {
+    let insertion = mockInsertWithId('ability-row-1')
+    await expect(
+      addVignetteEncounterSurvivorAbilityImpairment({
+        ability_impairment_id: 'ability-1',
+        source_vignette_survivor_ability_impairment_id: null,
+        vignette_encounter_survivor_id: 'survivor-1'
+      })
+    ).resolves.toBe('ability-row-1')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_survivor_ability_impairment'
+    )
+
+    insertion = mockInsertWithId('disorder-row-1')
+    await expect(
+      addVignetteEncounterSurvivorDisorder({
+        disorder_id: 'disorder-1',
+        source_vignette_survivor_disorder_id: null,
+        vignette_encounter_survivor_id: 'survivor-1'
+      })
+    ).resolves.toBe('disorder-row-1')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_survivor_disorder'
+    )
+
+    insertion = mockInsertWithId('fighting-art-row-1')
+    await expect(
+      addVignetteEncounterSurvivorFightingArt({
+        fighting_art_id: 'fighting-art-1',
+        source_vignette_survivor_fighting_art_id: null,
+        vignette_encounter_survivor_id: 'survivor-1'
+      })
+    ).resolves.toBe('fighting-art-row-1')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_survivor_fighting_art'
+    )
+
+    insertion = mockInsertWithId('secret-fighting-art-row-1')
+    await expect(
+      addVignetteEncounterSurvivorSecretFightingArt({
+        secret_fighting_art_id: 'secret-fighting-art-1',
+        source_vignette_survivor_secret_fighting_art_id: null,
+        vignette_encounter_survivor_id: 'survivor-1'
+      })
+    ).resolves.toBe('secret-fighting-art-row-1')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_survivor_secret_fighting_art'
+    )
+    expect(insertion.insert).toHaveBeenCalledWith({
+      secret_fighting_art_id: 'secret-fighting-art-1',
+      source_vignette_survivor_secret_fighting_art_id: null,
+      vignette_encounter_survivor_id: 'survivor-1'
+    })
+
+    let deletion = mockDelete()
+    await removeVignetteEncounterSurvivorAbilityImpairment('ability-row-1')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_survivor_ability_impairment'
+    )
+    expect(deletion.query.eq).toHaveBeenCalledWith('id', 'ability-row-1')
+
+    deletion = mockDelete()
+    await removeVignetteEncounterSurvivorDisorder('disorder-row-1')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_survivor_disorder'
+    )
+    expect(deletion.query.eq).toHaveBeenCalledWith('id', 'disorder-row-1')
+
+    deletion = mockDelete()
+    await removeVignetteEncounterSurvivorFightingArt('fighting-art-row-1')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_survivor_fighting_art'
+    )
+    expect(deletion.query.eq).toHaveBeenCalledWith('id', 'fighting-art-row-1')
+
+    deletion = mockDelete()
+    await removeVignetteEncounterSurvivorSecretFightingArt(
+      'secret-fighting-art-row-1'
+    )
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_survivor_secret_fighting_art'
+    )
+    expect(deletion.query.eq).toHaveBeenCalledWith(
+      'id',
+      'secret-fighting-art-row-1'
+    )
+  })
+
+  it('adds and removes shared users by exact username', async () => {
+    vi.mocked(lookupUserByUsername).mockResolvedValue('shared-user-1')
+
+    const insertion = mockInsertWithId('share-row-1')
+    await expect(
+      addVignetteEncounterSharedUser({
+        username: 'lantern.friend',
+        vignette_encounter_id: 'encounter-1'
+      })
+    ).resolves.toBe('share-row-1')
+
+    expect(lookupUserByUsername).toHaveBeenCalledWith('lantern.friend')
+    expect(mockSupabase.from).toHaveBeenLastCalledWith(
+      'vignette_encounter_shared_user'
+    )
+    expect(insertion.insert).toHaveBeenCalledWith({
+      shared_user_id: 'shared-user-1',
+      vignette_encounter_id: 'encounter-1'
+    })
+
+    const deletion = mockDelete()
+    await removeVignetteEncounterSharedUserByUsername({
+      username: 'lantern.friend',
+      vignette_encounter_id: 'encounter-1'
+    })
+
+    expect(deletion.query.eq).toHaveBeenCalledWith(
+      'vignette_encounter_id',
+      'encounter-1'
+    )
+    expect(deletion.query.eq).toHaveBeenCalledWith(
+      'shared_user_id',
+      'shared-user-1'
+    )
+  })
+
+  it('removes shared users by id', async () => {
+    const { query } = mockDelete()
+
+    await removeVignetteEncounterSharedUser({
+      shared_user_id: 'shared-user-1',
+      vignette_encounter_id: 'encounter-1'
+    })
+
+    expect(mockSupabase.from).toHaveBeenCalledWith(
+      'vignette_encounter_shared_user'
+    )
+    expect(query.eq).toHaveBeenCalledWith(
+      'vignette_encounter_id',
+      'encounter-1'
+    )
+    expect(query.eq).toHaveBeenCalledWith('shared_user_id', 'shared-user-1')
+  })
+
+  it('throws with the share prefix when username lookup fails', async () => {
+    vi.mocked(lookupUserByUsername).mockResolvedValue(null)
+
+    await expect(
+      addVignetteEncounterSharedUser({
+        username: 'missing.friend',
+        vignette_encounter_id: 'encounter-1'
+      })
+    ).rejects.toThrow(
+      'Error Adding Vignette Encounter Shared User: User Not Found'
+    )
+
+    expect(mockSupabase.from).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/lib/dal/vignette-encounter.test.ts
+++ b/__tests__/lib/dal/vignette-encounter.test.ts
@@ -999,7 +999,7 @@ describe('vignette encounter mutation helpers', () => {
         vignette_encounter_id: 'encounter-1'
       })
     ).rejects.toThrow(
-      'Error Adding Vignette Encounter Shared User: User Not Found'
+      'Error Adding Vignette Encounter Shared User: User not found or lookup throttled'
     )
 
     expect(mockSupabase.from).not.toHaveBeenCalled()

--- a/lib/dal/vignette-encounter.ts
+++ b/lib/dal/vignette-encounter.ts
@@ -3,7 +3,8 @@ import {
   resolveSettlementAuthorship,
   type SettlementMemberProfile
 } from '@/lib/dal/settlement-shared-user'
-import { getUserId } from '@/lib/dal/user'
+import { getUserId, lookupUserByUsername } from '@/lib/dal/user'
+import type { TablesInsert } from '@/lib/database.types'
 import { createClient } from '@/lib/supabase/client'
 import type {
   CatalogAuthorshipDetail,
@@ -17,8 +18,39 @@ import type {
   VignetteEncounterSurvivorLiveState,
   VignetteMonsterDetail
 } from '@/lib/types'
+import type {
+  VignetteCreateInput,
+  VignetteEncounterAIDeckUpdateInput,
+  VignetteEncounterDeleteInput,
+  VignetteEncounterMonsterMoodInput,
+  VignetteEncounterMonsterStateDeleteInput,
+  VignetteEncounterMonsterSurvivorStatusInput,
+  VignetteEncounterMonsterTraitInput,
+  VignetteEncounterMonsterUpdateInput,
+  VignetteEncounterSurvivorGearGridUpdateInput,
+  VignetteEncounterSurvivorLiveStateUpdateInput,
+  VignetteEncounterUpdateInput,
+  VignetteShareInput,
+  VignetteShareRemovalInput
+} from '@/schemas/vignette-encounter'
 
 type DataRow = Record<string, unknown>
+type VignetteEncounterSurvivorAbilityImpairmentInput = Omit<
+  TablesInsert<'vignette_encounter_survivor_ability_impairment'>,
+  'created_at' | 'id' | 'updated_at'
+>
+type VignetteEncounterSurvivorDisorderInput = Omit<
+  TablesInsert<'vignette_encounter_survivor_disorder'>,
+  'created_at' | 'id' | 'updated_at'
+>
+type VignetteEncounterSurvivorFightingArtInput = Omit<
+  TablesInsert<'vignette_encounter_survivor_fighting_art'>,
+  'created_at' | 'id' | 'updated_at'
+>
+type VignetteEncounterSurvivorSecretFightingArtInput = Omit<
+  TablesInsert<'vignette_encounter_survivor_secret_fighting_art'>,
+  'created_at' | 'id' | 'updated_at'
+>
 
 const EMPTY_MEMBER_PROFILES = new Map<string, SettlementMemberProfile>()
 
@@ -279,6 +311,21 @@ function omit(row: DataRow, keys: readonly string[]): DataRow {
   const result = { ...row }
   for (const key of keys) delete result[key]
   return result
+}
+
+async function resolveVignetteSharedUserId(
+  username: string,
+  operation: string
+): Promise<string> {
+  try {
+    const sharedUserId = await lookupUserByUsername(username)
+    if (!sharedUserId) throw new Error('User Not Found')
+    return sharedUserId
+  } catch (error) {
+    throw new Error(
+      `${operation}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
 }
 
 /**
@@ -992,4 +1039,610 @@ export async function getVignetteEncounter(
     survivors: survivors ?? {},
     shared_users: sharedUsers ?? []
   } as VignetteEncounterDetail
+}
+
+/**
+ * Create Vignette Encounter
+ *
+ * Creates an active vignette encounter from catalog monster and level data.
+ * The database RPC performs the deterministic catalog-to-active copy for the
+ * encounter, AI decks, monsters, survivors, and copied child rows.
+ *
+ * @param input Vignette Create Input
+ * @returns Created Vignette Encounter ID
+ */
+export async function createVignetteEncounter(
+  input: VignetteCreateInput
+): Promise<string> {
+  const supabase = createClient()
+
+  const { data, error } = await supabase.rpc(
+    'create_vignette_encounter_from_catalog',
+    {
+      target_level_number: input.level_number,
+      target_vignette_monster_id: input.vignette_monster_id
+    }
+  )
+
+  if (error)
+    throw new Error(`Error Creating Vignette Encounter: ${error.message}`)
+  if (!data)
+    throw new Error('Error Creating Vignette Encounter: Missing encounter ID')
+
+  return data
+}
+
+/**
+ * Update Vignette Encounter
+ *
+ * Updates mutable encounter-level state such as turn and notes.
+ *
+ * @param input Vignette Encounter Update Input
+ */
+export async function updateVignetteEncounter(
+  input: VignetteEncounterUpdateInput
+): Promise<void> {
+  const { vignette_encounter_id, ...updateData } = input
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter')
+    .update(updateData)
+    .eq('id', vignette_encounter_id)
+
+  if (error)
+    throw new Error(`Error Updating Vignette Encounter: ${error.message}`)
+}
+
+/**
+ * Remove Vignette Encounter
+ *
+ * Deletes an active vignette encounter. Database cascade rules remove active
+ * child state, clearing the owned active slot without recording outcome or
+ * lifecycle history.
+ *
+ * @param input Vignette Encounter Delete Input
+ */
+export async function removeVignetteEncounter(
+  input: VignetteEncounterDeleteInput
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter')
+    .delete()
+    .eq('id', input.vignette_encounter_id)
+
+  if (error)
+    throw new Error(`Error Removing Vignette Encounter: ${error.message}`)
+}
+
+/**
+ * Update Vignette Encounter AI Deck
+ *
+ * Updates remaining active AI deck card counts for a vignette encounter.
+ *
+ * @param input Vignette Encounter AI Deck Update Input
+ */
+export async function updateVignetteEncounterAIDeck(
+  input: VignetteEncounterAIDeckUpdateInput
+): Promise<void> {
+  const { vignette_encounter_ai_deck_id, ...updateData } = input
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_ai_deck')
+    .update(updateData)
+    .eq('id', vignette_encounter_ai_deck_id)
+
+  if (error)
+    throw new Error(
+      `Error Updating Vignette Encounter AI Deck: ${error.message}`
+    )
+}
+
+/**
+ * Update Vignette Encounter Monster
+ *
+ * Updates mutable active monster state including wounds, tokens, card state,
+ * stats, and notes.
+ *
+ * @param input Vignette Encounter Monster Update Input
+ */
+export async function updateVignetteEncounterMonster(
+  input: VignetteEncounterMonsterUpdateInput
+): Promise<void> {
+  const { vignette_encounter_monster_id, ...updateData } = input
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_monster')
+    .update(updateData)
+    .eq('id', vignette_encounter_monster_id)
+
+  if (error)
+    throw new Error(
+      `Error Updating Vignette Encounter Monster: ${error.message}`
+    )
+}
+
+/**
+ * Add Vignette Encounter Monster Mood
+ *
+ * Adds a mood row to an active vignette monster.
+ *
+ * @param input Vignette Encounter Monster Mood Input
+ * @returns Created Mood Row ID
+ */
+export async function addVignetteEncounterMonsterMood(
+  input: VignetteEncounterMonsterMoodInput
+): Promise<string> {
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_monster_mood')
+    .insert(input)
+    .select('id')
+    .single()
+
+  if (error)
+    throw new Error(
+      `Error Adding Vignette Encounter Monster Mood: ${error.message}`
+    )
+
+  return data.id
+}
+
+/**
+ * Remove Vignette Encounter Monster Mood
+ *
+ * Removes a mood row from an active vignette monster.
+ *
+ * @param input Vignette Encounter Monster State Delete Input
+ */
+export async function removeVignetteEncounterMonsterMood(
+  input: VignetteEncounterMonsterStateDeleteInput
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_monster_mood')
+    .delete()
+    .eq('id', input.id)
+
+  if (error)
+    throw new Error(
+      `Error Removing Vignette Encounter Monster Mood: ${error.message}`
+    )
+}
+
+/**
+ * Add Vignette Encounter Monster Trait
+ *
+ * Adds a trait row to an active vignette monster.
+ *
+ * @param input Vignette Encounter Monster Trait Input
+ * @returns Created Trait Row ID
+ */
+export async function addVignetteEncounterMonsterTrait(
+  input: VignetteEncounterMonsterTraitInput
+): Promise<string> {
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_monster_trait')
+    .insert(input)
+    .select('id')
+    .single()
+
+  if (error)
+    throw new Error(
+      `Error Adding Vignette Encounter Monster Trait: ${error.message}`
+    )
+
+  return data.id
+}
+
+/**
+ * Remove Vignette Encounter Monster Trait
+ *
+ * Removes a trait row from an active vignette monster.
+ *
+ * @param input Vignette Encounter Monster State Delete Input
+ */
+export async function removeVignetteEncounterMonsterTrait(
+  input: VignetteEncounterMonsterStateDeleteInput
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_monster_trait')
+    .delete()
+    .eq('id', input.id)
+
+  if (error)
+    throw new Error(
+      `Error Removing Vignette Encounter Monster Trait: ${error.message}`
+    )
+}
+
+/**
+ * Add Vignette Encounter Monster Survivor Status
+ *
+ * Adds a survivor status row to an active vignette monster.
+ *
+ * @param input Vignette Encounter Monster Survivor Status Input
+ * @returns Created Survivor Status Row ID
+ */
+export async function addVignetteEncounterMonsterSurvivorStatus(
+  input: VignetteEncounterMonsterSurvivorStatusInput
+): Promise<string> {
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_monster_survivor_status')
+    .insert(input)
+    .select('id')
+    .single()
+
+  if (error)
+    throw new Error(
+      `Error Adding Vignette Encounter Monster Survivor Status: ${error.message}`
+    )
+
+  return data.id
+}
+
+/**
+ * Remove Vignette Encounter Monster Survivor Status
+ *
+ * Removes a survivor status row from an active vignette monster.
+ *
+ * @param input Vignette Encounter Monster State Delete Input
+ */
+export async function removeVignetteEncounterMonsterSurvivorStatus(
+  input: VignetteEncounterMonsterStateDeleteInput
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_monster_survivor_status')
+    .delete()
+    .eq('id', input.id)
+
+  if (error)
+    throw new Error(
+      `Error Removing Vignette Encounter Monster Survivor Status: ${error.message}`
+    )
+}
+
+/**
+ * Update Vignette Encounter Survivor Live State
+ *
+ * Updates mutable active survivor live-state fields without changing copied
+ * survivor identity or base stat fields.
+ *
+ * @param input Vignette Encounter Survivor Live State Update Input
+ */
+export async function updateVignetteEncounterSurvivorLiveState(
+  input: VignetteEncounterSurvivorLiveStateUpdateInput
+): Promise<void> {
+  const { vignette_encounter_survivor_id, ...updateData } = input
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_survivor')
+    .update(updateData)
+    .eq('id', vignette_encounter_survivor_id)
+
+  if (error)
+    throw new Error(
+      `Error Updating Vignette Encounter Survivor Live State: ${error.message}`
+    )
+}
+
+/**
+ * Add Vignette Encounter Survivor Ability Impairment
+ *
+ * Adds an ability impairment row to an active vignette survivor.
+ *
+ * @param input Vignette Encounter Survivor Ability Impairment Input
+ * @returns Created Ability Impairment Row ID
+ */
+export async function addVignetteEncounterSurvivorAbilityImpairment(
+  input: VignetteEncounterSurvivorAbilityImpairmentInput
+): Promise<string> {
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_survivor_ability_impairment')
+    .insert(input)
+    .select('id')
+    .single()
+
+  if (error)
+    throw new Error(
+      `Error Adding Vignette Encounter Survivor Ability Impairment: ${error.message}`
+    )
+
+  return data.id
+}
+
+/**
+ * Remove Vignette Encounter Survivor Ability Impairment
+ *
+ * Removes an ability impairment row from an active vignette survivor.
+ *
+ * @param id Vignette Encounter Survivor Ability Impairment Row ID
+ */
+export async function removeVignetteEncounterSurvivorAbilityImpairment(
+  id: string
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_survivor_ability_impairment')
+    .delete()
+    .eq('id', id)
+
+  if (error)
+    throw new Error(
+      `Error Removing Vignette Encounter Survivor Ability Impairment: ${error.message}`
+    )
+}
+
+/**
+ * Add Vignette Encounter Survivor Disorder
+ *
+ * Adds a disorder row to an active vignette survivor.
+ *
+ * @param input Vignette Encounter Survivor Disorder Input
+ * @returns Created Disorder Row ID
+ */
+export async function addVignetteEncounterSurvivorDisorder(
+  input: VignetteEncounterSurvivorDisorderInput
+): Promise<string> {
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_survivor_disorder')
+    .insert(input)
+    .select('id')
+    .single()
+
+  if (error)
+    throw new Error(
+      `Error Adding Vignette Encounter Survivor Disorder: ${error.message}`
+    )
+
+  return data.id
+}
+
+/**
+ * Remove Vignette Encounter Survivor Disorder
+ *
+ * Removes a disorder row from an active vignette survivor.
+ *
+ * @param id Vignette Encounter Survivor Disorder Row ID
+ */
+export async function removeVignetteEncounterSurvivorDisorder(
+  id: string
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_survivor_disorder')
+    .delete()
+    .eq('id', id)
+
+  if (error)
+    throw new Error(
+      `Error Removing Vignette Encounter Survivor Disorder: ${error.message}`
+    )
+}
+
+/**
+ * Add Vignette Encounter Survivor Fighting Art
+ *
+ * Adds a fighting art row to an active vignette survivor.
+ *
+ * @param input Vignette Encounter Survivor Fighting Art Input
+ * @returns Created Fighting Art Row ID
+ */
+export async function addVignetteEncounterSurvivorFightingArt(
+  input: VignetteEncounterSurvivorFightingArtInput
+): Promise<string> {
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_survivor_fighting_art')
+    .insert(input)
+    .select('id')
+    .single()
+
+  if (error)
+    throw new Error(
+      `Error Adding Vignette Encounter Survivor Fighting Art: ${error.message}`
+    )
+
+  return data.id
+}
+
+/**
+ * Remove Vignette Encounter Survivor Fighting Art
+ *
+ * Removes a fighting art row from an active vignette survivor.
+ *
+ * @param id Vignette Encounter Survivor Fighting Art Row ID
+ */
+export async function removeVignetteEncounterSurvivorFightingArt(
+  id: string
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_survivor_fighting_art')
+    .delete()
+    .eq('id', id)
+
+  if (error)
+    throw new Error(
+      `Error Removing Vignette Encounter Survivor Fighting Art: ${error.message}`
+    )
+}
+
+/**
+ * Add Vignette Encounter Survivor Secret Fighting Art
+ *
+ * Adds a secret fighting art row to an active vignette survivor.
+ *
+ * @param input Vignette Encounter Survivor Secret Fighting Art Input
+ * @returns Created Secret Fighting Art Row ID
+ */
+export async function addVignetteEncounterSurvivorSecretFightingArt(
+  input: VignetteEncounterSurvivorSecretFightingArtInput
+): Promise<string> {
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_survivor_secret_fighting_art')
+    .insert(input)
+    .select('id')
+    .single()
+
+  if (error)
+    throw new Error(
+      `Error Adding Vignette Encounter Survivor Secret Fighting Art: ${error.message}`
+    )
+
+  return data.id
+}
+
+/**
+ * Remove Vignette Encounter Survivor Secret Fighting Art
+ *
+ * Removes a secret fighting art row from an active vignette survivor.
+ *
+ * @param id Vignette Encounter Survivor Secret Fighting Art Row ID
+ */
+export async function removeVignetteEncounterSurvivorSecretFightingArt(
+  id: string
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_survivor_secret_fighting_art')
+    .delete()
+    .eq('id', id)
+
+  if (error)
+    throw new Error(
+      `Error Removing Vignette Encounter Survivor Secret Fighting Art: ${error.message}`
+    )
+}
+
+/**
+ * Update Vignette Encounter Survivor Gear Grid
+ *
+ * Updates one copied active survivor gear-grid row.
+ *
+ * @param input Vignette Encounter Survivor Gear Grid Update Input
+ */
+export async function updateVignetteEncounterSurvivorGearGrid(
+  input: VignetteEncounterSurvivorGearGridUpdateInput
+): Promise<void> {
+  const { vignette_encounter_survivor_gear_grid_id, ...updateData } = input
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_survivor_gear_grid')
+    .update(updateData)
+    .eq('id', vignette_encounter_survivor_gear_grid_id)
+
+  if (error)
+    throw new Error(
+      `Error Updating Vignette Encounter Survivor Gear Grid: ${error.message}`
+    )
+}
+
+/**
+ * Add Vignette Encounter Shared User
+ *
+ * Resolves an exact username through the username lookup RPC, then shares the
+ * active vignette encounter with the resolved user.
+ *
+ * @param input Vignette Share Input
+ * @returns Created Share Row ID
+ */
+export async function addVignetteEncounterSharedUser(
+  input: VignetteShareInput
+): Promise<string> {
+  const sharedUserId = await resolveVignetteSharedUserId(
+    input.username,
+    'Error Adding Vignette Encounter Shared User'
+  )
+
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_encounter_shared_user')
+    .insert({
+      shared_user_id: sharedUserId,
+      vignette_encounter_id: input.vignette_encounter_id
+    })
+    .select('id')
+    .single()
+
+  if (error)
+    throw new Error(
+      `Error Adding Vignette Encounter Shared User: ${error.message}`
+    )
+
+  return data.id
+}
+
+/**
+ * Remove Vignette Encounter Shared User
+ *
+ * Revokes a user's access to an active vignette encounter by user ID.
+ *
+ * @param input Vignette Share Removal Input
+ */
+export async function removeVignetteEncounterSharedUser(
+  input: VignetteShareRemovalInput
+): Promise<void> {
+  const supabase = createClient()
+
+  const { error } = await supabase
+    .from('vignette_encounter_shared_user')
+    .delete()
+    .eq('vignette_encounter_id', input.vignette_encounter_id)
+    .eq('shared_user_id', input.shared_user_id)
+
+  if (error)
+    throw new Error(
+      `Error Removing Vignette Encounter Shared User: ${error.message}`
+    )
+}
+
+/**
+ * Remove Vignette Encounter Shared User By Username
+ *
+ * Resolves an exact username, then revokes that user's access to an active
+ * vignette encounter.
+ *
+ * @param input Vignette Share Input
+ */
+export async function removeVignetteEncounterSharedUserByUsername(
+  input: VignetteShareInput
+): Promise<void> {
+  const sharedUserId = await resolveVignetteSharedUserId(
+    input.username,
+    'Error Removing Vignette Encounter Shared User'
+  )
+
+  await removeVignetteEncounterSharedUser({
+    shared_user_id: sharedUserId,
+    vignette_encounter_id: input.vignette_encounter_id
+  })
 }

--- a/lib/dal/vignette-encounter.ts
+++ b/lib/dal/vignette-encounter.ts
@@ -319,7 +319,7 @@ async function resolveVignetteSharedUserId(
 ): Promise<string> {
   try {
     const sharedUserId = await lookupUserByUsername(username)
-    if (!sharedUserId) throw new Error('User Not Found')
+    if (!sharedUserId) throw new Error('User not found or lookup throttled')
     return sharedUserId
   } catch (error) {
     throw new Error(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.93.0",
+  "version": "0.94.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.93.0",
+      "version": "0.94.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.93.0",
+  "version": "0.94.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

- Add DAL mutation helpers for active vignette creation, encounter updates, active monster state, active survivor live state, survivor gear-grid state, copied survivor child rows, and vignette sharing.
- Add focused unit coverage for the new vignette DAL mutation helper behavior.
- Bump package version from 0.93.0 to 0.94.0 for this feature PR.

## Dependencies

No dependency changes.

## Related Issues

Closes #341.

## Verification

- npx eslint lib/dal/vignette-encounter.ts __tests__/lib/dal/vignette-encounter.test.ts
- npx prettier --check lib/dal/vignette-encounter.ts __tests__/lib/dal/vignette-encounter.test.ts package.json package-lock.json
- npx vitest run __tests__/lib/dal/vignette-encounter.test.ts --coverage.enabled=false
- git diff --check