### PR TITLE
Add active vignette limit UX

### DIFF
--- a/__tests__/lib/messages.test.ts
+++ b/__tests__/lib/messages.test.ts
@@ -33,7 +33,8 @@ import {
   SYSTEMIC_PRESSURE_MINIMUM_ERROR_MESSAGE,
   TIMELINE_EVENT_EMPTY_ERROR_MESSAGE,
   TIMELINE_EVENT_EMPTY_WARNING_MESSAGE,
-  TORMENT_MINIMUM_ERROR_MESSAGE
+  TORMENT_MINIMUM_ERROR_MESSAGE,
+  VIGNETTE_ACTIVE_LIMIT_MESSAGE
 } from '@/lib/messages'
 
 describe('CAMPAIGN_UNLOCK_KILLENIUM_BUTCHER_UPDATED_MESSAGE', () => {
@@ -159,6 +160,14 @@ describe('MONSTER_LEVEL_MISSING_MESSAGE', () => {
   it('returns correct message', () => {
     expect(MONSTER_LEVEL_MISSING_MESSAGE()).toBe(
       'At least one level is required.'
+    )
+  })
+})
+
+describe('VIGNETTE_ACTIVE_LIMIT_MESSAGE', () => {
+  it('returns themed active-limit copy', () => {
+    expect(VIGNETTE_ACTIVE_LIMIT_MESSAGE()).toBe(
+      'End your active vignette encounter before creating another.'
     )
   })
 })

--- a/components/vignette/vignette-encounters-card.tsx
+++ b/components/vignette/vignette-encounters-card.tsx
@@ -15,7 +15,7 @@ import {
   createVignetteEncounter,
   getVignetteMonster
 } from '@/lib/dal/vignette-encounter'
-import { ERROR_MESSAGE } from '@/lib/messages'
+import { ERROR_MESSAGE, VIGNETTE_ACTIVE_LIMIT_MESSAGE } from '@/lib/messages'
 import type {
   VignetteEncounterSummary,
   VignetteLandingState,
@@ -24,7 +24,10 @@ import type {
   VignetteMonsterSummary,
   VignetteSurvivorDetail
 } from '@/lib/types'
-import { VignetteCreateInputSchema } from '@/schemas/vignette-encounter'
+import {
+  VignetteActiveLimitSchema,
+  VignetteCreateInputSchema
+} from '@/schemas/vignette-encounter'
 import { Loader2Icon } from 'lucide-react'
 import { ReactElement, useCallback, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
@@ -104,6 +107,23 @@ function formatVignetteLabel(value: string | null | undefined): string {
  */
 function formatVignetteNumber(value: number | null | undefined): string {
   return value === null || value === undefined ? '-' : value.toString()
+}
+
+/**
+ * Is Vignette Active Limit Error
+ *
+ * @param error Error Value
+ * @returns Whether Error Represents Active Vignette Limit
+ */
+function isVignetteActiveLimitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+
+  const message = error.message.toLowerCase()
+  return (
+    message.includes('active limit') ||
+    message.includes('only one active vignette') ||
+    message.includes('one_active_vignette_encounter_per_user')
+  )
 }
 
 /**
@@ -278,6 +298,15 @@ export function VignetteEncountersCard({
   const handleCreateVignetteEncounter = useCallback(() => {
     if (!selectedCatalogMonster || !selectedLevelNumber) return
 
+    const activeLimit = VignetteActiveLimitSchema.safeParse({
+      active_vignette_encounter_id: vignetteLandingState.ownedActive?.id ?? null
+    })
+
+    if (!activeLimit.success) {
+      toast.error(VIGNETTE_ACTIVE_LIMIT_MESSAGE())
+      return
+    }
+
     const parsedInput = VignetteCreateInputSchema.safeParse({
       vignette_monster_id: selectedCatalogMonster.id,
       level_number: selectedLevelNumber
@@ -298,14 +327,21 @@ export function VignetteEncountersCard({
       })
       .catch((error: unknown) => {
         console.error('Vignette Encounter Create Error:', error)
-        toast.error(error instanceof Error ? error.message : ERROR_MESSAGE())
+        toast.error(
+          isVignetteActiveLimitError(error)
+            ? VIGNETTE_ACTIVE_LIMIT_MESSAGE()
+            : error instanceof Error
+              ? error.message
+              : ERROR_MESSAGE()
+        )
       })
       .finally(() => setIsCreatingVignetteEncounter(false))
   }, [
     refetchVignetteLandingState,
     selectedCatalogMonster,
     selectedLevelNumber,
-    setSelectedVignetteEncounterId
+    setSelectedVignetteEncounterId,
+    vignetteLandingState.ownedActive?.id
   ])
 
   const hasSharedActive = vignetteLandingState.sharedActive.length > 0
@@ -364,34 +400,46 @@ export function VignetteEncountersCard({
                     Available Vignette Encounters
                   </h3>
                   {hasCatalogMonsters ? (
-                    <Select
-                      value={selectedCatalogMonsterId}
-                      onValueChange={handleSelectCatalogMonster}>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Choose a vignette encounter..." />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {vignetteLandingState.catalogMonsters.map((monster) => {
-                          const levels = sortedVignetteLevels(monster)
+                    <div className="space-y-2">
+                      {hasSharedActive && (
+                        <p className="rounded-md border border-primary/30 bg-primary/5 p-3 text-xs text-muted-foreground">
+                          Shared vignette encounters do not stop you from
+                          creating one of your own.
+                        </p>
+                      )}
+                      <Select
+                        value={selectedCatalogMonsterId}
+                        onValueChange={handleSelectCatalogMonster}>
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Choose a vignette encounter..." />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {vignetteLandingState.catalogMonsters.map(
+                            (monster) => {
+                              const levels = sortedVignetteLevels(monster)
 
-                          return (
-                            <SelectItem key={monster.id} value={monster.id}>
-                              {monster.monster_name} ·{' '}
-                              {formatVignetteLabel(monster.source_monster_type)}
-                              {levels.length > 1 && (
-                                <>
-                                  {' '}
-                                  · Levels{' '}
-                                  {levels
-                                    .map((level) => level.level_number)
-                                    .join(', ')}
-                                </>
-                              )}
-                            </SelectItem>
-                          )
-                        })}
-                      </SelectContent>
-                    </Select>
+                              return (
+                                <SelectItem key={monster.id} value={monster.id}>
+                                  {monster.monster_name} ·{' '}
+                                  {formatVignetteLabel(
+                                    monster.source_monster_type
+                                  )}
+                                  {levels.length > 1 && (
+                                    <>
+                                      {' '}
+                                      · Levels{' '}
+                                      {levels
+                                        .map((level) => level.level_number)
+                                        .join(', ')}
+                                    </>
+                                  )}
+                                </SelectItem>
+                              )
+                            }
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </div>
                   ) : (
                     <p className="rounded-md border border-dashed p-3 text-muted-foreground">
                       No available vignette encounters.

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -195,6 +195,14 @@ export const MONSTER_LEVEL_MISSING_MESSAGE = () =>
   'At least one level is required.'
 
 /**
+ * Vignette Active Limit
+ *
+ * @returns Vignette Active Limit Message
+ */
+export const VIGNETTE_ACTIVE_LIMIT_MESSAGE = () =>
+  'End your active vignette encounter before creating another.'
+
+/**
  * Nameless Object Error
  *
  * @param objType Object Type

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.99.0",
+  "version": "0.100.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.99.0",
+      "version": "0.100.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.99.0",
+  "version": "0.100.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",


### PR DESCRIPTION
## Summary
- Add themed active-limit copy for owned vignette creation attempts.
- Validate the owned active vignette limit before creating a new vignette and handle stale RPC active-limit failures with the same copy.
- Clarify that shared active vignettes do not block creating the user's own active vignette.
- Bump package version to 0.100.0 for the PR.

## Dependencies
- No dependency changes.

## Related Issues
- Closes #346.

## Verification
- npx prettier --check package.json package-lock.json components/vignette/vignette-encounters-card.tsx lib/messages.ts __tests__/lib/messages.test.ts
- npx eslint components/vignette/vignette-encounters-card.tsx lib/messages.ts __tests__/lib/messages.test.ts
- npx vitest run __tests__/lib/messages.test.ts __tests__/schemas/vignette-encounter.test.ts __tests__/lib/dal/vignette-encounter.test.ts --coverage.enabled=false
- git diff --check