### PR TITLE
Build active vignette row sharing

### DIFF
--- a/__tests__/integration/vignette-encounter-create-rls.test.ts
+++ b/__tests__/integration/vignette-encounter-create-rls.test.ts
@@ -1,0 +1,101 @@
+import {
+  admin,
+  createTestUser,
+  deleteTestUser,
+  TestUser
+} from '@/__tests__/integration/helpers/supabase'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const KILLENIUM_BUTCHER_FIXTURE_NAME = 'Killenium Butcher'
+
+interface VignetteMonsterLevelFixture {
+  /** Vignette Monster ID */
+  vignette_monster_id: string
+  /** Level Number */
+  level_number: number
+}
+
+/**
+ * Integration - Vignette Encounter Create RLS
+ *
+ * Verifies the catalog-copy RPC can create the active vignette graph for an
+ * authenticated caller while table RLS remains enabled.
+ */
+describe('Vignette encounter create RLS', () => {
+  let authenticatedUser: TestUser
+  let fixtureLevel: VignetteMonsterLevelFixture
+
+  beforeAll(async () => {
+    authenticatedUser = await createTestUser()
+    fixtureLevel = await getFixtureLevel()
+  })
+
+  afterAll(async () => {
+    if (authenticatedUser) await deleteTestUser(authenticatedUser.id)
+  })
+
+  it('creates an active vignette encounter and copied child rows for the owner', async () => {
+    const { data: vignetteEncounterId, error: createError } =
+      await authenticatedUser.client.rpc(
+        'create_vignette_encounter_from_catalog',
+        {
+          target_level_number: fixtureLevel.level_number,
+          target_vignette_monster_id: fixtureLevel.vignette_monster_id
+        }
+      )
+
+    expect(createError).toBeNull()
+    expect(vignetteEncounterId).toEqual(expect.any(String))
+
+    const { data: encounter, error: encounterError } =
+      await authenticatedUser.client
+        .from('vignette_encounter')
+        .select('id, user_id, vignette_monster_id, level_number')
+        .eq('id', vignetteEncounterId)
+        .single()
+
+    expect(encounterError).toBeNull()
+    expect(encounter).toMatchObject({
+      id: vignetteEncounterId,
+      user_id: authenticatedUser.id,
+      vignette_monster_id: fixtureLevel.vignette_monster_id,
+      level_number: fixtureLevel.level_number
+    })
+
+    const { data: monsters, error: monstersError } =
+      await authenticatedUser.client
+        .from('vignette_encounter_monster')
+        .select('id, vignette_encounter_id')
+        .eq('vignette_encounter_id', vignetteEncounterId)
+
+    expect(monstersError).toBeNull()
+    expect(monsters?.length).toBeGreaterThan(0)
+
+    const { data: survivors, error: survivorsError } =
+      await authenticatedUser.client
+        .from('vignette_encounter_survivor')
+        .select('id, vignette_encounter_id')
+        .eq('vignette_encounter_id', vignetteEncounterId)
+
+    expect(survivorsError).toBeNull()
+    expect(survivors?.length).toBeGreaterThan(0)
+  })
+})
+
+async function getFixtureLevel(): Promise<VignetteMonsterLevelFixture> {
+  const { data, error } = await admin
+    .from('vignette_monster_level')
+    .select(
+      'vignette_monster_id, level_number, vignette_monster!inner(monster_name)'
+    )
+    .eq('vignette_monster.monster_name', KILLENIUM_BUTCHER_FIXTURE_NAME)
+    .single()
+
+  if (error || !data)
+    throw new Error(`getFixtureLevel failed: ${error?.message}`)
+
+  return {
+    vignette_monster_id: data.vignette_monster_id,
+    level_number: data.level_number
+  }
+}

--- a/__tests__/lib/dal/vignette-encounter.test.ts
+++ b/__tests__/lib/dal/vignette-encounter.test.ts
@@ -731,6 +731,7 @@ describe('vignette encounter mutation helpers', () => {
     })
 
     expect(result).toBe('encounter-1')
+    expect(getUserId).toHaveBeenCalled()
     expect(mockSupabase.rpc).toHaveBeenCalledWith(
       'create_vignette_encounter_from_catalog',
       {

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -34,7 +34,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}>
@@ -57,7 +57,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className
@@ -69,7 +69,7 @@ function SelectContent({
           className={cn(
             'p-1',
             position === 'popper' &&
-              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1'
+              'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width) scroll-my-1'
           )}>
           {children}
         </SelectPrimitive.Viewport>
@@ -101,7 +101,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}>

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -82,7 +82,7 @@ function TableHead({ className, ...props }: ComponentProps<'th'>) {
     <th
       data-slot="table-head"
       className={cn(
-        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap has-[[role=checkbox]]:pr-0 *:[[role=checkbox]]:translate-y-0.5',
         className
       )}
       {...props}
@@ -95,7 +95,7 @@ function TableCell({ className, ...props }: ComponentProps<'td'>) {
     <td
       data-slot="table-cell"
       className={cn(
-        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        'p-2 align-middle whitespace-nowrap has-[[role=checkbox]]:pr-0 *:[[role=checkbox]]:translate-y-0.5',
         className
       )}
       {...props}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -25,7 +25,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-0.75',
         className
       )}
       {...props}

--- a/components/vignette/vignette-encounters-card.tsx
+++ b/components/vignette/vignette-encounters-card.tsx
@@ -5,6 +5,16 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -12,6 +22,7 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import {
+  addVignetteEncounterSharedUser,
   createVignetteEncounter,
   getVignetteMonster
 } from '@/lib/dal/vignette-encounter'
@@ -26,10 +37,18 @@ import type {
 } from '@/lib/types'
 import {
   VignetteActiveLimitSchema,
-  VignetteCreateInputSchema
+  VignetteCreateInputSchema,
+  VignetteShareInputSchema
 } from '@/schemas/vignette-encounter'
-import { Loader2Icon } from 'lucide-react'
-import { ReactElement, useCallback, useMemo, useRef, useState } from 'react'
+import { Loader2Icon, Share2Icon } from 'lucide-react'
+import {
+  FormEvent,
+  ReactElement,
+  useCallback,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import { toast } from 'sonner'
 
 /** Vignette Encounters Card Properties */
@@ -224,6 +243,11 @@ export function VignetteEncountersCard({
     useState(false)
   const [isCreatingVignetteEncounter, setIsCreatingVignetteEncounter] =
     useState(false)
+  const [sharingVignetteEncounter, setSharingVignetteEncounter] =
+    useState<VignetteEncounterSummary | null>(null)
+  const [shareUsername, setShareUsername] = useState('')
+  const [isSharingVignetteEncounter, setIsSharingVignetteEncounter] =
+    useState(false)
 
   const handleSelectVignetteEncounter = useCallback(
     (summary: VignetteEncounterSummary) => {
@@ -344,6 +368,57 @@ export function VignetteEncountersCard({
     vignetteLandingState.ownedActive?.id
   ])
 
+  const handleOpenVignetteShare = useCallback(
+    (summary: VignetteEncounterSummary) => {
+      setSharingVignetteEncounter(summary)
+      setShareUsername('')
+    },
+    []
+  )
+
+  const handleShareDialogOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (isOpen || isSharingVignetteEncounter) return
+
+      setSharingVignetteEncounter(null)
+      setShareUsername('')
+    },
+    [isSharingVignetteEncounter]
+  )
+
+  const handleShareVignetteEncounter = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      if (!sharingVignetteEncounter) return
+
+      const parsedInput = VignetteShareInputSchema.safeParse({
+        vignette_encounter_id: sharingVignetteEncounter.id,
+        username: shareUsername
+      })
+
+      if (!parsedInput.success) {
+        toast.error(parsedInput.error.message)
+        return
+      }
+
+      setIsSharingVignetteEncounter(true)
+
+      addVignetteEncounterSharedUser(parsedInput.data)
+        .then(() => {
+          toast.success('Another lantern joins the vignette.')
+          setSharingVignetteEncounter(null)
+          setShareUsername('')
+          refetchVignetteLandingState()
+        })
+        .catch((error: unknown) => {
+          console.error('Vignette Encounter Share Error:', error)
+          toast.error(error instanceof Error ? error.message : ERROR_MESSAGE())
+        })
+        .finally(() => setIsSharingVignetteEncounter(false))
+    },
+    [refetchVignetteLandingState, shareUsername, sharingVignetteEncounter]
+  )
+
   const hasSharedActive = vignetteLandingState.sharedActive.length > 0
   const hasCatalogMonsters = vignetteLandingState.catalogMonsters.length > 0
   const isEmptyLanding =
@@ -392,6 +467,7 @@ export function VignetteEncountersCard({
                       vignetteLandingState.ownedActive.id
                     }
                     onSelect={handleSelectVignetteEncounter}
+                    onShare={handleOpenVignetteShare}
                   />
                 </section>
               ) : (
@@ -481,11 +557,94 @@ export function VignetteEncountersCard({
                   </p>
                 )}
               </section>
+
+              <VignetteShareDialog
+                isSharing={isSharingVignetteEncounter}
+                summary={sharingVignetteEncounter}
+                username={shareUsername}
+                onOpenChange={handleShareDialogOpenChange}
+                onSubmit={handleShareVignetteEncounter}
+                onUsernameChange={setShareUsername}
+              />
             </>
           )}
         </CardContent>
       </Card>
     </div>
+  )
+}
+
+/**
+ * Vignette Share Dialog
+ *
+ * @param props Vignette Share Dialog Properties
+ * @returns Vignette Share Dialog
+ */
+function VignetteShareDialog({
+  isSharing,
+  onOpenChange,
+  onSubmit,
+  onUsernameChange,
+  summary,
+  username
+}: {
+  /** Whether A Share Is Being Created */
+  isSharing: boolean
+  /** Handle Dialog Open State Change */
+  onOpenChange: (isOpen: boolean) => void
+  /** Handle Share Form Submit */
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  /** Handle Username Change */
+  onUsernameChange: (username: string) => void
+  /** Vignette Encounter Summary */
+  summary: VignetteEncounterSummary | null
+  /** Username Input Value */
+  username: string
+}): ReactElement {
+  return (
+    <Dialog open={summary !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Share Vignette Encounter</DialogTitle>
+          <DialogDescription>
+            Invite another user to {summary?.monster_name ?? 'this vignette'} by
+            exact username.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          id="vignette-share-form"
+          className="space-y-2"
+          onSubmit={onSubmit}>
+          <Label htmlFor="vignette-share-username">Username</Label>
+          <Input
+            id="vignette-share-username"
+            name="username"
+            autoComplete="off"
+            disabled={isSharing}
+            value={username}
+            onChange={(event) => onUsernameChange(event.target.value)}
+          />
+        </form>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isSharing}
+            onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="vignette-share-form"
+            disabled={isSharing || username.trim().length === 0}>
+            {isSharing && <Loader2Icon className="h-4 w-4 animate-spin" />}
+            Share
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }
 
@@ -498,6 +657,7 @@ export function VignetteEncountersCard({
 function VignetteSummaryRow({
   badge,
   isSelected,
+  onShare,
   onSelect,
   summary
 }: {
@@ -505,27 +665,46 @@ function VignetteSummaryRow({
   badge: string
   /** Whether This Vignette Is Selected */
   isSelected: boolean
+  /** Share Vignette Encounter */
+  onShare?: (summary: VignetteEncounterSummary) => void
   /** Select Vignette Encounter */
   onSelect: (summary: VignetteEncounterSummary) => void
   /** Vignette Encounter Summary */
   summary: VignetteEncounterSummary
 }): ReactElement {
   return (
-    <button
-      type="button"
-      aria-pressed={isSelected}
-      onClick={() => onSelect(summary)}
+    <div
       className={`flex w-full items-start justify-between gap-3 rounded-md border p-3 text-left transition-colors hover:bg-accent hover:text-accent-foreground ${
         isSelected ? 'border-primary bg-primary/10' : ''
       }`}>
-      <div className="min-w-0">
-        <p className="font-medium leading-none">{summary.monster_name}</p>
-        <p className="mt-1 text-xs text-muted-foreground">
+      <button
+        type="button"
+        aria-pressed={isSelected}
+        onClick={() => onSelect(summary)}
+        className="min-w-0 flex-1 text-left">
+        <span className="block font-medium leading-none">
+          {summary.monster_name}
+        </span>
+        <span className="mt-1 block text-xs text-muted-foreground">
           Level {summary.level_number} · {formatVignetteTurn(summary.turn)}
-        </p>
+        </span>
+      </button>
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+        {onShare && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onShare(summary)}>
+            <Share2Icon className="h-4 w-4" />
+            Share
+          </Button>
+        )}
+        <Badge variant={badge === 'Owner' ? 'default' : 'outline'}>
+          {badge}
+        </Badge>
       </div>
-      <Badge variant={badge === 'Owner' ? 'default' : 'outline'}>{badge}</Badge>
-    </button>
+    </div>
   )
 }
 

--- a/lib/dal/vignette-encounter.ts
+++ b/lib/dal/vignette-encounter.ts
@@ -1109,6 +1109,8 @@ export async function getVignetteEncounter(
 export async function createVignetteEncounter(
   input: VignetteCreateInput
 ): Promise<string> {
+  await getUserId()
+
   const supabase = createClient()
 
   const { data, error } = await supabase.rpc(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kdm",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kdm",
-      "version": "0.100.0",
+      "version": "0.101.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kdm",
   "description": "Kingdom Death: Monster (KDM) - Archivist",
   "author": "Nick Alteen <ncalteen@gmail.com>",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "type": "module",
   "homepage": "https://github.com/ncalteen/kdm-app#readme",
   "repository": "ncalteen/kdm-app",

--- a/supabase/migrations/20260625165749_harden_vignette_create_rpc_rls.sql
+++ b/supabase/migrations/20260625165749_harden_vignette_create_rpc_rls.sql
@@ -1,0 +1,17 @@
+--------------------------------------------------------------------------------
+-- Harden Vignette Create RPC RLS Boundary
+--------------------------------------------------------------------------------
+-- The catalog-copy RPC creates a parent vignette_encounter row and then copies
+-- child setup rows into the active encounter tables. Authenticated callers are
+-- still required, and the function assigns ownership from auth.uid(), but the
+-- copy process itself must not be interrupted by table RLS while it is creating
+-- the active graph for that owner.
+
+alter function public.create_vignette_encounter_from_catalog(uuid, int)
+	security definer;
+
+revoke all on function public.create_vignette_encounter_from_catalog(uuid, int)
+from public;
+revoke execute on function public.create_vignette_encounter_from_catalog(uuid, int)
+from anon;
+grant execute on function public.create_vignette_encounter_from_catalog(uuid, int) to authenticated;


### PR DESCRIPTION
## Summary
- Add an owner-only Share action to the active vignette row with a username invite dialog backed by the existing vignette sharing DAL.
- Remove the extra active vignette detail shell from the one-shots surface so the card stays focused on landing, selection, creation, and sharing.
- Harden `create_vignette_encounter_from_catalog` as a security definer RPC and add integration coverage for authenticated vignette creation under RLS.
- Bump the app version to `0.101.0`.

## Dependencies
- None.

## Verification
- `npx prettier --check components/vignette/vignette-encounters-card.tsx lib/dal/vignette-encounter.ts __tests__/lib/dal/vignette-encounter.test.ts __tests__/integration/vignette-encounter-create-rls.test.ts supabase/migrations/20260625165749_harden_vignette_create_rpc_rls.sql package.json package-lock.json`
- `npx eslint components/vignette/vignette-encounters-card.tsx lib/dal/vignette-encounter.ts __tests__/lib/dal/vignette-encounter.test.ts __tests__/integration/vignette-encounter-create-rls.test.ts`
- `npx vitest run __tests__/lib/dal/vignette-encounter.test.ts --coverage.enabled=false`
- `npm run integration-test -- __tests__/integration/vignette-encounter-create-rls.test.ts`
- `git diff --check`

Closes #348
