### PR TITLE
Build owned and shared vignette switcher

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,6 +101,7 @@ function MainPage(): ReactElement {
     selectedSurvivor,
     // selectedSurvivorId,
     selectedTab,
+    selectedVignetteEncounterId,
 
     // setIsCreatingNewHunt,
     setIsCreatingNewSettlement,
@@ -122,6 +123,7 @@ function MainPage(): ReactElement {
     setSelectedShowdownMonsterIndex,
     setSelectedSurvivor,
     setSelectedSurvivorId,
+    setSelectedVignetteEncounterId,
     setSelectedTab,
 
     setSurvivors,
@@ -174,6 +176,7 @@ function MainPage(): ReactElement {
             selectedShowdownMonsterIndex={selectedShowdownMonsterIndex}
             selectedSurvivor={selectedSurvivor}
             selectedTab={selectedTab}
+            selectedVignetteEncounterId={selectedVignetteEncounterId}
             settlementList={settlementList}
             setIsCreatingNewSettlement={setIsCreatingNewSettlement}
             setIsCreatingNewSurvivor={setIsCreatingNewSurvivor}
@@ -191,6 +194,7 @@ function MainPage(): ReactElement {
             setSelectedShowdownMonsterIndex={setSelectedShowdownMonsterIndex}
             setSelectedSurvivor={setSelectedSurvivor}
             setSelectedSurvivorId={setSelectedSurvivorId}
+            setSelectedVignetteEncounterId={setSelectedVignetteEncounterId}
             setSelectedTab={setSelectedTab}
             setSurvivors={setSurvivors}
             setUserSettings={setUserSettings}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -102,6 +102,9 @@ function MainPage(): ReactElement {
     // selectedSurvivorId,
     selectedTab,
     selectedVignetteEncounterId,
+    vignetteLandingState,
+    isVignetteLandingStateLoading,
+    hasVignetteLandingStateLoadError,
 
     // setIsCreatingNewHunt,
     setIsCreatingNewSettlement,
@@ -128,6 +131,7 @@ function MainPage(): ReactElement {
 
     setSurvivors,
     survivors,
+    refetchVignetteLandingState,
 
     // local,
     // updateLocal,
@@ -177,6 +181,10 @@ function MainPage(): ReactElement {
             selectedSurvivor={selectedSurvivor}
             selectedTab={selectedTab}
             selectedVignetteEncounterId={selectedVignetteEncounterId}
+            vignetteLandingState={vignetteLandingState}
+            isVignetteLandingStateLoading={isVignetteLandingStateLoading}
+            hasVignetteLandingStateLoadError={hasVignetteLandingStateLoadError}
+            refetchVignetteLandingState={refetchVignetteLandingState}
             settlementList={settlementList}
             setIsCreatingNewSettlement={setIsCreatingNewSettlement}
             setIsCreatingNewSurvivor={setIsCreatingNewSurvivor}

--- a/components/settlement/settlement-card.tsx
+++ b/components/settlement/settlement-card.tsx
@@ -80,7 +80,8 @@ import {
   SurvivorDetail,
   SurvivorsStateSetter,
   SurvivorStateSetter,
-  UserSettingsDetail
+  UserSettingsDetail,
+  VignetteLandingState
 } from '@/lib/types'
 import {
   BookOpenIcon,
@@ -120,6 +121,14 @@ interface SettlementCardProps {
   selectedTab: TabType
   /** Selected Vignette Encounter ID */
   selectedVignetteEncounterId: string | null
+  /** Vignette Landing State */
+  vignetteLandingState: VignetteLandingState
+  /** Whether Vignette Landing State Is Loading */
+  isVignetteLandingStateLoading: boolean
+  /** Whether Vignette Landing State Failed to Load */
+  hasVignetteLandingStateLoadError: boolean
+  /** Refetch Vignette Landing State */
+  refetchVignetteLandingState: () => void
   /** Settlement List (owned + shared, sourced from LocalContext) */
   settlementList: SettlementListEntry[]
   /** Set Is Creating New Settlement */
@@ -190,6 +199,10 @@ export function SettlementCard({
   selectedSurvivor,
   selectedTab,
   selectedVignetteEncounterId,
+  vignetteLandingState,
+  isVignetteLandingStateLoading,
+  hasVignetteLandingStateLoadError,
+  refetchVignetteLandingState,
   settlementList,
   setIsCreatingNewSettlement,
   setIsCreatingNewSurvivor,
@@ -291,8 +304,12 @@ export function SettlementCard({
   if (selectedTab === TabType.VIGNETTE_ENCOUNTERS && vignetteEncountersEnabled)
     return (
       <VignetteEncountersCard
+        hasVignetteLandingStateLoadError={hasVignetteLandingStateLoadError}
+        isVignetteLandingStateLoading={isVignetteLandingStateLoading}
+        refetchVignetteLandingState={refetchVignetteLandingState}
         selectedVignetteEncounterId={selectedVignetteEncounterId}
         setSelectedVignetteEncounterId={setSelectedVignetteEncounterId}
+        vignetteLandingState={vignetteLandingState}
       />
     )
 

--- a/components/settlement/settlement-card.tsx
+++ b/components/settlement/settlement-card.tsx
@@ -118,6 +118,8 @@ interface SettlementCardProps {
   selectedSurvivor: SurvivorDetail | null
   /** Selected Tab */
   selectedTab: TabType
+  /** Selected Vignette Encounter ID */
+  selectedVignetteEncounterId: string | null
   /** Settlement List (owned + shared, sourced from LocalContext) */
   settlementList: SettlementListEntry[]
   /** Set Is Creating New Settlement */
@@ -154,6 +156,8 @@ interface SettlementCardProps {
   setSelectedSurvivor: SurvivorStateSetter
   /** Set Selected Survivor ID */
   setSelectedSurvivorId: (survivorId: string | null) => void
+  /** Set Selected Vignette Encounter ID */
+  setSelectedVignetteEncounterId: (vignetteEncounterId: string | null) => void
   /** Set Selected Tab */
   setSelectedTab: (tab: TabType) => void
   /** Set Survivors */
@@ -185,6 +189,7 @@ export function SettlementCard({
   selectedShowdownMonsterIndex,
   selectedSurvivor,
   selectedTab,
+  selectedVignetteEncounterId,
   settlementList,
   setIsCreatingNewSettlement,
   setIsCreatingNewSurvivor,
@@ -202,6 +207,7 @@ export function SettlementCard({
   setSelectedShowdownMonsterIndex,
   setSelectedSurvivor,
   setSelectedSurvivorId,
+  setSelectedVignetteEncounterId,
   setSelectedTab,
   setSurvivors,
   setUserSettings,
@@ -283,7 +289,12 @@ export function SettlementCard({
   if (selectedTab === TabType.HELP) return <HelpCard />
 
   if (selectedTab === TabType.VIGNETTE_ENCOUNTERS && vignetteEncountersEnabled)
-    return <VignetteEncountersCard />
+    return (
+      <VignetteEncountersCard
+        selectedVignetteEncounterId={selectedVignetteEncounterId}
+        setSelectedVignetteEncounterId={setSelectedVignetteEncounterId}
+      />
+    )
 
   if (isCreatingNewSettlement)
     return (

--- a/components/vignette/vignette-encounters-card.tsx
+++ b/components/vignette/vignette-encounters-card.tsx
@@ -4,74 +4,28 @@ import { LanternLoader } from '@/components/generic/lantern-loader'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import {
-  getActiveVignetteEncounterForUser,
-  getSharedVignetteEncountersForUser,
-  getVignetteMonsterSummaries
-} from '@/lib/dal/vignette-encounter'
 import { ERROR_MESSAGE } from '@/lib/messages'
 import type {
+  VignetteLandingState,
   VignetteEncounterSummary,
   VignetteMonsterSummary
 } from '@/lib/types'
-import { ReactElement, useCallback, useEffect, useRef, useState } from 'react'
-import { toast } from 'sonner'
-
-/** Vignette Landing State */
-interface VignetteLandingState {
-  /** Catalog Monsters */
-  catalogMonsters: VignetteMonsterSummary[]
-  /** Owned Active Vignette */
-  ownedActive: VignetteEncounterSummary | null
-  /** Shared Active Vignettes */
-  sharedActive: VignetteEncounterSummary[]
-}
-
-/** Empty Vignette Landing State */
-const EMPTY_VIGNETTE_LANDING_STATE: VignetteLandingState = {
-  catalogMonsters: [],
-  ownedActive: null,
-  sharedActive: []
-}
+import { ReactElement, useCallback } from 'react'
 
 /** Vignette Encounters Card Properties */
 interface VignetteEncountersCardProps {
+  /** Whether Vignette Landing State Failed to Load */
+  hasVignetteLandingStateLoadError: boolean
+  /** Whether Vignette Landing State Is Loading */
+  isVignetteLandingStateLoading: boolean
+  /** Refetch Vignette Landing State */
+  refetchVignetteLandingState: () => void
   /** Selected Vignette Encounter ID */
   selectedVignetteEncounterId: string | null
   /** Set Selected Vignette Encounter ID */
   setSelectedVignetteEncounterId: (vignetteEncounterId: string | null) => void
-}
-
-/**
- * Fetch Vignette Landing State
- *
- * Retrieves active owned and shared vignette summaries. Catalog monsters are
- * fetched only when the caller does not own an active vignette so shared
- * vignettes never block owned vignette setup.
- *
- * @returns Vignette Landing State
- */
-async function fetchVignetteLandingState(): Promise<VignetteLandingState> {
-  const [ownedActive, sharedActive] = await Promise.all([
-    getActiveVignetteEncounterForUser(),
-    getSharedVignetteEncountersForUser()
-  ])
-
-  if (ownedActive) {
-    return {
-      catalogMonsters: [],
-      ownedActive,
-      sharedActive
-    }
-  }
-
-  const catalogMonsters = await getVignetteMonsterSummaries()
-
-  return {
-    catalogMonsters,
-    ownedActive,
-    sharedActive
-  }
+  /** Vignette Landing State */
+  vignetteLandingState: VignetteLandingState
 }
 
 /**
@@ -98,49 +52,6 @@ function sortedVignetteLevels(
 }
 
 /**
- * Resolve Selected Vignette Encounter ID
- *
- * Keeps the current active vignette selection when it is still accessible,
- * otherwise defaults to the owned active vignette, then the first shared
- * active vignette. The selected role is intentionally not stored in context;
- * callers should derive role from server-backed summary/detail rows.
- *
- * @param landingState Vignette Landing State
- * @param currentVignetteEncounterId Current Vignette Encounter ID
- * @returns Resolved Selected Vignette Encounter ID
- */
-function resolveSelectedVignetteEncounterId(
-  landingState: VignetteLandingState,
-  currentVignetteEncounterId: string | null
-): string | null {
-  const accessibleVignettes = [
-    ...(landingState.ownedActive ? [landingState.ownedActive] : []),
-    ...landingState.sharedActive
-  ]
-  const currentSummary = currentVignetteEncounterId
-    ? accessibleVignettes.find(
-        (summary) => summary.id === currentVignetteEncounterId
-      )
-    : null
-
-  if (currentSummary) return currentSummary.id
-  if (landingState.ownedActive) return landingState.ownedActive.id
-  if (landingState.sharedActive[0]) return landingState.sharedActive[0].id
-
-  return null
-}
-
-/**
- * Report Vignette Landing Error
- *
- * @param error Error to Report
- */
-function reportVignetteLandingError(error: unknown): void {
-  console.error('Vignette Landing Fetch Error:', error)
-  toast.error(ERROR_MESSAGE())
-}
-
-/**
  * Vignette Encounters Card
  *
  * Top-level one-shot surface that is intentionally available without a selected
@@ -150,88 +61,24 @@ function reportVignetteLandingError(error: unknown): void {
  * @returns Vignette Encounters Card
  */
 export function VignetteEncountersCard({
+  hasVignetteLandingStateLoadError,
+  isVignetteLandingStateLoading,
+  refetchVignetteLandingState,
   selectedVignetteEncounterId,
-  setSelectedVignetteEncounterId
+  setSelectedVignetteEncounterId,
+  vignetteLandingState
 }: VignetteEncountersCardProps): ReactElement {
-  const [landingState, setLandingState] = useState<VignetteLandingState>(
-    EMPTY_VIGNETTE_LANDING_STATE
-  )
-  const [isLoading, setIsLoading] = useState(true)
-  const [hasLoadError, setHasLoadError] = useState(false)
-  const selectedVignetteEncounterIdRef = useRef(selectedVignetteEncounterId)
-
-  useEffect(() => {
-    selectedVignetteEncounterIdRef.current = selectedVignetteEncounterId
-  }, [selectedVignetteEncounterId])
-
-  const applyLandingState = useCallback(
-    (nextLandingState: VignetteLandingState) => {
-      const nextSelectedVignetteEncounterId =
-        resolveSelectedVignetteEncounterId(
-          nextLandingState,
-          selectedVignetteEncounterIdRef.current
-        )
-
-      selectedVignetteEncounterIdRef.current = nextSelectedVignetteEncounterId
-      setLandingState(nextLandingState)
-      setSelectedVignetteEncounterId(nextSelectedVignetteEncounterId)
-      setHasLoadError(false)
-    },
-    [setSelectedVignetteEncounterId]
-  )
-
-  const reloadLandingState = useCallback(async () => {
-    setIsLoading(true)
-    setHasLoadError(false)
-
-    try {
-      applyLandingState(await fetchVignetteLandingState())
-    } catch (error) {
-      reportVignetteLandingError(error)
-      setHasLoadError(true)
-    } finally {
-      setIsLoading(false)
-    }
-  }, [applyLandingState])
-
-  useEffect(() => {
-    let ignore = false
-
-    async function loadLandingState(): Promise<void> {
-      try {
-        const nextLandingState = await fetchVignetteLandingState()
-        if (ignore) return
-
-        applyLandingState(nextLandingState)
-      } catch (error) {
-        if (ignore) return
-
-        reportVignetteLandingError(error)
-        setHasLoadError(true)
-      } finally {
-        if (!ignore) setIsLoading(false)
-      }
-    }
-
-    loadLandingState()
-
-    return () => {
-      ignore = true
-    }
-  }, [applyLandingState])
-
   const handleSelectVignetteEncounter = useCallback(
     (summary: VignetteEncounterSummary) => {
-      selectedVignetteEncounterIdRef.current = summary.id
       setSelectedVignetteEncounterId(summary.id)
     },
     [setSelectedVignetteEncounterId]
   )
 
-  const hasSharedActive = landingState.sharedActive.length > 0
-  const hasCatalogMonsters = landingState.catalogMonsters.length > 0
+  const hasSharedActive = vignetteLandingState.sharedActive.length > 0
+  const hasCatalogMonsters = vignetteLandingState.catalogMonsters.length > 0
   const isEmptyLanding =
-    !landingState.ownedActive && !hasSharedActive && !hasCatalogMonsters
+    !vignetteLandingState.ownedActive && !hasSharedActive && !hasCatalogMonsters
   return (
     <div className="pt-(--header-height) px-2 py-2">
       <Card className="mx-auto max-w-3xl border bg-card/70 mt-2">
@@ -239,13 +86,13 @@ export function VignetteEncountersCard({
           <CardTitle>Vignette Encounters</CardTitle>
         </CardHeader>
         <CardContent className="flex flex-col gap-4 text-sm">
-          {isLoading ? (
+          {isVignetteLandingStateLoading ? (
             <LanternLoader
               variant="inline"
               title="Kindling the vignette lantern..."
               caption="A one-shot waits beyond the settlement record."
             />
-          ) : hasLoadError ? (
+          ) : hasVignetteLandingStateLoadError ? (
             <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive">
               <p className="font-medium">{ERROR_MESSAGE()}</p>
               <Button
@@ -253,7 +100,7 @@ export function VignetteEncountersCard({
                 variant="outline"
                 size="sm"
                 className="mt-3"
-                onClick={() => void reloadLandingState()}>
+                onClick={refetchVignetteLandingState}>
                 Try again
               </Button>
             </div>
@@ -263,17 +110,17 @@ export function VignetteEncountersCard({
             </p>
           ) : (
             <>
-              {landingState.ownedActive ? (
+              {vignetteLandingState.ownedActive ? (
                 <section className="space-y-2">
                   <h3 className="text-sm font-semibold">
                     Active Vignette Encounter
                   </h3>
                   <VignetteSummaryRow
-                    summary={landingState.ownedActive}
+                    summary={vignetteLandingState.ownedActive}
                     badge="Owner"
                     isSelected={
                       selectedVignetteEncounterId ===
-                      landingState.ownedActive.id
+                      vignetteLandingState.ownedActive.id
                     }
                     onSelect={handleSelectVignetteEncounter}
                   />
@@ -285,7 +132,7 @@ export function VignetteEncountersCard({
                   </h3>
                   {hasCatalogMonsters ? (
                     <div className="grid gap-2">
-                      {landingState.catalogMonsters.map((monster) => (
+                      {vignetteLandingState.catalogMonsters.map((monster) => (
                         <VignetteCatalogRow
                           key={monster.id}
                           monster={monster}
@@ -304,7 +151,7 @@ export function VignetteEncountersCard({
                 <h3 className="text-sm font-semibold">Shared With Me</h3>
                 {hasSharedActive ? (
                   <div className="grid gap-2">
-                    {landingState.sharedActive.map((summary) => (
+                    {vignetteLandingState.sharedActive.map((summary) => (
                       <VignetteSummaryRow
                         key={summary.id}
                         summary={summary}

--- a/components/vignette/vignette-encounters-card.tsx
+++ b/components/vignette/vignette-encounters-card.tsx
@@ -14,7 +14,7 @@ import type {
   VignetteEncounterSummary,
   VignetteMonsterSummary
 } from '@/lib/types'
-import { ReactElement, useCallback, useEffect, useState } from 'react'
+import { ReactElement, useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 /** Vignette Landing State */
@@ -32,6 +32,14 @@ const EMPTY_VIGNETTE_LANDING_STATE: VignetteLandingState = {
   catalogMonsters: [],
   ownedActive: null,
   sharedActive: []
+}
+
+/** Vignette Encounters Card Properties */
+interface VignetteEncountersCardProps {
+  /** Selected Vignette Encounter ID */
+  selectedVignetteEncounterId: string | null
+  /** Set Selected Vignette Encounter ID */
+  setSelectedVignetteEncounterId: (vignetteEncounterId: string | null) => void
 }
 
 /**
@@ -90,6 +98,39 @@ function sortedVignetteLevels(
 }
 
 /**
+ * Resolve Selected Vignette Encounter ID
+ *
+ * Keeps the current active vignette selection when it is still accessible,
+ * otherwise defaults to the owned active vignette, then the first shared
+ * active vignette. The selected role is intentionally not stored in context;
+ * callers should derive role from server-backed summary/detail rows.
+ *
+ * @param landingState Vignette Landing State
+ * @param currentVignetteEncounterId Current Vignette Encounter ID
+ * @returns Resolved Selected Vignette Encounter ID
+ */
+function resolveSelectedVignetteEncounterId(
+  landingState: VignetteLandingState,
+  currentVignetteEncounterId: string | null
+): string | null {
+  const accessibleVignettes = [
+    ...(landingState.ownedActive ? [landingState.ownedActive] : []),
+    ...landingState.sharedActive
+  ]
+  const currentSummary = currentVignetteEncounterId
+    ? accessibleVignettes.find(
+        (summary) => summary.id === currentVignetteEncounterId
+      )
+    : null
+
+  if (currentSummary) return currentSummary.id
+  if (landingState.ownedActive) return landingState.ownedActive.id
+  if (landingState.sharedActive[0]) return landingState.sharedActive[0].id
+
+  return null
+}
+
+/**
  * Report Vignette Landing Error
  *
  * @param error Error to Report
@@ -105,28 +146,53 @@ function reportVignetteLandingError(error: unknown): void {
  * Top-level one-shot surface that is intentionally available without a selected
  * settlement.
  *
+ * @param props Vignette Encounters Card Properties
  * @returns Vignette Encounters Card
  */
-export function VignetteEncountersCard(): ReactElement {
+export function VignetteEncountersCard({
+  selectedVignetteEncounterId,
+  setSelectedVignetteEncounterId
+}: VignetteEncountersCardProps): ReactElement {
   const [landingState, setLandingState] = useState<VignetteLandingState>(
     EMPTY_VIGNETTE_LANDING_STATE
   )
   const [isLoading, setIsLoading] = useState(true)
   const [hasLoadError, setHasLoadError] = useState(false)
+  const selectedVignetteEncounterIdRef = useRef(selectedVignetteEncounterId)
+
+  useEffect(() => {
+    selectedVignetteEncounterIdRef.current = selectedVignetteEncounterId
+  }, [selectedVignetteEncounterId])
+
+  const applyLandingState = useCallback(
+    (nextLandingState: VignetteLandingState) => {
+      const nextSelectedVignetteEncounterId =
+        resolveSelectedVignetteEncounterId(
+          nextLandingState,
+          selectedVignetteEncounterIdRef.current
+        )
+
+      selectedVignetteEncounterIdRef.current = nextSelectedVignetteEncounterId
+      setLandingState(nextLandingState)
+      setSelectedVignetteEncounterId(nextSelectedVignetteEncounterId)
+      setHasLoadError(false)
+    },
+    [setSelectedVignetteEncounterId]
+  )
 
   const reloadLandingState = useCallback(async () => {
     setIsLoading(true)
     setHasLoadError(false)
 
     try {
-      setLandingState(await fetchVignetteLandingState())
+      applyLandingState(await fetchVignetteLandingState())
     } catch (error) {
       reportVignetteLandingError(error)
       setHasLoadError(true)
     } finally {
       setIsLoading(false)
     }
-  }, [])
+  }, [applyLandingState])
 
   useEffect(() => {
     let ignore = false
@@ -136,8 +202,7 @@ export function VignetteEncountersCard(): ReactElement {
         const nextLandingState = await fetchVignetteLandingState()
         if (ignore) return
 
-        setLandingState(nextLandingState)
-        setHasLoadError(false)
+        applyLandingState(nextLandingState)
       } catch (error) {
         if (ignore) return
 
@@ -153,13 +218,20 @@ export function VignetteEncountersCard(): ReactElement {
     return () => {
       ignore = true
     }
-  }, [])
+  }, [applyLandingState])
+
+  const handleSelectVignetteEncounter = useCallback(
+    (summary: VignetteEncounterSummary) => {
+      selectedVignetteEncounterIdRef.current = summary.id
+      setSelectedVignetteEncounterId(summary.id)
+    },
+    [setSelectedVignetteEncounterId]
+  )
 
   const hasSharedActive = landingState.sharedActive.length > 0
   const hasCatalogMonsters = landingState.catalogMonsters.length > 0
   const isEmptyLanding =
     !landingState.ownedActive && !hasSharedActive && !hasCatalogMonsters
-
   return (
     <div className="pt-(--header-height) px-2 py-2">
       <Card className="mx-auto max-w-3xl border bg-card/70 mt-2">
@@ -199,6 +271,11 @@ export function VignetteEncountersCard(): ReactElement {
                   <VignetteSummaryRow
                     summary={landingState.ownedActive}
                     badge="Owner"
+                    isSelected={
+                      selectedVignetteEncounterId ===
+                      landingState.ownedActive.id
+                    }
+                    onSelect={handleSelectVignetteEncounter}
                   />
                 </section>
               ) : (
@@ -232,6 +309,8 @@ export function VignetteEncountersCard(): ReactElement {
                         key={summary.id}
                         summary={summary}
                         badge="Shared"
+                        isSelected={selectedVignetteEncounterId === summary.id}
+                        onSelect={handleSelectVignetteEncounter}
                       />
                     ))}
                   </div>
@@ -257,15 +336,27 @@ export function VignetteEncountersCard(): ReactElement {
  */
 function VignetteSummaryRow({
   badge,
+  isSelected,
+  onSelect,
   summary
 }: {
   /** Badge Label */
   badge: string
+  /** Whether This Vignette Is Selected */
+  isSelected: boolean
+  /** Select Vignette Encounter */
+  onSelect: (summary: VignetteEncounterSummary) => void
   /** Vignette Encounter Summary */
   summary: VignetteEncounterSummary
 }): ReactElement {
   return (
-    <div className="flex items-start justify-between gap-3 rounded-md border p-3">
+    <button
+      type="button"
+      aria-pressed={isSelected}
+      onClick={() => onSelect(summary)}
+      className={`flex w-full items-start justify-between gap-3 rounded-md border p-3 text-left transition-colors hover:bg-accent hover:text-accent-foreground ${
+        isSelected ? 'border-primary bg-primary/10' : ''
+      }`}>
       <div className="min-w-0">
         <p className="font-medium leading-none">{summary.monster_name}</p>
         <p className="mt-1 text-xs text-muted-foreground">
@@ -273,7 +364,7 @@ function VignetteSummaryRow({
         </p>
       </div>
       <Badge variant={badge === 'Owner' ? 'default' : 'outline'}>{badge}</Badge>
-    </div>
+    </button>
   )
 }
 

--- a/contexts/local-context.tsx
+++ b/contexts/local-context.tsx
@@ -14,7 +14,12 @@ import { getShowdown } from '@/lib/dal/showdown'
 import { getSurvivor, getSurvivors } from '@/lib/dal/survivor'
 import { getSettlementForUser, getUserSettings } from '@/lib/dal/user'
 import { getUserSubscription } from '@/lib/dal/user-subscription'
-import { getVignetteEncounter } from '@/lib/dal/vignette-encounter'
+import {
+  getActiveVignetteEncounterForUser,
+  getSharedVignetteEncountersForUser,
+  getVignetteEncounter,
+  getVignetteMonsterSummaries
+} from '@/lib/dal/vignette-encounter'
 import { TabType } from '@/lib/enums'
 import { ERROR_MESSAGE } from '@/lib/messages'
 import { isUserSettingsAdmin } from '@/lib/supabase/admin-role'
@@ -36,7 +41,8 @@ import {
   UserSettingsDetail,
   UserSubscriptionDetail,
   VignetteEncounterDetail,
-  VignetteEncounterStateSetter
+  VignetteEncounterStateSetter,
+  VignetteLandingState
 } from '@/lib/types'
 import { saveToLocalStorage } from '@/lib/utils'
 import {
@@ -90,7 +96,46 @@ const newLocal: LocalStateType = {
 
 const NOTIFICATION_INSERT_COALESCE_MS = 250
 
+/** Empty Vignette Landing State */
+const EMPTY_VIGNETTE_LANDING_STATE: VignetteLandingState = {
+  catalogMonsters: [],
+  ownedActive: null,
+  sharedActive: []
+}
+
 type NotificationInsertListener = () => void
+
+/**
+ * Fetch Vignette Landing State
+ *
+ * Retrieves active owned and shared vignette summaries. Catalog monsters are
+ * fetched only when the caller does not own an active vignette so shared
+ * vignettes never block owned vignette setup.
+ *
+ * @returns Vignette Landing State
+ */
+async function fetchVignetteLandingState(): Promise<VignetteLandingState> {
+  const [ownedActive, sharedActive] = await Promise.all([
+    getActiveVignetteEncounterForUser(),
+    getSharedVignetteEncountersForUser()
+  ])
+
+  if (ownedActive) {
+    return {
+      catalogMonsters: [],
+      ownedActive,
+      sharedActive
+    }
+  }
+
+  const catalogMonsters = await getVignetteMonsterSummaries()
+
+  return {
+    catalogMonsters,
+    ownedActive,
+    sharedActive
+  }
+}
 
 /**
  * Local Context Type
@@ -149,6 +194,12 @@ interface LocalContextType {
   selectedVignetteEncounter: VignetteEncounterDetail | null
   /** Selected Vignette Encounter ID */
   selectedVignetteEncounterId: string | null
+  /** Vignette Landing State */
+  vignetteLandingState: VignetteLandingState
+  /** Whether Vignette Landing State Is Loading */
+  isVignetteLandingStateLoading: boolean
+  /** Whether Vignette Landing State Failed to Load */
+  hasVignetteLandingStateLoadError: boolean
   /** Selected Tab */
   selectedTab: TabType
 
@@ -202,6 +253,8 @@ interface LocalContextType {
   setSurvivors: SurvivorsStateSetter
   /** Survivors */
   survivors: SurvivorDetail[]
+  /** Refetch Vignette Landing State */
+  refetchVignetteLandingState: () => void
 
   /** Local Context */
   local: LocalStateType
@@ -368,6 +421,16 @@ export function LocalProvider({
     useState<VignetteEncounterDetail | null>(null)
   const [selectedVignetteEncounterId, setSelectedVignetteEncounterIdState] =
     useState<string | null>(() => local.selectedVignetteEncounterId ?? null)
+
+  // Vignette Landing State
+  const [vignetteLandingState, setVignetteLandingState] =
+    useState<VignetteLandingState>(EMPTY_VIGNETTE_LANDING_STATE)
+  const [isVignetteLandingStateLoading, setIsVignetteLandingStateLoading] =
+    useState<boolean>(true)
+  const [
+    hasVignetteLandingStateLoadError,
+    setHasVignetteLandingStateLoadError
+  ] = useState<boolean>(false)
 
   // Survivors (all for Settlement)
   const [survivors, setSurvivors] = useState<SurvivorDetail[]>([])
@@ -974,6 +1037,82 @@ export function LocalProvider({
     onNotificationInsert: handleNotificationInsert,
     onOwnedSettlementChange: handleOwnedSettlementChange
   })
+
+  /**
+   * Refetch Vignette Landing State
+   *
+   * Refreshes owned/shared vignette summaries and catalog monsters without
+   * changing the selected vignette id. Selection remains an explicit user
+   * action.
+   */
+  const refetchVignetteLandingState = useCallback(() => {
+    if (!vignetteEncountersEnabled || isAuthenticated !== true) {
+      setVignetteLandingState(EMPTY_VIGNETTE_LANDING_STATE)
+      setIsVignetteLandingStateLoading(false)
+      setHasVignetteLandingStateLoadError(false)
+      return
+    }
+
+    setIsVignetteLandingStateLoading(true)
+    setHasVignetteLandingStateLoadError(false)
+
+    fetchVignetteLandingState()
+      .then((nextLandingState) => {
+        setVignetteLandingState(nextLandingState)
+      })
+      .catch((err: unknown) => {
+        console.error('Vignette Landing Fetch Error:', err)
+        setHasVignetteLandingStateLoadError(true)
+        sonnerToast.error(ERROR_MESSAGE())
+      })
+      .finally(() => {
+        setIsVignetteLandingStateLoading(false)
+      })
+  }, [isAuthenticated, vignetteEncountersEnabled])
+
+  /**
+   * Fetch Vignette Landing State
+   *
+   * Loads the switcher/list data into LocalContext after authentication. This
+   * intentionally does not select a default vignette; it only refreshes the
+   * data that the vignette tab renders.
+   */
+  useEffect(() => {
+    let isCancelled = false
+
+    if (!vignetteEncountersEnabled || isAuthenticated !== true)
+      return () => {
+        isCancelled = true
+      }
+
+    Promise.resolve()
+      .then(() => {
+        if (isCancelled) return null
+
+        setIsVignetteLandingStateLoading(true)
+        setHasVignetteLandingStateLoadError(false)
+        return fetchVignetteLandingState()
+      })
+      .then((nextLandingState) => {
+        if (isCancelled || !nextLandingState) return
+
+        setVignetteLandingState(nextLandingState)
+      })
+      .catch((err: unknown) => {
+        if (isCancelled) return
+
+        console.error('Vignette Landing Fetch Error:', err)
+        setHasVignetteLandingStateLoadError(true)
+        sonnerToast.error(ERROR_MESSAGE())
+      })
+      .finally(() => {
+        if (!isCancelled) setIsVignetteLandingStateLoading(false)
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [isAuthenticated, vignetteEncountersEnabled])
 
   /**
    * Fetch Hunt Data
@@ -1983,6 +2122,9 @@ export function LocalProvider({
       selectedSurvivorId,
       selectedVignetteEncounter,
       selectedVignetteEncounterId,
+      vignetteLandingState,
+      isVignetteLandingStateLoading,
+      hasVignetteLandingStateLoadError,
       selectedTab,
 
       setIsCreatingNewHunt,
@@ -2011,6 +2153,7 @@ export function LocalProvider({
 
       setSurvivors,
       survivors,
+      refetchVignetteLandingState,
 
       local,
       updateLocal,
@@ -2051,6 +2194,9 @@ export function LocalProvider({
       selectedSurvivorId,
       selectedVignetteEncounter,
       selectedVignetteEncounterId,
+      vignetteLandingState,
+      isVignetteLandingStateLoading,
+      hasVignetteLandingStateLoadError,
       selectedTab,
       survivors,
       local,
@@ -2061,6 +2207,7 @@ export function LocalProvider({
       vignetteEncountersEnabled,
       settlementList,
       isSettlementListLoading,
+      refetchVignetteLandingState,
       setSelectedHunt,
       setSelectedHuntId,
       setSelectedHuntMonsterIndex,

--- a/contexts/local-context.tsx
+++ b/contexts/local-context.tsx
@@ -14,6 +14,7 @@ import { getShowdown } from '@/lib/dal/showdown'
 import { getSurvivor, getSurvivors } from '@/lib/dal/survivor'
 import { getSettlementForUser, getUserSettings } from '@/lib/dal/user'
 import { getUserSubscription } from '@/lib/dal/user-subscription'
+import { getVignetteEncounter } from '@/lib/dal/vignette-encounter'
 import { TabType } from '@/lib/enums'
 import { ERROR_MESSAGE } from '@/lib/messages'
 import { isUserSettingsAdmin } from '@/lib/supabase/admin-role'
@@ -33,7 +34,9 @@ import {
   SurvivorsStateSetter,
   SurvivorStateSetter,
   UserSettingsDetail,
-  UserSubscriptionDetail
+  UserSubscriptionDetail,
+  VignetteEncounterDetail,
+  VignetteEncounterStateSetter
 } from '@/lib/types'
 import { saveToLocalStorage } from '@/lib/utils'
 import {
@@ -67,6 +70,8 @@ export interface LocalStateType {
   selectedShowdownMonsterIndex: number
   /** Selected Survivor ID */
   selectedSurvivorId: string | null
+  /** Selected Vignette Encounter ID */
+  selectedVignetteEncounterId: string | null
   /** Selected Tab */
   selectedTab: TabType | null
 }
@@ -79,6 +84,7 @@ const newLocal: LocalStateType = {
   selectedShowdownId: null,
   selectedShowdownMonsterIndex: 0,
   selectedSurvivorId: null,
+  selectedVignetteEncounterId: null,
   selectedTab: null
 }
 
@@ -139,6 +145,10 @@ interface LocalContextType {
   selectedSurvivor: SurvivorDetail | null
   /** Selected Survivor ID */
   selectedSurvivorId: string | null
+  /** Selected Vignette Encounter */
+  selectedVignetteEncounter: VignetteEncounterDetail | null
+  /** Selected Vignette Encounter ID */
+  selectedVignetteEncounterId: string | null
   /** Selected Tab */
   selectedTab: TabType
 
@@ -181,6 +191,10 @@ interface LocalContextType {
   setSelectedSurvivor: SurvivorStateSetter
   /** Set Selected Survivor ID */
   setSelectedSurvivorId: (survivorId: string | null) => void
+  /** Set Selected Vignette Encounter */
+  setSelectedVignetteEncounter: VignetteEncounterStateSetter
+  /** Set Selected Vignette Encounter ID */
+  setSelectedVignetteEncounterId: (vignetteEncounterId: string | null) => void
   /** Set Selected Tab */
   setSelectedTab: (tab: TabType) => void
 
@@ -348,6 +362,12 @@ export function LocalProvider({
   const [selectedSurvivorId, setSelectedSurvivorIdState] = useState<
     string | null
   >(() => local.selectedSurvivorId ?? null)
+
+  // Vignette Encounter
+  const [selectedVignetteEncounter, setSelectedVignetteEncounterState] =
+    useState<VignetteEncounterDetail | null>(null)
+  const [selectedVignetteEncounterId, setSelectedVignetteEncounterIdState] =
+    useState<string | null>(() => local.selectedVignetteEncounterId ?? null)
 
   // Survivors (all for Settlement)
   const [survivors, setSurvivors] = useState<SurvivorDetail[]>([])
@@ -1389,6 +1409,74 @@ export function LocalProvider({
   ])
 
   /**
+   * Fetch Vignette Encounter Data
+   *
+   * Triggered whenever the selected vignette encounter id changes. The
+   * persisted browser state stores only the id; this effect resolves the full
+   * detail from the Supabase-backed DAL so caller role and encounter state are
+   * always server-derived.
+   */
+  useEffect(() => {
+    console.debug('Fetching Vignette Encounter Data')
+
+    let isCancelled = false
+
+    if (
+      !vignetteEncountersEnabled ||
+      !isAuthenticated ||
+      !selectedVignetteEncounterId
+    )
+      return () => {
+        isCancelled = true
+      }
+
+    if (selectedVignetteEncounter?.id === selectedVignetteEncounterId)
+      return () => {
+        isCancelled = true
+      }
+
+    getVignetteEncounter(selectedVignetteEncounterId)
+      .then((vignetteEncounter) => {
+        if (isCancelled) return
+
+        console.debug('Vignette Encounter Data:', vignetteEncounter)
+
+        setSelectedVignetteEncounterState(vignetteEncounter)
+
+        if (!vignetteEncounter) {
+          setSelectedVignetteEncounterIdState(null)
+
+          setLocalState((prev) => ({
+            ...prev,
+            selectedVignetteEncounterId: null
+          }))
+        }
+      })
+      .catch((err: unknown) => {
+        if (isCancelled) return
+
+        console.error('Vignette Encounter Fetch Error:', err)
+
+        setSelectedVignetteEncounterState(null)
+        setSelectedVignetteEncounterIdState(null)
+
+        setLocalState((prev) => ({
+          ...prev,
+          selectedVignetteEncounterId: null
+        }))
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [
+    isAuthenticated,
+    selectedVignetteEncounter?.id,
+    selectedVignetteEncounterId,
+    vignetteEncountersEnabled
+  ])
+
+  /**
    * Fetch User Settings Data
    */
   useEffect(() => {
@@ -1777,6 +1865,54 @@ export function LocalProvider({
   }, [])
 
   /**
+   * Set Selected Vignette Encounter
+   *
+   * @param vignetteOrUpdater Selected Vignette Encounter or functional updater
+   * receiving the previous vignette encounter state
+   */
+  const setSelectedVignetteEncounter =
+    useCallback<VignetteEncounterStateSetter>((vignetteOrUpdater) => {
+      if (typeof vignetteOrUpdater === 'function') {
+        setSelectedVignetteEncounterState(vignetteOrUpdater)
+        return
+      }
+
+      const vignetteEncounter = vignetteOrUpdater
+
+      setSelectedVignetteEncounterState(vignetteEncounter)
+      setSelectedVignetteEncounterIdState(vignetteEncounter?.id ?? null)
+
+      setLocalState((local) => ({
+        ...local,
+        selectedVignetteEncounterId: vignetteEncounter?.id ?? null
+      }))
+    }, [])
+
+  /**
+   * Set Selected Vignette Encounter ID
+   *
+   * Pure ID mutation. The vignette encounter fetch effect is the source of
+   * truth for resolving full detail.
+   *
+   * @param vignetteEncounterId Selected Vignette Encounter ID
+   */
+  const setSelectedVignetteEncounterId = useCallback(
+    (vignetteEncounterId: string | null) => {
+      setSelectedVignetteEncounterIdState((prevId) => {
+        if (prevId === vignetteEncounterId) return prevId
+
+        setSelectedVignetteEncounterState(null)
+        setLocalState((local) => ({
+          ...local,
+          selectedVignetteEncounterId: vignetteEncounterId
+        }))
+        return vignetteEncounterId
+      })
+    },
+    []
+  )
+
+  /**
    * Set Selected Tab
    *
    * @param tab Selected Tab
@@ -1845,6 +1981,8 @@ export function LocalProvider({
       selectedShowdownMonsterIndex,
       selectedSurvivor,
       selectedSurvivorId,
+      selectedVignetteEncounter,
+      selectedVignetteEncounterId,
       selectedTab,
 
       setIsCreatingNewHunt,
@@ -1867,6 +2005,8 @@ export function LocalProvider({
       setSelectedShowdownMonsterIndex,
       setSelectedSurvivor,
       setSelectedSurvivorId,
+      setSelectedVignetteEncounter,
+      setSelectedVignetteEncounterId,
       setSelectedTab,
 
       setSurvivors,
@@ -1909,6 +2049,8 @@ export function LocalProvider({
       selectedShowdownMonsterIndex,
       selectedSurvivor,
       selectedSurvivorId,
+      selectedVignetteEncounter,
+      selectedVignetteEncounterId,
       selectedTab,
       survivors,
       local,
@@ -1931,6 +2073,8 @@ export function LocalProvider({
       setSelectedShowdownMonsterIndex,
       setSelectedSurvivor,
       setSelectedSurvivorId,
+      setSelectedVignetteEncounter,
+      setSelectedVignetteEncounterId,
       setSelectedTab,
       setSelectedEncounter,
       setUserSettings,

--- a/docs/vignette-encounters-implementation-plan.md
+++ b/docs/vignette-encounters-implementation-plan.md
@@ -506,7 +506,9 @@ cannot create another owned vignette until their owned active vignette is ended.
 - The surface should not depend on `selectedSettlement`, `selectedHunt`,
   `selectedShowdown`, or `selectedSettlementPhase`.
 - The surface will depend on new state tracking fields such as
-  `selectedVignetteEncounterId` and `selectedVignetteEncounterRole`.
+  `selectedVignetteEncounterId` in browser local storage and
+  `selectedVignetteEncounter` in `LocalContext`. Role should be derived from
+  server-backed vignette summary/detail rows, not persisted separately.
 
 ### Suggested Component Structure
 

--- a/docs/vignette-encounters-implementation-plan.md
+++ b/docs/vignette-encounters-implementation-plan.md
@@ -507,8 +507,10 @@ cannot create another owned vignette until their owned active vignette is ended.
   `selectedShowdown`, or `selectedSettlementPhase`.
 - The surface will depend on new state tracking fields such as
   `selectedVignetteEncounterId` in browser local storage and
-  `selectedVignetteEncounter` in `LocalContext`. Role should be derived from
-  server-backed vignette summary/detail rows, not persisted separately.
+  `selectedVignetteEncounter` in `LocalContext`. Owned/shared vignette landing
+  data should also be cached in `LocalContext` and passed down through the page
+  tree. Role should be derived from server-backed vignette summary/detail rows,
+  not persisted separately.
 
 ### Suggested Component Structure
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -757,6 +757,16 @@ export interface VignetteEncounterSummary {
   role: VignetteEncounterRole
 }
 
+/** Vignette Landing State */
+export interface VignetteLandingState {
+  /** Catalog Monsters */
+  catalogMonsters: VignetteMonsterSummary[]
+  /** Owned Active Vignette */
+  ownedActive: VignetteEncounterSummary | null
+  /** Shared Active Vignettes */
+  sharedActive: VignetteEncounterSummary[]
+}
+
 /**
  * Vignette Encounter State Setter
  *

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -757,14 +757,6 @@ export interface VignetteEncounterSummary {
   role: VignetteEncounterRole
 }
 
-/** Selected Vignette Encounter */
-export interface SelectedVignetteEncounter {
-  /** Vignette Encounter ID */
-  vignette_encounter_id: string
-  /** Caller's Role on This Vignette */
-  role: VignetteEncounterRole
-}
-
 /**
  * Vignette Encounter State Setter
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.97.0",
+  "version": "0.98.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.97.0",
+      "version": "0.98.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.97.0",
+  "version": "0.98.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary
- Add LocalContext support for selected vignette encounter IDs, selected vignette detail, and cached owned/shared vignette landing state.
- Render the Vignette Encounters switcher from context-provided landing state passed through page.tsx and SettlementCard.
- Keep role server-derived and avoid auto-selecting a vignette on tab load; selection changes only when the user chooses an active vignette row.
- Bump package version to 0.98.0 for the PR.

## Dependencies
- No dependency changes.

## Related Issues
- Closes #345.

## Verification
- npx prettier --check package.json package-lock.json app/page.tsx components/settlement/settlement-card.tsx components/vignette/vignette-encounters-card.tsx contexts/local-context.tsx lib/types.ts docs/vignette-encounters-implementation-plan.md
- npx eslint app/page.tsx components/settlement/settlement-card.tsx components/vignette/vignette-encounters-card.tsx contexts/local-context.tsx lib/types.ts
- npx vitest run __tests__/lib/enums.test.ts --coverage.enabled=false
- git diff --check