### PR TITLE
[VIG-03.02] Build vignette landing card

### DIFF
--- a/__tests__/lib/dal/vignette-encounter.test.ts
+++ b/__tests__/lib/dal/vignette-encounter.test.ts
@@ -33,6 +33,7 @@ const {
   getVignetteEncounterSharedUsers,
   getVignetteEncounterSurvivors,
   getVignetteMonster,
+  getVignetteMonsterSummaries,
   getVignetteMonsters,
   removeVignetteEncounter,
   removeVignetteEncounterMonsterMood,
@@ -286,6 +287,65 @@ describe('getVignetteMonsters', () => {
 
     await expect(getVignetteMonsters()).rejects.toThrow(
       'Error Fetching Vignette Monsters: DB error'
+    )
+  })
+})
+
+describe('getVignetteMonsterSummaries', () => {
+  it('returns lightweight vignette catalog rows keyed for landing display', async () => {
+    const query = makeQuery([
+      {
+        id: 'vm-2',
+        monster_name: 'Screaming Nukalope',
+        multi_monster: false,
+        source_monster_type: 'QUARRY',
+        vignette_monster_level: [
+          { id: 'level-2', level_number: 2 },
+          { id: 'level-1', level_number: 1 }
+        ]
+      },
+      {
+        id: 'vm-1',
+        monster_name: 'Killenium Butcher',
+        multi_monster: true,
+        source_monster_type: 'NEMESIS',
+        vignette_monster_level: [{ id: 'level-3', level_number: 3 }]
+      }
+    ])
+    mockSupabase.from.mockReturnValue(query)
+
+    const result = await getVignetteMonsterSummaries()
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('vignette_monster')
+    expect(query.select).toHaveBeenCalledWith(
+      'id, monster_name, multi_monster, source_monster_type, vignette_monster_level(id, level_number)'
+    )
+    expect(result).toEqual([
+      {
+        id: 'vm-1',
+        monster_name: 'Killenium Butcher',
+        multi_monster: true,
+        source_monster_type: 'NEMESIS',
+        levels: [{ id: 'level-3', level_number: 3 }]
+      },
+      {
+        id: 'vm-2',
+        monster_name: 'Screaming Nukalope',
+        multi_monster: false,
+        source_monster_type: 'QUARRY',
+        levels: [
+          { id: 'level-2', level_number: 2 },
+          { id: 'level-1', level_number: 1 }
+        ]
+      }
+    ])
+  })
+
+  it('throws when the summary query fails', async () => {
+    mockSupabase.from.mockReturnValue(makeQuery(null, { message: 'DB error' }))
+
+    await expect(getVignetteMonsterSummaries()).rejects.toThrow(
+      'Error Fetching Vignette Monster Summaries: DB error'
     )
   })
 })

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,6 +51,7 @@ export default async function RootLayout({
   // dynamic rendering, so this per-request flag evaluation does not
   // regress static optimization.
   const subscriptionManagementEnabled = await subscriptionManagementFlag()
+  const vignetteEncountersEnabled = process.env.NODE_ENV === 'development'
 
   return (
     <html lang="en" suppressHydrationWarning>
@@ -64,7 +65,8 @@ export default async function RootLayout({
           disableTransitionOnChange
           nonce={nonce}>
           <LocalProvider
-            subscriptionManagementEnabled={subscriptionManagementEnabled}>
+            subscriptionManagementEnabled={subscriptionManagementEnabled}
+            vignetteEncountersEnabled={vignetteEncountersEnabled}>
             {children}
           </LocalProvider>
           <Toaster />

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -307,8 +307,12 @@ export function AppSidebar({
   // single early-access allowlist. When the rollout opens to everyone, the
   // Sharing entry should be re-gated on `canShare` so non-subscribers stop
   // seeing it; see `docs/settlement-sharing-architecture.md` §9.
-  const { isAdmin, subscriptionManagementEnabled, userSubscription } =
-    useLocal()
+  const {
+    isAdmin,
+    subscriptionManagementEnabled,
+    userSubscription,
+    vignetteEncountersEnabled
+  } = useLocal()
 
   const navItems = useMemo(() => {
     const items =
@@ -405,14 +409,16 @@ export function AppSidebar({
           />
         </SidebarGroup>
 
-        <SidebarGroup className="group-data-[collapsible=icon]:p-0">
-          <SidebarGroupLabel>One-Shots</SidebarGroupLabel>
-          <NavMain
-            items={navOneShots}
-            selectedTab={selectedTab}
-            setSelectedTab={setSelectedTab}
-          />
-        </SidebarGroup>
+        {vignetteEncountersEnabled && (
+          <SidebarGroup className="group-data-[collapsible=icon]:p-0">
+            <SidebarGroupLabel>One-Shots</SidebarGroupLabel>
+            <NavMain
+              items={navOneShots}
+              selectedTab={selectedTab}
+              setSelectedTab={setSelectedTab}
+            />
+          </SidebarGroup>
+        )}
 
         <SidebarGroup>
           <SidebarGroupLabel>Configuration</SidebarGroupLabel>

--- a/components/settlement/settlement-card.tsx
+++ b/components/settlement/settlement-card.tsx
@@ -214,8 +214,12 @@ export function SettlementCard({
   // skips the post-checkout tab switch). This local check protects against
   // a stale `selectedTab` value persisted to localStorage from a previous
   // session when the user was on the allowlist but has since been removed.
-  const { isAdmin, subscriptionManagementEnabled, userSubscription } =
-    useLocal()
+  const {
+    isAdmin,
+    subscriptionManagementEnabled,
+    userSubscription,
+    vignetteEncountersEnabled
+  } = useLocal()
 
   // User settings are always accessible, regardless of settlement state.
   if (selectedTab === TabType.SETTINGS)
@@ -278,7 +282,7 @@ export function SettlementCard({
   // Help tab is always accessible, regardless of settlement state.
   if (selectedTab === TabType.HELP) return <HelpCard />
 
-  if (selectedTab === TabType.VIGNETTE_ENCOUNTERS)
+  if (selectedTab === TabType.VIGNETTE_ENCOUNTERS && vignetteEncountersEnabled)
     return <VignetteEncountersCard />
 
   if (isCreatingNewSettlement)

--- a/components/vignette/vignette-encounters-card.tsx
+++ b/components/vignette/vignette-encounters-card.tsx
@@ -1,6 +1,107 @@
+'use client'
+
+import { LanternLoader } from '@/components/generic/lantern-loader'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  getActiveVignetteEncounterForUser,
+  getSharedVignetteEncountersForUser,
+  getVignetteMonsters
+} from '@/lib/dal/vignette-encounter'
+import { ERROR_MESSAGE } from '@/lib/messages'
+import type {
+  VignetteEncounterSummary,
+  VignetteMonsterDetail
+} from '@/lib/types'
 import { SkullIcon } from 'lucide-react'
-import { ReactElement } from 'react'
+import { ReactElement, useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
+/** Vignette Landing State */
+interface VignetteLandingState {
+  /** Catalog Monsters */
+  catalogMonsters: VignetteMonsterDetail[]
+  /** Owned Active Vignette */
+  ownedActive: VignetteEncounterSummary | null
+  /** Shared Active Vignettes */
+  sharedActive: VignetteEncounterSummary[]
+}
+
+/** Empty Vignette Landing State */
+const EMPTY_VIGNETTE_LANDING_STATE: VignetteLandingState = {
+  catalogMonsters: [],
+  ownedActive: null,
+  sharedActive: []
+}
+
+/**
+ * Fetch Vignette Landing State
+ *
+ * Retrieves active owned and shared vignette summaries. Catalog monsters are
+ * fetched only when the caller does not own an active vignette so shared
+ * vignettes never block owned vignette setup.
+ *
+ * @returns Vignette Landing State
+ */
+async function fetchVignetteLandingState(): Promise<VignetteLandingState> {
+  const [ownedActive, sharedActive] = await Promise.all([
+    getActiveVignetteEncounterForUser(),
+    getSharedVignetteEncountersForUser()
+  ])
+
+  if (ownedActive) {
+    return {
+      catalogMonsters: [],
+      ownedActive,
+      sharedActive
+    }
+  }
+
+  const catalogMonsterMap = await getVignetteMonsters()
+  const catalogMonsters = Object.values(catalogMonsterMap).sort((a, b) =>
+    a.monster_name.localeCompare(b.monster_name)
+  )
+
+  return {
+    catalogMonsters,
+    ownedActive,
+    sharedActive
+  }
+}
+
+/**
+ * Format Vignette Turn
+ *
+ * @param turn Vignette Turn
+ * @returns Display Turn
+ */
+function formatVignetteTurn(turn: VignetteEncounterSummary['turn']): string {
+  const lower = turn.toLowerCase()
+  return `${lower.charAt(0).toUpperCase()}${lower.slice(1)} turn`
+}
+
+/**
+ * Sorted Vignette Levels
+ *
+ * @param monster Vignette Monster Detail
+ * @returns Sorted Vignette Levels
+ */
+function sortedVignetteLevels(
+  monster: VignetteMonsterDetail
+): VignetteMonsterDetail['levels'] {
+  return [...monster.levels].sort((a, b) => a.level_number - b.level_number)
+}
+
+/**
+ * Report Vignette Landing Error
+ *
+ * @param error Error to Report
+ */
+function reportVignetteLandingError(error: unknown): void {
+  console.error('Vignette Landing Fetch Error:', error)
+  toast.error(ERROR_MESSAGE())
+}
 
 /**
  * Vignette Encounters Card
@@ -11,6 +112,58 @@ import { ReactElement } from 'react'
  * @returns Vignette Encounters Card
  */
 export function VignetteEncountersCard(): ReactElement {
+  const [landingState, setLandingState] = useState<VignetteLandingState>(
+    EMPTY_VIGNETTE_LANDING_STATE
+  )
+  const [isLoading, setIsLoading] = useState(true)
+  const [hasLoadError, setHasLoadError] = useState(false)
+
+  const reloadLandingState = useCallback(async () => {
+    setIsLoading(true)
+    setHasLoadError(false)
+
+    try {
+      setLandingState(await fetchVignetteLandingState())
+    } catch (error) {
+      reportVignetteLandingError(error)
+      setHasLoadError(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    let ignore = false
+
+    async function loadLandingState(): Promise<void> {
+      try {
+        const nextLandingState = await fetchVignetteLandingState()
+        if (ignore) return
+
+        setLandingState(nextLandingState)
+        setHasLoadError(false)
+      } catch (error) {
+        if (ignore) return
+
+        reportVignetteLandingError(error)
+        setHasLoadError(true)
+      } finally {
+        if (!ignore) setIsLoading(false)
+      }
+    }
+
+    loadLandingState()
+
+    return () => {
+      ignore = true
+    }
+  }, [])
+
+  const hasSharedActive = landingState.sharedActive.length > 0
+  const hasCatalogMonsters = landingState.catalogMonsters.length > 0
+  const isEmptyLanding =
+    !landingState.ownedActive && !hasSharedActive && !hasCatalogMonsters
+
   return (
     <div className="pt-(--header-height) px-2 py-2">
       <Card className="mx-auto max-w-3xl border bg-card/70 mt-2">
@@ -20,10 +173,151 @@ export function VignetteEncountersCard(): ReactElement {
           </div>
           <CardTitle>Vignette Encounters</CardTitle>
         </CardHeader>
-        <CardContent className="text-sm text-muted-foreground">
-          One-shot encounters outside of settlement play.
+        <CardContent className="flex flex-col gap-4 text-sm">
+          {isLoading ? (
+            <LanternLoader
+              variant="inline"
+              title="Kindling the vignette lantern..."
+              caption="A one-shot waits beyond the settlement record."
+            />
+          ) : hasLoadError ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive">
+              <p className="font-medium">{ERROR_MESSAGE()}</p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-3"
+                onClick={() => void reloadLandingState()}>
+                Try again
+              </Button>
+            </div>
+          ) : isEmptyLanding ? (
+            <p className="rounded-md border border-dashed p-3 text-muted-foreground">
+              No vignette encounters are available yet.
+            </p>
+          ) : (
+            <>
+              {landingState.ownedActive ? (
+                <section className="space-y-2">
+                  <h3 className="text-sm font-semibold">
+                    Active Vignette Encounter
+                  </h3>
+                  <VignetteSummaryRow
+                    summary={landingState.ownedActive}
+                    badge="Owner"
+                  />
+                </section>
+              ) : (
+                <section className="space-y-2">
+                  <h3 className="text-sm font-semibold">
+                    Available Vignette Encounters
+                  </h3>
+                  {hasCatalogMonsters ? (
+                    <div className="grid gap-2">
+                      {landingState.catalogMonsters.map((monster) => (
+                        <VignetteCatalogRow
+                          key={monster.id}
+                          monster={monster}
+                        />
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="rounded-md border border-dashed p-3 text-muted-foreground">
+                      No available vignette encounters.
+                    </p>
+                  )}
+                </section>
+              )}
+
+              <section className="space-y-2">
+                <h3 className="text-sm font-semibold">Shared With Me</h3>
+                {hasSharedActive ? (
+                  <div className="grid gap-2">
+                    {landingState.sharedActive.map((summary) => (
+                      <VignetteSummaryRow
+                        key={summary.id}
+                        summary={summary}
+                        badge="Shared"
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="rounded-md border border-dashed p-3 text-muted-foreground">
+                    No shared vignette encounters are available.
+                  </p>
+                )}
+              </section>
+            </>
+          )}
         </CardContent>
       </Card>
+    </div>
+  )
+}
+
+/**
+ * Vignette Summary Row
+ *
+ * @param props Vignette Summary Row Properties
+ * @returns Vignette Summary Row
+ */
+function VignetteSummaryRow({
+  badge,
+  summary
+}: {
+  /** Badge Label */
+  badge: string
+  /** Vignette Encounter Summary */
+  summary: VignetteEncounterSummary
+}): ReactElement {
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-md border p-3">
+      <div className="min-w-0">
+        <p className="font-medium leading-none">{summary.monster_name}</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Level {summary.level_number} · {formatVignetteTurn(summary.turn)}
+        </p>
+      </div>
+      <Badge variant={badge === 'Owner' ? 'default' : 'outline'}>{badge}</Badge>
+    </div>
+  )
+}
+
+/**
+ * Vignette Catalog Row
+ *
+ * @param props Vignette Catalog Row Properties
+ * @returns Vignette Catalog Row
+ */
+function VignetteCatalogRow({
+  monster
+}: {
+  /** Vignette Monster */
+  monster: VignetteMonsterDetail
+}): ReactElement {
+  const levels = sortedVignetteLevels(monster)
+
+  return (
+    <div className="rounded-md border p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="font-medium leading-none">{monster.monster_name}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {monster.source_monster_type.toLowerCase()}
+          </p>
+        </div>
+        {monster.multi_monster && (
+          <Badge variant="outline">Multi-monster</Badge>
+        )}
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {levels.map((level) => (
+          <Badge key={level.id} variant="secondary">
+            Level {level.level_number}
+          </Badge>
+        ))}
+      </div>
     </div>
   )
 }

--- a/components/vignette/vignette-encounters-card.tsx
+++ b/components/vignette/vignette-encounters-card.tsx
@@ -14,7 +14,6 @@ import type {
   VignetteEncounterSummary,
   VignetteMonsterDetail
 } from '@/lib/types'
-import { SkullIcon } from 'lucide-react'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -168,9 +167,6 @@ export function VignetteEncountersCard(): ReactElement {
     <div className="pt-(--header-height) px-2 py-2">
       <Card className="mx-auto max-w-3xl border bg-card/70 mt-2">
         <CardHeader>
-          <div className="mb-2 flex h-12 w-12 items-center justify-center rounded-md border border-red-400/40 bg-red-500/10 text-red-400">
-            <SkullIcon className="h-6 w-6" />
-          </div>
           <CardTitle>Vignette Encounters</CardTitle>
         </CardHeader>
         <CardContent className="flex flex-col gap-4 text-sm">

--- a/components/vignette/vignette-encounters-card.tsx
+++ b/components/vignette/vignette-encounters-card.tsx
@@ -7,12 +7,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   getActiveVignetteEncounterForUser,
   getSharedVignetteEncountersForUser,
-  getVignetteMonsters
+  getVignetteMonsterSummaries
 } from '@/lib/dal/vignette-encounter'
 import { ERROR_MESSAGE } from '@/lib/messages'
 import type {
   VignetteEncounterSummary,
-  VignetteMonsterDetail
+  VignetteMonsterSummary
 } from '@/lib/types'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
@@ -20,7 +20,7 @@ import { toast } from 'sonner'
 /** Vignette Landing State */
 interface VignetteLandingState {
   /** Catalog Monsters */
-  catalogMonsters: VignetteMonsterDetail[]
+  catalogMonsters: VignetteMonsterSummary[]
   /** Owned Active Vignette */
   ownedActive: VignetteEncounterSummary | null
   /** Shared Active Vignettes */
@@ -57,10 +57,7 @@ async function fetchVignetteLandingState(): Promise<VignetteLandingState> {
     }
   }
 
-  const catalogMonsterMap = await getVignetteMonsters()
-  const catalogMonsters = Object.values(catalogMonsterMap).sort((a, b) =>
-    a.monster_name.localeCompare(b.monster_name)
-  )
+  const catalogMonsters = await getVignetteMonsterSummaries()
 
   return {
     catalogMonsters,
@@ -87,8 +84,8 @@ function formatVignetteTurn(turn: VignetteEncounterSummary['turn']): string {
  * @returns Sorted Vignette Levels
  */
 function sortedVignetteLevels(
-  monster: VignetteMonsterDetail
-): VignetteMonsterDetail['levels'] {
+  monster: VignetteMonsterSummary
+): VignetteMonsterSummary['levels'] {
   return [...monster.levels].sort((a, b) => a.level_number - b.level_number)
 }
 
@@ -290,7 +287,7 @@ function VignetteCatalogRow({
   monster
 }: {
   /** Vignette Monster */
-  monster: VignetteMonsterDetail
+  monster: VignetteMonsterSummary
 }): ReactElement {
   const levels = sortedVignetteLevels(monster)
 

--- a/contexts/local-context.tsx
+++ b/contexts/local-context.tsx
@@ -239,6 +239,15 @@ interface LocalContextType {
   subscriptionManagementEnabled: boolean
 
   /**
+   * Vignette Encounters Flag
+   *
+   * Server-derived development-mode gate for the unfinished Vignette
+   * Encounters UI. Kept separate from user-facing feature flags so this
+   * surface cannot leak in production before launch.
+   */
+  vignetteEncountersEnabled: boolean
+
+  /**
    * Settlement List
    *
    * Cached result of `getSettlementForUser`. Refreshed automatically when
@@ -267,6 +276,14 @@ interface LocalProviderProps {
    * Edge Config from the browser.
    */
   subscriptionManagementEnabled?: boolean
+  /**
+   * Vignette Encounters Flag
+   *
+   * Pre-resolved server-side from `process.env.NODE_ENV === 'development'`.
+   * Defaults to `false` so tests and stories do not accidentally expose the
+   * unfinished one-shot surfaces.
+   */
+  vignetteEncountersEnabled?: boolean
 }
 
 /**
@@ -282,7 +299,8 @@ const LocalContext = createContext<LocalContextType | undefined>(undefined)
  */
 export function LocalProvider({
   children,
-  subscriptionManagementEnabled = false
+  subscriptionManagementEnabled = false,
+  vignetteEncountersEnabled = false
 }: LocalProviderProps): ReactElement {
   // Get the local state information from local storage, or set to default if
   // not present.
@@ -1865,6 +1883,7 @@ export function LocalProvider({
       subscribeToNotificationInserts,
       canShare: userSubscription?.can_share === true,
       subscriptionManagementEnabled,
+      vignetteEncountersEnabled,
 
       settlementList,
       isSettlementListLoading
@@ -1897,6 +1916,7 @@ export function LocalProvider({
       userSubscription,
       subscribeToNotificationInserts,
       subscriptionManagementEnabled,
+      vignetteEncountersEnabled,
       settlementList,
       isSettlementListLoading,
       setSelectedHunt,

--- a/lib/dal/vignette-encounter.ts
+++ b/lib/dal/vignette-encounter.ts
@@ -16,7 +16,8 @@ import type {
   VignetteEncounterSummary,
   VignetteEncounterSurvivorDetail,
   VignetteEncounterSurvivorLiveState,
-  VignetteMonsterDetail
+  VignetteMonsterDetail,
+  VignetteMonsterSummary
 } from '@/lib/types'
 import type {
   VignetteCreateInput,
@@ -165,6 +166,15 @@ const VIGNETTE_MONSTER_SELECT = [
     ].join(', '),
     ')'
   ].join('')
+].join(', ')
+
+/** Vignette Monster Summary Select Statement */
+const VIGNETTE_MONSTER_SUMMARY_SELECT = [
+  'id',
+  'monster_name',
+  'multi_monster',
+  'source_monster_type',
+  'vignette_monster_level(id, level_number)'
 ].join(', ')
 
 /**
@@ -522,6 +532,21 @@ function vignetteMonster(row: DataRow): VignetteMonsterDetail {
     levels: rows(row.vignette_monster_level).map(vignetteMonsterLevel),
     survivors: rows(row.vignette_survivor).map(vignetteSurvivor)
   } as VignetteMonsterDetail
+}
+
+/**
+ * Vignette Monster Summary
+ *
+ * Maps a lightweight catalog vignette monster row for landing-page lists.
+ *
+ * @param row Vignette Monster Row
+ * @returns Vignette Monster Summary
+ */
+function vignetteMonsterSummary(row: DataRow): VignetteMonsterSummary {
+  return {
+    ...omit(row, ['vignette_monster_level']),
+    levels: rows(row.vignette_monster_level)
+  } as VignetteMonsterSummary
 }
 
 /**
@@ -888,6 +913,36 @@ export async function getVignetteMonsters(): Promise<{
   for (const row of rawRows) monsters[row.id as string] = vignetteMonster(row)
 
   return monsters
+}
+
+/**
+ * Get Vignette Monster Summaries
+ *
+ * Retrieves lightweight vignette catalog monster summaries for landing UI.
+ * This intentionally avoids the full survivor, gear-grid, and catalog card
+ * graph loaded by {@link getVignetteMonsters}.
+ *
+ * @returns Vignette Monster Summaries
+ */
+export async function getVignetteMonsterSummaries(): Promise<
+  VignetteMonsterSummary[]
+> {
+  await getUserId()
+
+  const supabase = createClient()
+
+  const { data, error } = await supabase
+    .from('vignette_monster')
+    .select(VIGNETTE_MONSTER_SUMMARY_SELECT)
+
+  if (error)
+    throw new Error(
+      `Error Fetching Vignette Monster Summaries: ${error.message}`
+    )
+
+  return ((data ?? []) as unknown as DataRow[])
+    .map(vignetteMonsterSummary)
+    .sort((a, b) => a.monster_name.localeCompare(b.monster_name))
 }
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -545,6 +545,15 @@ export type VignetteMonsterDetail = Omit<
   survivors: VignetteSurvivorDetail[]
 }
 
+/** Vignette Monster Summary */
+export type VignetteMonsterSummary = Pick<
+  Tables<'vignette_monster'>,
+  'id' | 'monster_name' | 'multi_monster' | 'source_monster_type'
+> & {
+  /** Levels */
+  levels: Pick<Tables<'vignette_monster_level'>, 'id' | 'level_number'>[]
+}
+
 /** Vignette Encounter AI Deck Detail */
 export type VignetteEncounterAIDeckDetail = Omit<
   Tables<'vignette_encounter_ai_deck'>,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.96.0",
+      "version": "0.97.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary

- Build the Vignette Encounters landing card using existing DAL reads for owned active, shared active, and catalog vignette data.
- Render clear owned-active, shared-active, available-catalog, loading, retry, and empty states.
- Keep catalog setup available when the user only has shared vignettes, so shared access does not block starting an owned vignette.
- Bump package version from 0.96.0 to 0.97.0 for this feature PR.

## Dependencies

No dependency changes.

## Related Issues

Closes #343.

## Verification

- npx eslint components/vignette/vignette-encounters-card.tsx components/settlement/settlement-card.tsx
- npx prettier --check components/vignette/vignette-encounters-card.tsx components/settlement/settlement-card.tsx package.json package-lock.json
- npx vitest run __tests__/lib/enums.test.ts --coverage.enabled=false
- git diff --check