### PR TITLE
[VIG-03.01] Add Vignette Encounters tab and sidebar entry

### DIFF
--- a/__tests__/lib/enums.test.ts
+++ b/__tests__/lib/enums.test.ts
@@ -89,6 +89,7 @@ describe('TabType', () => {
     expect(TabType.SQUIRES).toBe('squires')
     expect(TabType.SURVIVORS).toBe('survivors')
     expect(TabType.TIMELINE).toBe('timeline')
+    expect(TabType.VIGNETTE_ENCOUNTERS).toBe('vignetteEncounters')
     expect(TabType.USER).toBe('user')
   })
 })

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -143,6 +143,17 @@ const navSettlementSettingsEntry = {
 }
 
 /**
+ * One-Shot Navigation Items
+ */
+const navOneShots = [
+  {
+    title: 'Vignette Encounters',
+    tab: TabType.VIGNETTE_ENCOUNTERS,
+    icon: SkullIcon
+  }
+]
+
+/**
  * Embark Navigation Items
  */
 const navEmbark = [
@@ -389,6 +400,15 @@ export function AppSidebar({
           <SidebarGroupLabel>Embark</SidebarGroupLabel>
           <NavMain
             items={navEmbark}
+            selectedTab={selectedTab}
+            setSelectedTab={setSelectedTab}
+          />
+        </SidebarGroup>
+
+        <SidebarGroup className="group-data-[collapsible=icon]:p-0">
+          <SidebarGroupLabel>One-Shots</SidebarGroupLabel>
+          <NavMain
+            items={navOneShots}
             selectedTab={selectedTab}
             setSelectedTab={setSelectedTab}
           />

--- a/components/settlement/settlement-card.tsx
+++ b/components/settlement/settlement-card.tsx
@@ -52,6 +52,7 @@ import {
   TooltipTrigger
 } from '@/components/ui/tooltip'
 import { UserCard } from '@/components/user/user-card'
+import { VignetteEncountersCard } from '@/components/vignette/vignette-encounters-card'
 import { useLocal } from '@/contexts/local-context'
 import { FREE_TIER_SETTLEMENT_LIMIT } from '@/lib/common'
 import { updateSettlement } from '@/lib/dal/settlement'
@@ -276,6 +277,9 @@ export function SettlementCard({
 
   // Help tab is always accessible, regardless of settlement state.
   if (selectedTab === TabType.HELP) return <HelpCard />
+
+  if (selectedTab === TabType.VIGNETTE_ENCOUNTERS)
+    return <VignetteEncountersCard />
 
   if (isCreatingNewSettlement)
     return (

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -243,8 +243,8 @@ function Sidebar({
         className={cn(
           'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
           side === 'left'
-            ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
-            : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
+            ? 'left-0 group-data-[collapsible=offcanvas]:-left-(--sidebar-width)'
+            : 'right-0 group-data-[collapsible=offcanvas]:-right-(--sidebar-width)',
           // Adjust the padding for floating and inset variants.
           variant === 'floating' || variant === 'inset'
             ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
@@ -300,7 +300,7 @@ function SidebarRail({ className, ...props }: ComponentProps<'button'>) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex',
+        'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 sm:flex',
         'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
         '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
         'hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full',

--- a/components/vignette/vignette-encounters-card.tsx
+++ b/components/vignette/vignette-encounters-card.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { SkullIcon } from 'lucide-react'
+import { ReactElement } from 'react'
+
+/**
+ * Vignette Encounters Card
+ *
+ * Top-level one-shot surface that is intentionally available without a selected
+ * settlement.
+ *
+ * @returns Vignette Encounters Card
+ */
+export function VignetteEncountersCard(): ReactElement {
+  return (
+    <div className="pt-(--header-height) px-2 py-2">
+      <Card className="mx-auto max-w-3xl border bg-card/70 mt-2">
+        <CardHeader>
+          <div className="mb-2 flex h-12 w-12 items-center justify-center rounded-md border border-red-400/40 bg-red-500/10 text-red-400">
+            <SkullIcon className="h-6 w-6" />
+          </div>
+          <CardTitle>Vignette Encounters</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          One-shot encounters outside of settlement play.
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/lib/enums.ts
+++ b/lib/enums.ts
@@ -103,6 +103,8 @@ export enum TabType {
   SURVIVORS = 'survivors',
   /** Timeline */
   TIMELINE = 'timeline',
+  /** Vignette Encounters */
+  VIGNETTE_ENCOUNTERS = 'vignetteEncounters',
   /** User */
   USER = 'user'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.95.0",
+      "version": "0.96.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

- Add `TabType.VIGNETTE_ENCOUNTERS` and enum coverage.
- Add a top-level One-Shots sidebar group with a Vignette Encounters entry below Embark and above Configuration.
- Add a settlement-independent Vignette Encounters placeholder surface in `components/vignette`.
- Bump package version from 0.95.0 to 0.96.0 for this feature PR.

## Dependencies

No dependency changes.

## Related Issues

Closes #347.

## Verification

- npx eslint components/app-sidebar.tsx components/settlement/settlement-card.tsx components/vignette/vignette-encounters-card.tsx lib/enums.ts __tests__/lib/enums.test.ts
- npx prettier --check components/app-sidebar.tsx components/settlement/settlement-card.tsx components/vignette/vignette-encounters-card.tsx lib/enums.ts __tests__/lib/enums.test.ts package.json package-lock.json
- npx vitest run __tests__/lib/enums.test.ts --coverage.enabled=false
- git diff --check