### PR TITLE
[VIG-02.05] Add vignette sharing entitlement helper

### DIFF
--- a/__tests__/lib/subscription-entitlements.test.ts
+++ b/__tests__/lib/subscription-entitlements.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  canCreateUnlimitedSettlements,
+  canShareVignetteEncounters
+} from '@/lib/subscription-entitlements'
+import type { PlanSlug, UserSubscriptionDetail } from '@/lib/types'
+
+function subscription(
+  plan_id: PlanSlug,
+  status: string
+): Pick<UserSubscriptionDetail, 'plan_id' | 'status'> {
+  return { plan_id, status }
+}
+
+describe('canCreateUnlimitedSettlements', () => {
+  it('allows active and trialing paid settlement tiers', () => {
+    expect(
+      canCreateUnlimitedSettlements(subscription('lantern', 'active'))
+    ).toBe(true)
+    expect(
+      canCreateUnlimitedSettlements(subscription('lantern_hoard', 'trialing'))
+    ).toBe(true)
+  })
+
+  it('blocks free, missing, and non-entitled settlement statuses', () => {
+    expect(canCreateUnlimitedSettlements(subscription('free', 'active'))).toBe(
+      false
+    )
+    expect(
+      canCreateUnlimitedSettlements(subscription('lantern', 'past_due'))
+    ).toBe(false)
+    expect(canCreateUnlimitedSettlements(null)).toBe(false)
+  })
+})
+
+describe('canShareVignetteEncounters', () => {
+  it('allows active and trialing Lantern Hoard subscriptions', () => {
+    expect(
+      canShareVignetteEncounters(subscription('lantern_hoard', 'active'))
+    ).toBe(true)
+    expect(
+      canShareVignetteEncounters(subscription('lantern_hoard', 'trialing'))
+    ).toBe(true)
+  })
+
+  it.each([
+    ['free', 'active'],
+    ['lantern', 'active'],
+    ['lantern_hoard', 'canceled'],
+    ['lantern_hoard', 'past_due'],
+    ['lantern_hoard', 'incomplete']
+  ] satisfies [PlanSlug, string][])(
+    'blocks %s with %s status',
+    (planId, status) => {
+      expect(canShareVignetteEncounters(subscription(planId, status))).toBe(
+        false
+      )
+    }
+  )
+
+  it('blocks missing subscriptions', () => {
+    expect(canShareVignetteEncounters(null)).toBe(false)
+  })
+})

--- a/lib/subscription-entitlements.ts
+++ b/lib/subscription-entitlements.ts
@@ -5,6 +5,10 @@ const UNLIMITED_OWNED_SETTLEMENT_PLAN_IDS: ReadonlySet<PlanSlug> = new Set([
   'lantern_hoard'
 ])
 
+const VIGNETTE_SHARING_PLAN_IDS: ReadonlySet<PlanSlug> = new Set([
+  'lantern_hoard'
+])
+
 const ENTITLED_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing'])
 
 /**
@@ -24,5 +28,26 @@ export function canCreateUnlimitedSettlements(
     !!subscription &&
     ENTITLED_SUBSCRIPTION_STATUSES.has(subscription.status) &&
     UNLIMITED_OWNED_SETTLEMENT_PLAN_IDS.has(subscription.plan_id)
+  )
+}
+
+/**
+ * Can Share Vignette Encounters
+ *
+ * Returns true when the current subscription is on the Lantern Hoard tier and
+ * still in an entitling Stripe status. This mirrors the
+ * `can_share_vignette_encounters(user_id uuid)` Postgres helper consulted by
+ * RLS on `vignette_encounter_shared_user.INSERT`.
+ *
+ * @param subscription User Subscription Detail
+ * @returns Whether The User Can Create Vignette Encounter Shares
+ */
+export function canShareVignetteEncounters(
+  subscription: Pick<UserSubscriptionDetail, 'plan_id' | 'status'> | null
+): boolean {
+  return (
+    !!subscription &&
+    ENTITLED_SUBSCRIPTION_STATUSES.has(subscription.status) &&
+    VIGNETTE_SHARING_PLAN_IDS.has(subscription.plan_id)
   )
 }

--- a/lib/subscription-entitlements.ts
+++ b/lib/subscription-entitlements.ts
@@ -9,7 +9,9 @@ const VIGNETTE_SHARING_PLAN_IDS: ReadonlySet<PlanSlug> = new Set([
   'lantern_hoard'
 ])
 
-const ENTITLED_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing'])
+const ENTITLED_SUBSCRIPTION_STATUSES: ReadonlySet<
+  UserSubscriptionDetail['status']
+> = new Set(['active', 'trialing'])
 
 /**
  * Can Create Unlimited Settlements
@@ -36,7 +38,7 @@ export function canCreateUnlimitedSettlements(
  *
  * Returns true when the current subscription is on the Lantern Hoard tier and
  * still in an entitling Stripe status. This mirrors the
- * `can_share_vignette_encounters(user_id uuid)` Postgres helper consulted by
+ * `can_share_vignette_encounters(target_user_id uuid)` Postgres helper consulted by
  * RLS on `vignette_encounter_shared_user.INSERT`.
  *
  * @param subscription User Subscription Detail

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.94.0",
+  "version": "0.95.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.94.0",
+      "version": "0.95.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.94.0",
+  "version": "0.95.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

- Add `canShareVignetteEncounters()` to mirror the `can_share_vignette_encounters(user_id uuid)` RLS helper for vignette share creation.
- Add unit coverage for active/trialing Lantern Hoard eligibility and non-entitled plan/status combinations.
- Bump package version from 0.94.0 to 0.95.0 for this feature PR.

## Dependencies

No dependency changes.

## Related Issues

Closes #340.

## Verification

- npx eslint lib/subscription-entitlements.ts __tests__/lib/subscription-entitlements.test.ts
- npx prettier --check lib/subscription-entitlements.ts __tests__/lib/subscription-entitlements.test.ts package.json package-lock.json
- npx vitest run __tests__/lib/subscription-entitlements.test.ts --coverage.enabled=false
- git diff --check